### PR TITLE
[Python] 1\n Added helpers for retrieving & merging model settings

### DIFF
--- a/python/src/aiconfig/util/config_utils.py
+++ b/python/src/aiconfig/util/config_utils.py
@@ -1,4 +1,11 @@
 import os
+from typing import TYPE_CHECKING
+
+import copy
+
+if TYPE_CHECKING:
+    from aiconfig import AIConfigSettings
+    from aiconfig.AIConfigSettings import InferenceSettings
 
 
 def get_api_key_from_environment(api_key_name: str):
@@ -6,4 +13,36 @@ def get_api_key_from_environment(api_key_name: str):
         raise Exception("Missing API key '{}' in environment".format(api_key_name))
 
     return os.environ[api_key_name]
-    
+
+
+def extract_override_settings(
+    config_runtime: "AIConfigSettings", inference_settings: "InferenceSettings", model_id: str
+):
+    """
+    Extract inference settings with overrides based on inference settings.
+
+    This function takes the inference settings and a model ID and returns a subset
+    of inference settings that have been overridden by model-specific settings. It
+    compares the provided settings with global settings, and returns only those that
+    differ or have no corresponding global setting.
+
+    Args:
+        settings (InferenceSettings): The inference settings.
+        model_id (str): The model id.
+
+    Returns:
+        InferenceSettings: The inference settings with overrides from global settings.
+    """
+    model_name = model_id
+    global_model_settings = config_runtime.get_global_settings(model_name)
+
+    if global_model_settings:
+        # Identify the settings that differ from global settings
+        override_settings = {
+            key: copy.deepcopy(inference_settings[key])
+            for key in inference_settings
+            if key not in global_model_settings
+            or global_model_settings.get(key) != inference_settings[key]
+        }
+        return override_settings
+    return inference_settings


### PR DESCRIPTION
[Python] 1\n Added helpers for retrieving & merging model settings







This diff adds two helpers which ensure that retreived model settings properly contains relevant global settings.

- `extract_override_settings`
- `generate_model_metadata`

Added test for `extract_override_settings`

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/37).
* #33
* #38
* #39
* __->__ #37