### PR TITLE
[Python] 4/n Serialize OpenAI Model Parser

### DIFF
--- a/python/src/aiconfig/AIConfigSettings.py
+++ b/python/src/aiconfig/AIConfigSettings.py
@@ -93,10 +93,11 @@ class PromptMetadata(BaseModel):
 
 
 class PromptInput(BaseModel):
-    # The prompt string, which may be a handlebars template
-    prompt: str
     # Any additional inputs to the model
-    data: Any
+    data: Optional[Any] = None
+
+    class Config:
+        extra = "allow"
 
 
 class Prompt(BaseModel):

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -113,7 +113,7 @@ class AIConfigRuntime(AIConfig):
             data = resp.json()
             return cls.model_validate_json(data)
 
-    async def serialize(self, model_name: str, data: Dict, params: Optional[dict] = {},  prompt_name: Optional[str] = "") -> List[Prompt]:
+    async def serialize(self, model_name: str, data: Dict,  prompt_name: str, params: Optional[dict] = {}) -> List[Prompt]:
         """
         Serializes the completion params into a Prompt object. Inverse of the 'resolve' function.
 
@@ -127,9 +127,11 @@ class AIConfigRuntime(AIConfig):
         """
         model_parser = ModelParserRegistry.get_model_parser(model_name)
         if not model_parser:
-            raise ValueError(f"Unable to serialize data: `{data}`\n Model Parser for model {model_name} does not exist.")
-        
-        prompts = model_parser.serialize("", data, self, params)
+            raise ValueError(
+                f"Unable to serialize data: `{data}`\n Model Parser for model {model_name} does not exist."
+            )
+
+        prompts = model_parser.serialize(prompt_name, data, self, params)
         return prompts
 
     async def resolve(

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 import copy
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 from typing import TYPE_CHECKING, Any, Dict, Optional
 from aiconfig import AIConfigSettings
 from aiconfig.AIConfigSettings import (
@@ -349,3 +349,47 @@ def refine_chat_completion_params(model_settings):
             completion_data[key] = model_settings[key]
 
     return completion_data
+
+
+def add_prompt_as_message(
+    prompt: Prompt, aiconfig: "AIConfigRuntime", messages: List, params=None
+):
+    """
+    Converts a given prompt to a message and adds it to the specified messages list.
+
+    Note:
+    - If the prompt contains valid input, it's treated as a user message.
+    - If the prompt has a custom role, function call, or name, these attributes are included in the message.
+    - If an AI model output exists, it is appended to the messages list.
+    """
+    if is_prompt_template(prompt):
+        resolved_prompt = resolve_prompt(prompt, params, aiconfig)
+        messages.append({"content": resolved_prompt, "role": "user"})
+    else:
+        # Assumes Prompt input will be in the format of ChatCompletionMessageParam (with content, role, function_name, and name attributes)
+        resolved_prompt = resolve_prompt(prompt.input.content, params, aiconfig)
+
+        prompt_input = prompt.input
+        role = prompt_input.role if hasattr(prompt_input, "role") else "user"
+        fn_call = prompt_input.function_call if hasattr(prompt_input, "function_call") else None
+        name = prompt_input.name if hasattr(prompt_input, "name") else None
+        messages.append(
+            {"content": resolved_prompt, "role": role, "function_call": fn_call, "name": name}
+        )
+
+    output = aiconfig.get_latest_output(prompt)
+    if output:
+        if output.output_type == "execute_result":
+            output_message = output.data
+            if output_message["role"] == "assistant":
+                messages.append(output_message)
+    return messages
+
+
+def is_prompt_template(prompt: Prompt):
+    """
+    Check if a prompt's input is a valid string.
+    """
+    return isinstance(prompt.input, str) or (
+        hasattr(prompt.input, "data") and isinstance(prompt.input.data, str)
+    )

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -14,7 +14,7 @@ from aiconfig.AIConfigSettings import (
 )
 from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
 from aiconfig.util.config_utils import get_api_key_from_environment
-from aiconfig.util.params import resolve_parameters, resolve_prompt, resolve_system_prompt
+from aiconfig.util.params import resolve_parameters, resolve_prompt, resolve_prompt_string, resolve_system_prompt
 
 import openai
 
@@ -122,55 +122,54 @@ class OpenAIInference(ParameterizedModelParser):
         Returns:
             dict: Model-specific completion parameters.
         """
-        resolved_prompt = resolve_prompt(prompt, params, aiconfig)
-
-        # Build Completion data
+        # Build Completion params
         model_settings = aiconfig.get_model_settings(prompt)
 
-        completion_data = refine_chat_completion_params(model_settings)
+        completion_params = refine_chat_completion_params(model_settings)
 
-        completion_data["messages"] = []
+        # In the case thhat the messages array weren't saves as part of the model settings, build it here. Messages array is used for conversation history.
+        if not completion_params.get("messages"):
+            completion_params["messages"] = []
 
-        # Handle System Prompt
-        if "system_prompt" in model_settings:
-            system_prompt = model_settings["system_prompt"]
-            resolved_system_prompt = resolve_system_prompt(prompt, system_prompt, params, aiconfig)
-            completion_data["messages"].append(
-                {"content": resolved_system_prompt, "role": "system"}
-            )
+            # Add System Prompt
+            if "system_prompt" in model_settings:
+                system_prompt = model_settings["system_prompt"]
+                resolved_system_prompt = resolve_system_prompt(prompt, system_prompt, params, aiconfig)
+                completion_params["messages"].append(
+                    {"content": resolved_system_prompt, "role": "system"}
+                )
 
-        # Handle Streaming
-        if options and options.stream:
-            completion_data["stream"] = options.stream
+            # Handle Streaming
+            if options and options.stream:
+                completion_params["stream"] = options.stream
 
-        # Default to always use chat context
-        if not hasattr(prompt.metadata, "remember_chat_context") or (
-            hasattr(prompt.metadata, "remember_chat_context")
-            and prompt.metadata.remember_chat_context != False
-        ):
-            # handle chat history. check previous prompts for the same model. if same model, add prompt and its output to completion data if it has a completed output
-            for i, previous_prompt in enumerate(aiconfig.prompts):
-                # include prompts upto the current one
-                if previous_prompt.name == prompt.name:
-                    break
+            # Default to always use chat context
+            if not hasattr(prompt.metadata, "remember_chat_context") or (
+                hasattr(prompt.metadata, "remember_chat_context")
+                and prompt.metadata.remember_chat_context != False
+            ):
+                # handle chat history. check previous prompts for the same model. if same model, add prompt and its output to completion data if it has a completed output
+                for i, previous_prompt in enumerate(aiconfig.prompts):
+                    # include prompts upto the current one
+                    if previous_prompt.name == prompt.name:
+                        break
 
-                # check if prompt is of the same model
-                if previous_prompt.get_model_name() == self.id():
-                    # add prompt and its output to completion data
-                    # constructing this prompt will take into account available parameters.
-                    resolved_previous_prompt = resolve_parameters({}, previous_prompt, aiconfig)
-                    completion_data["messages"].append(
-                        {"content": resolved_previous_prompt, "role": "user"}
-                    )
-                    # check if prompt has an output
-                    if len(previous_prompt.outputs) > 0:
-                        completion_data["messages"].append(
-                            {"content": str(previous_prompt.outputs[-1].data), "role": "assistant"}
+                    if previous_prompt.get_model_name() == prompt.get_model_name():
+                        # Add prompt and its output to completion data. Constructing this prompt will take into account available parameters.
+                        add_prompt_as_message(
+                            previous_prompt, aiconfig, completion_params["messages"], params
                         )
+        else:
+            # If messages are already specified in the model settings, then just resolve each message with the given parameters and append the latest message
+            for i in range(len(completion_params.get("messages"))):
+                completion_params["messages"][i]["content"] = resolve_prompt_string(
+                   prompt, params, aiconfig, completion_params["messages"][i]["content"]
+                )
 
-        # pass in the user prompt
-        completion_data["messages"].append({"content": resolved_prompt, "role": "user"})
-        return completion_data
+        # Add in the latest prompt
+        add_prompt_as_message(prompt, aiconfig, completion_params["messages"], params)
+
+        return completion_params
 
     async def run_inference(self, prompt: Prompt, aiconfig, options, parameters) -> Output:
         """
@@ -335,6 +334,7 @@ def refine_chat_completion_params(model_settings):
         "logit_bias",
         "max_tokens",
         "model",
+        "messages",
         "n",
         "presence_penalty",
         "stop",

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -4,13 +4,12 @@ from typing import Dict, List, Optional, Union
 from typing import TYPE_CHECKING, Any, Dict, Optional
 from aiconfig import AIConfigSettings
 from aiconfig.AIConfigSettings import (
-    AIConfig,
     ExecuteResult,
-    InferenceResponse,
+    ModelMetadata,
     Output,
     Prompt,
+    PromptInput,
     PromptMetadata,
-    Stream,
 )
 from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
 from aiconfig.util.config_utils import get_api_key_from_environment
@@ -36,36 +35,13 @@ class OpenAIInference(ParameterizedModelParser):
     def serialize(
         self,
         prompt_name: str,
-        data: Any,
-        ai_config: "AIConfigRuntime",
-        params: Optional[Dict] = {None},
-        **kwargs
-    ) -> Prompt:
-        """
-        Defines how a prompt and model inference settings get serialized in the .aiconfig.
-
-        Args:
-            prompt_name (str): The name of the prompt.
-            data (dict): The prompt data to be serialized.
-            ai_config (dict): Model-specific inference settings to be serialized.
-            parameters (dict, optional): Additional parameters. Defaults to None.
-
-        Returns:
-            Prompt: Serialized representation of the prompt and inference settings.
-        """
-        # input = data.prompt if isinstance(data.prompt str) else {"data": data.prompt}
-        pass
-
-    def serialize(
-        self,
-        prompt_name: str,
         data: Dict,
         ai_config: "AIConfigRuntime",
         parameters: Optional[Dict],
-        **kwargs
-    ) -> Prompt:
+        **kwargs,
+    ) -> List[Prompt]:
         """
-        Defines how a prompt and model inference settings get serialized in the .aiconfig.
+        Defines how prompts and model inference settings get serialized in the .aiconfig.
 
         Args:
             prompt (str): The prompt to be serialized.
@@ -74,40 +50,76 @@ class OpenAIInference(ParameterizedModelParser):
         Returns:
             str: Serialized representation of the prompt and inference settings.
         """
-        # Serialize Prompt input
-        prompt_input = (
-            data["prompt"] if isinstance(data["prompt"], str) else {"data": data["prompt"]}
-        )
+        prompts = []
 
-        # Cosntruct model settings, does not include prompt
-        prompt_model_metadata = {key: value for key, value in data.items() if key != "prompt"}
+        # Combine conversation data with any extra keyword args
+        conversation_data = {**data}
 
-        # check if config already has model settings in global metadata
-        model_name = prompt_model_metadata.get("model", self.id())
-        global_model_metadata = ai_config.metadata.models.get(model_name, {})
+        if not "messages" in conversation_data:
+            raise ValueError("Data must have `messages` array to match openai api spec")
 
-        if global_model_metadata:
-            # Check if the model settings from the input data are the same as the global model settings
-            # Compute the difference between the global model settings and the model settings from the input data
-            # If there is a difference, then we need to add the different model settings as overrides on the prompt's metadata
-            override_keys = set(prompt_model_metadata.keys()) - set(global_model_metadata.keys())
+        # Find first system prompt. Every prompt in the config will bet set to use this system prompt.
+        system_prompt = None
+        for message in conversation_data["messages"]:
+            if "role" in message and message["role"] == "system":
+                # Note: system prompt for openai represented will be an object with content and role attributes {content: str, role: str}
+                system_prompt = message
+                break
 
-            override_settings = {key: prompt_model_metadata[key] for key in override_keys}
+        # Get the global settings for the model
+        model_name = conversation_data["model"] if "model" in conversation_data else self.id()
 
-            if override_settings:
-                model_metadata = {"name": model_name, "settings": override_settings}
-            else:
-                model_metadata = model_name
-        else:
-            model_metadata = {"name": model_name, "settings": prompt_model_metadata}
+        model_metadata = ai_config.generate_model_metadata(conversation_data, model_name)
+        # Remove messages array from model metadata. Handled separately
+        model_metadata.settings.pop("messages", None)
 
-        return Prompt(
-            name=prompt_name,
-            input=prompt_input,
-            metadata=PromptMetadata(model=PromptMetadata(**model_metadata)),
-            parameters=parameters,
-            **kwargs
-        )
+        # Add in system prompt
+        if system_prompt:
+            model_metadata.settings["system_prompt"] = system_prompt
+
+        i = 0
+        while i < len(conversation_data["messages"]):
+            messsage = conversation_data["messages"][i]
+            role = messsage["role"]
+            if role == "user" or role == "function":
+                # Serialize User message as a prompt and save the assistant response as an output
+                assistant_response = None
+                if i + 1 < len(conversation_data["messages"]):
+                    next_message = conversation_data["messages"][i + 1]
+                    if next_message["role"] == "assistant":
+                        assistant_response = next_message
+                        i += 1
+                new_prompt_name = f"{prompt_name}_{len(prompts) + 1}"
+
+                input = messsage["content"] if role == "user" else PromptInput(**messsage)
+
+                prompt = Prompt(
+                    name=new_prompt_name,
+                    input=input,
+                    metadata=PromptMetadata(
+                        **{
+                            "model": copy.deepcopy(model_metadata),
+                            "parameters": parameters,
+                            "remember_chat_context": True,
+                        }
+                    ),
+                    outputs=[
+                        ExecuteResult(
+                            output_type="execute_result",
+                            execution_count=None,
+                            data=assistant_response,
+                            metadata={},
+                        )
+                    ]
+                    if assistant_response
+                    else [],
+                )
+                prompts.append(prompt)
+            i += 1
+
+        if prompts:
+            prompts[len(prompts) - 1].name = prompt_name
+        return prompts
 
     async def deserialize(
         self, prompt: Prompt, aiconfig: "AIConfigRuntime", options, params: Optional[Dict] = {}
@@ -134,7 +146,9 @@ class OpenAIInference(ParameterizedModelParser):
             # Add System Prompt
             if "system_prompt" in model_settings:
                 system_prompt = model_settings["system_prompt"]
-                resolved_system_prompt = resolve_system_prompt(prompt, system_prompt, params, aiconfig)
+                resolved_system_prompt = resolve_system_prompt(
+                    prompt, system_prompt, params, aiconfig
+                )
                 completion_params["messages"].append(
                     {"content": resolved_system_prompt, "role": "system"}
                 )
@@ -327,6 +341,7 @@ def refine_chat_completion_params(model_settings):
     # completion parameters to be used for openai's chat completion api
     # system prompt handled separately
     # streaming handled seperatly.
+    # Messages array built dynamically and handled separately
     supported_keys = {
         "frequency_penalty",
         "functions",

--- a/python/src/aiconfig/util/config_utils.py
+++ b/python/src/aiconfig/util/config_utils.py
@@ -1,4 +1,11 @@
 import os
+from typing import TYPE_CHECKING
+
+import copy
+
+if TYPE_CHECKING:
+    from aiconfig import AIConfigSettings
+    from aiconfig.AIConfigSettings import InferenceSettings
 
 
 def get_api_key_from_environment(api_key_name: str):
@@ -6,4 +13,36 @@ def get_api_key_from_environment(api_key_name: str):
         raise Exception("Missing API key '{}' in environment".format(api_key_name))
 
     return os.environ[api_key_name]
-    
+
+
+def extract_override_settings(
+    config_runtime: "AIConfigSettings", inference_settings: "InferenceSettings", model_id: str
+):
+    """
+    Extract inference settings with overrides based on inference settings.
+
+    This function takes the inference settings and a model ID and returns a subset
+    of inference settings that have been overridden by model-specific settings. It
+    compares the provided settings with global settings, and returns only those that
+    differ or have no corresponding global setting.
+
+    Args:
+        settings (InferenceSettings): The inference settings.
+        model_id (str): The model id.
+
+    Returns:
+        InferenceSettings: The inference settings with overrides from global settings.
+    """
+    model_name = model_id
+    global_model_settings = config_runtime.get_global_settings(model_name)
+
+    if global_model_settings:
+        # Identify the settings that differ from global settings
+        override_settings = {
+            key: copy.deepcopy(inference_settings[key])
+            for key in inference_settings
+            if key not in global_model_settings
+            or global_model_settings.get(key) != inference_settings[key]
+        }
+        return override_settings
+    return inference_settings

--- a/python/tests/parsers/test_openai_util.py
+++ b/python/tests/parsers/test_openai_util.py
@@ -1,3 +1,5 @@
+from aiconfig import Prompt
+from aiconfig import PromptMetadata, ExecuteResult
 from aiconfig.Config import AIConfigRuntime
 from aiconfig import Prompt
 from aiconfig.default_parsers.openai import add_prompt_as_message, refine_chat_completion_params
@@ -22,6 +24,7 @@ def test_refine_chat_completion_params():
     assert "random_attribute" not in refined_params
     assert refined_params["n"] == "3"
 
+
 @pytest.mark.asyncio
 @patch.object(openai.ChatCompletion, "create", side_effect=mock_openai_chat_completion)
 async def test_get_output_text(mock_method):
@@ -30,5 +33,270 @@ async def test_get_output_text(mock_method):
 
     output = aiconfig.get_output_text("prompt1")
     # Mock outputs stored in conftest
-    assert output =="1. Visit Times Square: Experience the bright lights and bustling atmosphere of this iconic NYC landmark. Enjoy shopping, dining, and various entertainment options.\n\n2. Explore Central Park: Take a leisurely stroll or rent a bike to explore the beautiful landscapes, visit the Central Park Zoo, have a picnic, or even go horseback riding.\n\n3. Walk the High Line: This elevated park built on a historic freight rail line offers stunning views of the city skyline, beautiful gardens, art installations, and a unique perspective of NYC.\n\n4. Take a ferry to the Statue of Liberty: Visit the iconic Statue of Liberty on Liberty Island and enjoy breathtaking views of the city from the Crown or the pedestal. You can also explore Ellis Island's immigration museum nearby.\n\n5. Visit the Metropolitan Museum of Art: Explore the vast collections of art and artifacts from around the world at the Met and immerse yourself in the rich cultural history.\n\n6. Discover the vibrant neighborhoods: Explore the diverse neighborhoods of NYC, such as Chinatown, Little Italy, Greenwich Village, and Williamsburg. Enjoy authentic cuisine, unique shops, and immerse yourself in different cultures.\n\n7. Catch a Broadway show: Experience the magic of Broadway by watching a world-class performance at one of the many theaters in the Theater District.\n\n8. Walk across the Brooklyn Bridge: Enjoy panoramic views of the city as you walk or bike across the iconic Brooklyn Bridge, connecting Manhattan and Brooklyn.\n\n9. Explore the Museum of Modern Art (MoMA): Discover modern and contemporary art at MoMA, featuring masterpieces by artists like Van Gogh, Picasso, Warhol, and many more.\n\n10. Enjoy the food scene: NYC is a food lover's paradise. Indulge in diverse culinary experiences, from street food to Michelin-starred restaurants. Don't forget to try New York-style pizza, bagels, and the famous cronut."
+    assert (
+        output
+        == "1. Visit Times Square: Experience the bright lights and bustling atmosphere of this iconic NYC landmark. Enjoy shopping, dining, and various entertainment options.\n\n2. Explore Central Park: Take a leisurely stroll or rent a bike to explore the beautiful landscapes, visit the Central Park Zoo, have a picnic, or even go horseback riding.\n\n3. Walk the High Line: This elevated park built on a historic freight rail line offers stunning views of the city skyline, beautiful gardens, art installations, and a unique perspective of NYC.\n\n4. Take a ferry to the Statue of Liberty: Visit the iconic Statue of Liberty on Liberty Island and enjoy breathtaking views of the city from the Crown or the pedestal. You can also explore Ellis Island's immigration museum nearby.\n\n5. Visit the Metropolitan Museum of Art: Explore the vast collections of art and artifacts from around the world at the Met and immerse yourself in the rich cultural history.\n\n6. Discover the vibrant neighborhoods: Explore the diverse neighborhoods of NYC, such as Chinatown, Little Italy, Greenwich Village, and Williamsburg. Enjoy authentic cuisine, unique shops, and immerse yourself in different cultures.\n\n7. Catch a Broadway show: Experience the magic of Broadway by watching a world-class performance at one of the many theaters in the Theater District.\n\n8. Walk across the Brooklyn Bridge: Enjoy panoramic views of the city as you walk or bike across the iconic Brooklyn Bridge, connecting Manhattan and Brooklyn.\n\n9. Explore the Museum of Modern Art (MoMA): Discover modern and contemporary art at MoMA, featuring masterpieces by artists like Van Gogh, Picasso, Warhol, and many more.\n\n10. Enjoy the food scene: NYC is a food lover's paradise. Indulge in diverse culinary experiences, from street food to Michelin-starred restaurants. Don't forget to try New York-style pizza, bagels, and the famous cronut."
+    )
 
+
+@pytest.mark.asyncio
+@patch.object(openai.ChatCompletion, "create", side_effect=mock_openai_chat_completion)
+async def test_serialize(mock_method):
+    # Test with one input prompt and system. No output
+    completion_params = {
+        "model": "gpt-3.5-turbo",
+        "temperature": 0.7,
+        "max_tokens": 900,
+        "messages": [
+            {"role": "system", "content": "You are an expert greeter"},
+            {"role": "user", "content": "Hello!"},
+        ],
+    }
+
+    aiconfig = AIConfigRuntime.create()
+    serialized_prompts = await aiconfig.serialize(
+        "gpt-3.5-turbo", completion_params, prompt_name="the prompt"
+    )
+    new_prompt = serialized_prompts[0]
+
+    # assert prompt serialized correctly into config
+    assert new_prompt == Prompt(
+        name="the prompt",
+        input="Hello!",
+        metadata=PromptMetadata(
+            **{
+                "model": {
+                    "name": "gpt-3.5-turbo",
+                    "settings": {
+                        "model": "gpt-3.5-turbo",
+                        "temperature": 0.7,
+                        "max_tokens": 900,
+                        "system_prompt": {
+                            "role": "system",
+                            "content": "You are an expert greeter",
+                        },
+                    },
+                },
+                "remember_chat_context": True,
+            }
+        ),
+        outputs=[],
+    )
+
+    # Test with Completion params with an output
+    completion_params = {
+        "model": "gpt-3.5-turbo",
+        "temperature": 0.7,
+        "max_tokens": 900,
+        "messages": [
+            {"role": "system", "content": "You are an expert greeter"},
+            {"role": "user", "content": "Hello!"},
+            {"role": "assistant", "content": "Hello! How can I assist you today?"},
+        ],
+    }
+
+    serialized_prompts = await aiconfig.serialize("gpt-3.5-turbo", completion_params, "prompt")
+    new_prompt = serialized_prompts[0]
+
+    assert new_prompt == Prompt(
+        name="prompt",
+        input="Hello!",
+        metadata=PromptMetadata(
+            **{
+                "model": {
+                    "name": "gpt-3.5-turbo",
+                    "settings": {
+                        "model": "gpt-3.5-turbo",
+                        "temperature": 0.7,
+                        "max_tokens": 900,
+                        "system_prompt": {
+                            "role": "system",
+                            "content": "You are an expert greeter",
+                        },
+                    },
+                },
+                "remember_chat_context": True,
+            }
+        ),
+        outputs=[
+            ExecuteResult(
+                output_type="execute_result",
+                execution_count=None,
+                data={"role": "assistant", "content": "Hello! How can I assist you today?"},
+                metadata={},
+            )
+        ],
+    )
+
+    # Test completion params with a function call input
+
+    completion_params = {
+        "model": "gpt-3.5-turbo",
+        "temperature": 0.7,
+        "max_tokens": 900,
+        "messages": [
+            {"role": "system", "content": "You are an expert decision maker"},
+            {"role": "user", "content": "What is the weather today?"},
+        ],
+        "functions": [
+            {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                        },
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                    },
+                    "required": ["location"],
+                },
+            }
+        ],
+    }
+
+    serialized_prompts = await aiconfig.serialize("gpt-3.5-turbo", completion_params, "prompt")
+    new_prompt = serialized_prompts[0]
+    assert new_prompt == Prompt(
+        name="prompt",
+        input="What is the weather today?",
+        metadata=PromptMetadata(
+            **{
+                "model": {
+                    "name": "gpt-3.5-turbo",
+                    "settings": {
+                        "model": "gpt-3.5-turbo",
+                        "temperature": 0.7,
+                        "max_tokens": 900,
+                        "system_prompt": {
+                            "role": "system",
+                            "content": "You are an expert decision maker",
+                        },
+                        "functions": [
+                            {
+                                "name": "get_current_weather",
+                                "description": "Get the current weather in a given location",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {
+                                        "location": {
+                                            "type": "string",
+                                            "description": "The city and state, e.g. San Francisco, CA",
+                                        },
+                                        "unit": {
+                                            "type": "string",
+                                            "enum": ["celsius", "fahrenheit"],
+                                        },
+                                    },
+                                    "required": ["location"],
+                                },
+                            }
+                        ],
+                    },
+                },
+                "remember_chat_context": True,
+            }
+        ),
+    )
+
+    completion_params = {
+        "model": "gpt-3.5-turbo",
+        "temperature": 0.7,
+        "max_tokens": 900,
+        "messages": [
+            {"role": "system", "content": "You are an expert decision maker"},
+            {"role": "user", "content": "What's the weather like in Boston today?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "function_call": {
+                    "name": "get_current_weather",
+                    "arguments": '{ "location": "Boston, MA"}',
+                },
+            },
+            {
+                "role": "function",
+                "name": "get_current_weather",
+                "content": '{"temperature": "22", "unit": "celsius", "description": "Sunny"}',
+            },
+            {
+                "role": "assistant",
+                "content": "The current weather in Boston is 22 degrees Celsius and sunny.",
+            },
+        ],
+        "functions": [
+            {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                        },
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                    },
+                    "required": ["location"],
+                },
+            }
+        ],
+    }
+
+    prompts = await aiconfig.serialize("gpt-3.5-turbo", completion_params, "prompt")
+    new_prompt = prompts[1]
+    assert new_prompt == Prompt(
+        name="prompt",
+        input={
+            "content": '{"temperature": "22", "unit": "celsius", "description": "Sunny"}',
+            "name": "get_current_weather",
+            "role": "function",
+        },
+        metadata={
+            "model": {
+                "name": "gpt-3.5-turbo",
+                "settings": {
+                    "functions": [
+                        {
+                            "description": "Get the current weather in a given location",
+                            "name": "get_current_weather",
+                            "parameters": {
+                                "properties": {
+                                    "location": {
+                                        "description": "The city and state, e.g. San Francisco, CA",
+                                        "type": "string",
+                                    },
+                                    "unit": {"enum": ["celsius", "fahrenheit"], "type": "string"},
+                                },
+                                "required": ["location"],
+                                "type": "object",
+                            },
+                        }
+                    ],
+                    "max_tokens": 900,
+                    "model": "gpt-3.5-turbo",
+                    "system_prompt": {
+                        "role": "system",
+                        "content": "You are an expert decision maker",
+                    },
+                    "temperature": 0.7,
+                },
+            },
+            "parameters": {},
+            "remember_chat_context": True,
+            "tags": None,
+        },
+        outputs=[
+            {
+                "data": {
+                    "content": "The current weather in Boston is 22 degrees Celsius and sunny.",
+                    "role": "assistant",
+                },
+                "execution_count": None,
+                "metadata": {},
+                "output_type": "execute_result",
+            }
+        ],
+    )

--- a/python/tests/parsers/test_openai_util.py
+++ b/python/tests/parsers/test_openai_util.py
@@ -1,5 +1,6 @@
 from aiconfig.Config import AIConfigRuntime
-from aiconfig.default_parsers.openai import refine_chat_completion_params
+from aiconfig import Prompt
+from aiconfig.default_parsers.openai import add_prompt_as_message, refine_chat_completion_params
 from mock import patch
 import openai
 import pytest

--- a/typescript/__tests__/config.test.ts
+++ b/typescript/__tests__/config.test.ts
@@ -126,6 +126,7 @@ describe("Loading an AIConfig", () => {
     const serializeResult = await aiConfig.serialize(
       "gpt-3.5-turbo",
       completionParams,
+      "prompt",
       {
         products: "Thunderbolt",
       }
@@ -183,6 +184,7 @@ describe("Loading an AIConfig", () => {
     const serializeResult = await aiConfig.serialize(
       "gpt-3.5-turbo",
       completionParams,
+      "prompt",
       {
         products: "Thunderbolt",
       }

--- a/typescript/demo/demo.ts
+++ b/typescript/demo/demo.ts
@@ -99,7 +99,7 @@ async function createAIConfig() {
   };
 
   const aiConfig = AIConfigRuntime.create("demo", "this is a demo AIConfig");
-  const result = await aiConfig.serialize(model, data);
+  const result = await aiConfig.serialize(model, data, "demoPrompt");
 
   if (Array.isArray(result)) {
     for (const prompt of result) {

--- a/typescript/demo/function-call-stream.ts
+++ b/typescript/demo/function-call-stream.ts
@@ -273,7 +273,7 @@ async function createAIConfig() {
     "function-call-demo",
     "this is a demo AIConfig to show function calling using OpenAI"
   );
-  const result = await aiConfig.serialize(model, data);
+  const result = await aiConfig.serialize(model, data, "functionCallResult");
 
   if (Array.isArray(result)) {
     for (const prompt of result) {

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -274,7 +274,8 @@ export class AIConfigRuntime implements AIConfig {
   public async serialize(
     modelName: string,
     data: JSONObject,
-    params?: JSONObject
+    promptName: string,
+    params?: JSONObject,
   ): Promise<Prompt | Prompt[]> {
     const modelParser = ModelParserRegistry.getModelParser(modelName);
     if (!modelParser) {
@@ -284,8 +285,8 @@ export class AIConfigRuntime implements AIConfig {
         )}: ModelParser for model ${modelName} does not exist`
       );
     }
-
-    const prompts = modelParser.serialize("prompt2", data, this, params);
+    
+    const prompts = modelParser.serialize(promptName, data, this, params);
     return prompts;
   }
 

--- a/typescript/lib/parsers/openai.ts
+++ b/typescript/lib/parsers/openai.ts
@@ -350,9 +350,12 @@ export class OpenAIChatModelParser extends ParameterizedModelParser<Chat.ChatCom
           }
         }
 
+        const input: PromptInput =
+          message.role === "user" ? message.content ?? "" : { ...message };
+
         const prompt: Prompt = {
           name: `${promptName}_${prompts.length + 1}`,
-          input: message,
+          input: input,
           metadata: {
             model: modelMetadata,
             parameters: params ?? {},


### PR DESCRIPTION
[Python] 4/n Serialize OpenAI Model Parser



Modified serialize return type to list of Prompts.

Implemented serialize for OpenAI ModelParser.

Tested with api wrapper with the diff on top.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/33).
* __->__ #33
* #38
* #39
* #37