### PR TITLE
[Python] 2\n helper fn's to Augment OpenAI Serialize()

### DIFF
--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 import copy
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 from typing import TYPE_CHECKING, Any, Dict, Optional
 from aiconfig import AIConfigSettings
 from aiconfig.AIConfigSettings import (
@@ -349,3 +349,47 @@ def refine_chat_completion_params(model_settings):
             completion_data[key] = model_settings[key]
 
     return completion_data
+
+
+def add_prompt_as_message(
+    prompt: Prompt, aiconfig: "AIConfigRuntime", messages: List, params=None
+):
+    """
+    Converts a given prompt to a message and adds it to the specified messages list.
+
+    Note:
+    - If the prompt contains valid input, it's treated as a user message.
+    - If the prompt has a custom role, function call, or name, these attributes are included in the message.
+    - If an AI model output exists, it is appended to the messages list.
+    """
+    if is_prompt_template(prompt):
+        resolved_prompt = resolve_prompt(prompt, params, aiconfig)
+        messages.append({"content": resolved_prompt, "role": "user"})
+    else:
+        # Assumes Prompt input will be in the format of ChatCompletionMessageParam (with content, role, function_name, and name attributes)
+        resolved_prompt = resolve_prompt(prompt.input.content, params, aiconfig)
+
+        prompt_input = prompt.input
+        role = prompt_input.role if hasattr(prompt_input, "role") else "user"
+        fn_call = prompt_input.function_call if hasattr(prompt_input, "function_call") else None
+        name = prompt_input.name if hasattr(prompt_input, "name") else None
+        messages.append(
+            {"content": resolved_prompt, "role": role, "function_call": fn_call, "name": name}
+        )
+
+    output = aiconfig.get_latest_output(prompt)
+    if output:
+        if output.output_type == "execute_result":
+            output_message = output.data
+            if output_message["role"] == "assistant":
+                messages.append(output_message)
+    return messages
+
+
+def is_prompt_template(prompt: Prompt):
+    """
+    Check if a prompt's input is a valid string.
+    """
+    return isinstance(prompt.input, str) or (
+        hasattr(prompt.input, "data") and isinstance(prompt.input.data, str)
+    )

--- a/python/src/aiconfig/util/config_utils.py
+++ b/python/src/aiconfig/util/config_utils.py
@@ -1,4 +1,11 @@
 import os
+from typing import TYPE_CHECKING
+
+import copy
+
+if TYPE_CHECKING:
+    from aiconfig import AIConfigSettings
+    from aiconfig.AIConfigSettings import InferenceSettings
 
 
 def get_api_key_from_environment(api_key_name: str):
@@ -6,4 +13,36 @@ def get_api_key_from_environment(api_key_name: str):
         raise Exception("Missing API key '{}' in environment".format(api_key_name))
 
     return os.environ[api_key_name]
-    
+
+
+def extract_override_settings(
+    config_runtime: "AIConfigSettings", inference_settings: "InferenceSettings", model_id: str
+):
+    """
+    Extract inference settings with overrides based on inference settings.
+
+    This function takes the inference settings and a model ID and returns a subset
+    of inference settings that have been overridden by model-specific settings. It
+    compares the provided settings with global settings, and returns only those that
+    differ or have no corresponding global setting.
+
+    Args:
+        settings (InferenceSettings): The inference settings.
+        model_id (str): The model id.
+
+    Returns:
+        InferenceSettings: The inference settings with overrides from global settings.
+    """
+    model_name = model_id
+    global_model_settings = config_runtime.get_global_settings(model_name)
+
+    if global_model_settings:
+        # Identify the settings that differ from global settings
+        override_settings = {
+            key: copy.deepcopy(inference_settings[key])
+            for key in inference_settings
+            if key not in global_model_settings
+            or global_model_settings.get(key) != inference_settings[key]
+        }
+        return override_settings
+    return inference_settings


### PR DESCRIPTION
[Python] 2\n helper fn's to Augment OpenAI Serialize()



This diff introduces two new helper functions inside the openai model parser.

- `add_prompt_as_message`
- `has_valid_prompt_string`


First one  converts prompts into messages and appends them to a list of messages. Designed to augment serialize()

Second one validates if a prompt's input type.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/39).
* #33
* #38
* __->__ #39
* #37