### PR TITLE
OpenAI Api Chat Completion wrapper

### DIFF
--- a/python/src/aiconfig/ChatCompletion.py
+++ b/python/src/aiconfig/ChatCompletion.py
@@ -1,0 +1,48 @@
+"""
+wrapper around openai.ChatCompletion.create that will serialize prompts and save them to config 
+
+usage:
+
+    Normal Import:
+        ` import openai`
+
+    Modified:
+        ```
+        import openai 
+        
+        from aiconfig.ChatCompletion import create_and_save_to_config
+        openai.ChatCompletion.create = create_and_save_to_config
+        ```
+"""
+
+from aiconfig.AIConfigSettings import ExecuteResult
+from aiconfig.Config import AIConfigRuntime
+import openai
+import asyncio
+
+aiconfig = AIConfigRuntime.create("")
+
+openai_chat_completion_create = openai.ChatCompletion.create
+
+
+def create_and_save_to_config(*args, **kwargs):
+    response = openai_chat_completion_create(*args, **kwargs)
+
+    prompts = asyncio.run(aiconfig.serialize(kwargs.get("model"), kwargs))
+    for i, new_prompt in enumerate(prompts):
+        in_config = False
+        for config_prompt in aiconfig.prompts:
+            # check for duplicates (same input and settings.)
+            if (
+                config_prompt.input == new_prompt.input
+                and new_prompt.metadata == config_prompt.metadata
+            ):
+                in_config = True
+                break
+        if not in_config:
+            new_prompt_name = "prompt_{}".format(str(len(aiconfig.prompts)))
+            new_prompt.name = new_prompt_name
+            aiconfig.add_prompt(new_prompt.name, new_prompt)
+    aiconfig.save(include_outputs=False)
+
+    return response

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -203,7 +203,7 @@ class AIConfigRuntime(AIConfig):
     #    @param saveOptions Options that determine how to save the AIConfig to the file.
     #    */
 
-    def save(self, json_config_filepath: str = "aiconfig.json"):
+    def save(self, json_config_filepath: str = "aiconfig.json", include_outputs: bool = True):
         """
         Save the AI Configuration to a JSON file.
 
@@ -211,12 +211,18 @@ class AIConfigRuntime(AIConfig):
             json_config_filepath (str, optional): The file path to the JSON configuration file.
                 Defaults to "aiconfig.json".
         """
+        exclude_options = {
+            "prompt_index": True,
+        }
+        if not include_outputs:
+            exclude_options["prompts"] = {"__all__": {"outputs"}}
+            pass
         with open(json_config_filepath, "w") as file:
             # Serialize the AI Configuration to JSON and save it to the file
             json.dump(
                 self.model_dump(
                     mode="json",
-                    exclude={"prompt_index": True, "prompts": {"__all__": {"outputs"}}},
+                    exclude=exclude_options,
                 ),
                 file,
             )


### PR DESCRIPTION
OpenAI Api Chat Completion wrapper




Wrapper for openai.ChatCompletion.Create()

Saves the latest prompt and system prompt in each call to config and disk under `aiconfig.json`


TODO: make a test
