### PR TITLE
[Python] 3\n Update OpenAI Deserialize spec to handle function calling

### DIFF
--- a/python/src/aiconfig/AIConfigSettings.py
+++ b/python/src/aiconfig/AIConfigSettings.py
@@ -93,10 +93,11 @@ class PromptMetadata(BaseModel):
 
 
 class PromptInput(BaseModel):
-    # The prompt string, which may be a handlebars template
-    prompt: str
     # Any additional inputs to the model
-    data: Any
+    data: Optional[Any] = None
+
+    class Config:
+        extra = "allow"
 
 
 class Prompt(BaseModel):

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 import copy
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 from typing import TYPE_CHECKING, Any, Dict, Optional
 from aiconfig import AIConfigSettings
 from aiconfig.AIConfigSettings import (
@@ -349,3 +349,47 @@ def refine_chat_completion_params(model_settings):
             completion_data[key] = model_settings[key]
 
     return completion_data
+
+
+def add_prompt_as_message(
+    prompt: Prompt, aiconfig: "AIConfigRuntime", messages: List, params=None
+):
+    """
+    Converts a given prompt to a message and adds it to the specified messages list.
+
+    Note:
+    - If the prompt contains valid input, it's treated as a user message.
+    - If the prompt has a custom role, function call, or name, these attributes are included in the message.
+    - If an AI model output exists, it is appended to the messages list.
+    """
+    if is_prompt_template(prompt):
+        resolved_prompt = resolve_prompt(prompt, params, aiconfig)
+        messages.append({"content": resolved_prompt, "role": "user"})
+    else:
+        # Assumes Prompt input will be in the format of ChatCompletionMessageParam (with content, role, function_name, and name attributes)
+        resolved_prompt = resolve_prompt(prompt.input.content, params, aiconfig)
+
+        prompt_input = prompt.input
+        role = prompt_input.role if hasattr(prompt_input, "role") else "user"
+        fn_call = prompt_input.function_call if hasattr(prompt_input, "function_call") else None
+        name = prompt_input.name if hasattr(prompt_input, "name") else None
+        messages.append(
+            {"content": resolved_prompt, "role": role, "function_call": fn_call, "name": name}
+        )
+
+    output = aiconfig.get_latest_output(prompt)
+    if output:
+        if output.output_type == "execute_result":
+            output_message = output.data
+            if output_message["role"] == "assistant":
+                messages.append(output_message)
+    return messages
+
+
+def is_prompt_template(prompt: Prompt):
+    """
+    Check if a prompt's input is a valid string.
+    """
+    return isinstance(prompt.input, str) or (
+        hasattr(prompt.input, "data") and isinstance(prompt.input.data, str)
+    )

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -14,7 +14,7 @@ from aiconfig.AIConfigSettings import (
 )
 from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
 from aiconfig.util.config_utils import get_api_key_from_environment
-from aiconfig.util.params import resolve_parameters, resolve_prompt, resolve_system_prompt
+from aiconfig.util.params import resolve_parameters, resolve_prompt, resolve_prompt_string, resolve_system_prompt
 
 import openai
 
@@ -122,55 +122,54 @@ class OpenAIInference(ParameterizedModelParser):
         Returns:
             dict: Model-specific completion parameters.
         """
-        resolved_prompt = resolve_prompt(prompt, params, aiconfig)
-
-        # Build Completion data
+        # Build Completion params
         model_settings = aiconfig.get_model_settings(prompt)
 
-        completion_data = refine_chat_completion_params(model_settings)
+        completion_params = refine_chat_completion_params(model_settings)
 
-        completion_data["messages"] = []
+        # In the case thhat the messages array weren't saves as part of the model settings, build it here. Messages array is used for conversation history.
+        if not completion_params.get("messages"):
+            completion_params["messages"] = []
 
-        # Handle System Prompt
-        if "system_prompt" in model_settings:
-            system_prompt = model_settings["system_prompt"]
-            resolved_system_prompt = resolve_system_prompt(prompt, system_prompt, params, aiconfig)
-            completion_data["messages"].append(
-                {"content": resolved_system_prompt, "role": "system"}
-            )
+            # Add System Prompt
+            if "system_prompt" in model_settings:
+                system_prompt = model_settings["system_prompt"]
+                resolved_system_prompt = resolve_system_prompt(prompt, system_prompt, params, aiconfig)
+                completion_params["messages"].append(
+                    {"content": resolved_system_prompt, "role": "system"}
+                )
 
-        # Handle Streaming
-        if options and options.stream:
-            completion_data["stream"] = options.stream
+            # Handle Streaming
+            if options and options.stream:
+                completion_params["stream"] = options.stream
 
-        # Default to always use chat context
-        if not hasattr(prompt.metadata, "remember_chat_context") or (
-            hasattr(prompt.metadata, "remember_chat_context")
-            and prompt.metadata.remember_chat_context != False
-        ):
-            # handle chat history. check previous prompts for the same model. if same model, add prompt and its output to completion data if it has a completed output
-            for i, previous_prompt in enumerate(aiconfig.prompts):
-                # include prompts upto the current one
-                if previous_prompt.name == prompt.name:
-                    break
+            # Default to always use chat context
+            if not hasattr(prompt.metadata, "remember_chat_context") or (
+                hasattr(prompt.metadata, "remember_chat_context")
+                and prompt.metadata.remember_chat_context != False
+            ):
+                # handle chat history. check previous prompts for the same model. if same model, add prompt and its output to completion data if it has a completed output
+                for i, previous_prompt in enumerate(aiconfig.prompts):
+                    # include prompts upto the current one
+                    if previous_prompt.name == prompt.name:
+                        break
 
-                # check if prompt is of the same model
-                if previous_prompt.get_model_name() == self.id():
-                    # add prompt and its output to completion data
-                    # constructing this prompt will take into account available parameters.
-                    resolved_previous_prompt = resolve_parameters({}, previous_prompt, aiconfig)
-                    completion_data["messages"].append(
-                        {"content": resolved_previous_prompt, "role": "user"}
-                    )
-                    # check if prompt has an output
-                    if len(previous_prompt.outputs) > 0:
-                        completion_data["messages"].append(
-                            {"content": str(previous_prompt.outputs[-1].data), "role": "assistant"}
+                    if previous_prompt.get_model_name() == prompt.get_model_name():
+                        # Add prompt and its output to completion data. Constructing this prompt will take into account available parameters.
+                        add_prompt_as_message(
+                            previous_prompt, aiconfig, completion_params["messages"], params
                         )
+        else:
+            # If messages are already specified in the model settings, then just resolve each message with the given parameters and append the latest message
+            for i in range(len(completion_params.get("messages"))):
+                completion_params["messages"][i]["content"] = resolve_prompt_string(
+                   prompt, params, aiconfig, completion_params["messages"][i]["content"]
+                )
 
-        # pass in the user prompt
-        completion_data["messages"].append({"content": resolved_prompt, "role": "user"})
-        return completion_data
+        # Add in the latest prompt
+        add_prompt_as_message(prompt, aiconfig, completion_params["messages"], params)
+
+        return completion_params
 
     async def run_inference(self, prompt: Prompt, aiconfig, options, parameters) -> Output:
         """
@@ -335,6 +334,7 @@ def refine_chat_completion_params(model_settings):
         "logit_bias",
         "max_tokens",
         "model",
+        "messages",
         "n",
         "presence_penalty",
         "stop",

--- a/python/src/aiconfig/util/config_utils.py
+++ b/python/src/aiconfig/util/config_utils.py
@@ -1,4 +1,11 @@
 import os
+from typing import TYPE_CHECKING
+
+import copy
+
+if TYPE_CHECKING:
+    from aiconfig import AIConfigSettings
+    from aiconfig.AIConfigSettings import InferenceSettings
 
 
 def get_api_key_from_environment(api_key_name: str):
@@ -6,4 +13,36 @@ def get_api_key_from_environment(api_key_name: str):
         raise Exception("Missing API key '{}' in environment".format(api_key_name))
 
     return os.environ[api_key_name]
-    
+
+
+def extract_override_settings(
+    config_runtime: "AIConfigSettings", inference_settings: "InferenceSettings", model_id: str
+):
+    """
+    Extract inference settings with overrides based on inference settings.
+
+    This function takes the inference settings and a model ID and returns a subset
+    of inference settings that have been overridden by model-specific settings. It
+    compares the provided settings with global settings, and returns only those that
+    differ or have no corresponding global setting.
+
+    Args:
+        settings (InferenceSettings): The inference settings.
+        model_id (str): The model id.
+
+    Returns:
+        InferenceSettings: The inference settings with overrides from global settings.
+    """
+    model_name = model_id
+    global_model_settings = config_runtime.get_global_settings(model_name)
+
+    if global_model_settings:
+        # Identify the settings that differ from global settings
+        override_settings = {
+            key: copy.deepcopy(inference_settings[key])
+            for key in inference_settings
+            if key not in global_model_settings
+            or global_model_settings.get(key) != inference_settings[key]
+        }
+        return override_settings
+    return inference_settings

--- a/python/tests/parsers/test_openai_util.py
+++ b/python/tests/parsers/test_openai_util.py
@@ -1,5 +1,6 @@
 from aiconfig.Config import AIConfigRuntime
-from aiconfig.default_parsers.openai import refine_chat_completion_params
+from aiconfig import Prompt
+from aiconfig.default_parsers.openai import add_prompt_as_message, refine_chat_completion_params
 from mock import patch
 import openai
 import pytest


### PR DESCRIPTION
[Python] 3\n Update OpenAI Deserialize spec to handle function calling




- Modified PromptInput type args to be  more generic and in turn allow function calling .


Function calling prompt input with openai will look something like the following. The main difference is that the input has a role, and content, similar,
```
newPrompt:
 {
  name: 'functionCallResult-3',
  input: {
    role: 'function',
    name: 'list',
    content: '[{"name":"To Kill a Mockingbird","id":"a1"},{"name":"All the Light We Cannot See","id":"a2"},{"name":"Where the Crawdads Sing","id":"a3"}]'
  },
  metadata: {
    model: { name: 'gpt-3.5-turbo', settings: [Object] },
    parameters: {},
    remember_chat_context: true
  },
  outputs: undefined
}```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/38).
* #33
* __->__ #38
* #39
* #37