### PR TITLE
[Python] 1/n Serialize Setup

### DIFF
--- a/python/src/aiconfig/AIConfigSettings.py
+++ b/python/src/aiconfig/AIConfigSettings.py
@@ -521,3 +521,15 @@ class AIConfig(BaseModel):
         model_settings.update(prompt_model_settings)
 
         return model_settings
+
+    def get_global_settings(self, model_name: str):
+        """
+        Gets the global settings for a model.
+
+        Args:
+            model_name (str): The name of the model.
+
+        Returns:
+            dict: The global settings for the model.
+        """
+        return self.metadata.models.get(model_name)

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -113,6 +113,25 @@ class AIConfigRuntime(AIConfig):
             data = resp.json()
             return cls.model_validate_json(data)
 
+    async def serialize(self, model_name: str, data: Dict, params: Optional[dict] = {},  prompt_name: Optional[str] = "") -> List[Prompt]:
+        """
+        Serializes the completion params into a Prompt object. Inverse of the 'resolve' function.
+
+        args:
+            model_name (str): The model name to create a Prompt object for
+            data (dict): The data to save as a Prompt Object
+            params (dict, optional): Optional parameters to save alongside the prompt
+
+        returns:
+            Prompt | List[Prompt]: A prompt or list of prompts representing the input data
+        """
+        model_parser = ModelParserRegistry.get_model_parser(model_name)
+        if not model_parser:
+            raise ValueError(f"Unable to serialize data: `{data}`\n Model Parser for model {model_name} does not exist.")
+        
+        prompts = model_parser.serialize("", data, self, params)
+        return prompts
+
     async def resolve(
         self,
         prompt_name: str,


### PR DESCRIPTION
[Python] 1/n Serialize Setup

Implemented Serialize in ConfigRuntime which calls ModelParser
`serialize`

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/32).
* #33
* __->__ #32