### PR TITLE
[Typescript][Long] Added HuggingFace Text Generation Parser.

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+from aiconfig.default_parsers.hf import HuggingFaceTextParser
 import requests
 from typing import ClassVar, Dict, List, Optional
 
@@ -32,6 +33,7 @@ gpt_models = [
 for model in gpt_models:
     ModelParserRegistry.register_model_parser(DefaultOpenAIParser(model))
 ModelParserRegistry.register_model_parser(PaLMChatParser())
+ModelParserRegistry.register_model_parser(HuggingFaceTextParser("mistralai/Mistral-7B-Instruct-v0.1"))
 
 class AIConfigRuntime(AIConfig):
     # A mapping of model names to their respective parsers

--- a/python/src/aiconfig/default_parsers/hf.py
+++ b/python/src/aiconfig/default_parsers/hf.py
@@ -1,0 +1,266 @@
+from abc import abstractmethod
+import copy
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from aiconfig.AIConfigSettings import (
+    ExecuteResult,
+    ModelMetadata,
+    Output,
+    Prompt,
+    PromptMetadata,
+)
+from aiconfig.default_parsers.openai import multi_choice_message_reducer
+from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
+from aiconfig.util.config_utils import get_api_key_from_environment
+from aiconfig.util.params import resolve_parameters, resolve_prompt
+from huggingface_hub import InferenceClient
+from huggingface_hub.inference._text_generation import (
+    TextGenerationResponse,
+    TextGenerationStreamResponse,
+)
+
+if TYPE_CHECKING:
+    from aiconfig.Config import AIConfigRuntime
+
+
+class HuggingFaceTextParser(ParameterizedModelParser):
+    """
+    A subclassable model parser for HuggingFace text generation models.
+    """
+
+    def __init__(self, model_id: str, use_api_token=False):
+        """
+        Args:
+            model_id (str): The model ID of the model to use.
+            no_token (bool): Whether or not to require an API token. Set to False if you don't have an api key.
+
+        Returns:
+            HuggingFaceTextParser: The HuggingFaceTextParser object.
+
+        Usage:
+
+        1. Create a new model parser object with the model ID of the model to use.
+                parser = HuggingFaceTextParser("mistralai/Mistral-7B-Instruct-v0.1", use_api_token=False)
+        2. Add the model parser to the registry.
+                config.register_model_parser(parser)
+
+        If use_api_token is set to True, then the model parser will require an API token to be set in the environment variable HUGGING_FACE_API_TOKEN.
+
+
+        """
+        super().__init__()
+
+        self.model_id = model_id
+
+        token = None
+
+        if use_api_token:
+            token = get_api_key_from_environment("HUGGING_FACE_API_TOKEN")
+
+        self.client = InferenceClient(model_id, token=token)
+
+    def id(self) -> str:
+        """
+        Returns an identifier for the model (e.g. llama-2, gpt-4, etc.).
+        """
+        return self.model_id
+
+    def serialize(
+        self,
+        prompt_name: str,
+        data: Any,
+        ai_config: "AIConfigRuntime",
+        parameters: Optional[Dict] = None,
+        **kwargs
+    ) -> Prompt:
+        """
+        Defines how a prompt and model inference settings get serialized in the .aiconfig.
+
+        Args:
+            prompt (str): The prompt to be serialized.
+            inference_settings (dict): Model-specific inference settings to be serialized.
+
+        Returns:
+            str: Serialized representation of the prompt and inference settings.
+        """
+        data = copy.deepcopy(data)
+
+        # assume data is completion params for HF text generation
+        prompt_input = data["prompt"]
+
+        # Prompt is handled, remove from data
+        data.pop("prompt", None)
+
+        model_metadata = ai_config.generate_model_metadata(data, self.id())
+        prompt = Prompt(
+            name=prompt_name,
+            input=prompt_input,
+            metadata=PromptMetadata(model=model_metadata, parameters=parameters, **kwargs),
+        )
+        return [prompt]
+
+    async def deserialize(
+        self, prompt: Prompt, aiconfig: "AIConfigRuntime", options, params: Optional[Dict] = {}
+    ) -> Dict:
+        """
+        Defines how to parse a prompt in the .aiconfig for a particular model
+        and constructs the completion params for that model.
+
+        Args:
+            serialized_data (str): Serialized data from the .aiconfig.
+
+        Returns:
+            dict: Model-specific completion parameters.
+        """
+        resolved_prompt = resolve_prompt(prompt, params, aiconfig)
+
+        # Build Completion data
+        model_settings = aiconfig.get_model_settings(prompt)
+
+        completion_data = refine_chat_completion_params(model_settings)
+
+        completion_data["prompt"] = resolved_prompt
+
+        return completion_data
+
+    async def run_inference(self, prompt: Prompt, aiconfig, options, parameters) -> Output:
+        """
+        Invoked to run a prompt in the .aiconfig. This method should perform
+        the actual model inference based on the provided prompt and inference settings.
+
+        Args:
+            prompt (str): The input prompt.
+            inference_settings (dict): Model-specific inference settings.
+
+        Returns:
+            InferenceResponse: The response from the model.
+        """
+        completion_data = await self.deserialize(prompt, aiconfig, options, parameters)
+
+        # if stream enabled in runtime options and config, then stream. Otherwise don't stream.
+        stream = (options.stream if options else False) and (
+            "stream" in completion_data and completion_data.get("stream") == True
+        )
+
+        response = self.client.text_generation(**completion_data)
+        response_is_detailed = completion_data.get("details", False)
+        outputs = []
+
+        # HF Text Generation api doesn't support multiple outputs. Expect only one output.
+        # Output spec: .data to to the actual string, and metadata to the details and any other info present.
+        if not stream:
+            output = construct_regular_output(response, response_is_detailed)
+            outputs.append(output)
+        else:
+            # Handles stream callback
+            output = construct_stream_output(response, response_is_detailed, options)
+            outputs.append(output)
+
+        prompt.outputs = outputs
+        return prompt.outputs
+
+    def get_output_text(
+        self, prompt: Prompt, aiconfig: "AIConfigRuntime", output: Optional[Output] = None
+    ) -> str:
+        if not output:
+            output = aiconfig.get_latest_output(prompt)
+
+        if not output:
+            return ""
+
+        if output.output_type == "execute_result":
+            if isinstance(output.data, str):
+                return output.data
+        else:
+            return ""
+
+
+def refine_chat_completion_params(model_settings):
+    # completion parameters to be used for HF text generation api
+    # Prompt is handled separately
+    supported_keys = {
+        "details",
+        "stream",
+        "model",
+        "do_sample",
+        "max_new_tokens",
+        "best_of",
+        "repetition_penalty",
+        "return_full_text",
+        "seed",
+        "stop_sequences",
+        "temperature",
+        "top_k",
+        "top_p",
+        "truncate",
+        "typical_p",
+        "watermark",
+        "decoder_input_details",
+    }
+
+    completion_data = {}
+    for key in model_settings:
+        if key.lower() in supported_keys:
+            completion_data[key.lower()] = model_settings[key]
+
+    return completion_data
+
+
+def construct_stream_output(
+    response: TextGenerationStreamResponse, response_includes_details: bool, options
+) -> Output:
+    """
+    Constructs the output for a stream response.
+
+    Args:
+        response (TextGenerationStreamResponse): The response from the model.
+        response_includes_details (bool): Whether or not the response includes details.
+        options (InferenceOptions): The inference options. Used to determine the stream callback.
+
+    """
+    accumulated_message = ""
+    for iteration in response:
+        metadata = {}
+        data = iteration
+        if response_includes_details:
+            iteration: TextGenerationStreamResponse
+            data = iteration.token.text
+            metadata = {"token": iteration.token, "details": iteration.details}
+        else:
+            data: str
+
+        # Reduce
+        accumulated_message += data
+
+        index = 0  # HF Text Generation api doesn't support multiple outputs
+        delta = data
+        options.stream_callback(delta, accumulated_message, index)
+
+        output = ExecuteResult(
+            **{
+                "output_type": "execute_result",
+                "data": copy.deepcopy(accumulated_message),
+                "execution_count": index,
+                "metadata": metadata,
+            }
+        )
+
+    return output
+
+
+def construct_regular_output(response, response_includes_details: bool) -> Output:
+    metadata = {}
+    data = response
+    if response_includes_details:
+        response: TextGenerationResponse  # Expect response to be of type TextGenerationResponse
+        data = response.generated_text
+        metadata = {"details": response.details}
+
+    output = ExecuteResult(
+        **{
+            "output_type": "execute_result",
+            "data": data,
+            "execution_count": 0,
+            "metadata": metadata,
+        }
+    )
+    return output

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -222,7 +222,10 @@ export class AIConfigRuntime implements AIConfig {
    * @param modelParser The model parser to add to the registry.
    * @param ids Optional list of model IDs to register the model parser for. If unspecified, the model parser will be registered for modelParser.id.
    */
-  public static registerModelParser(modelParser: ModelParser, ids?: string[]) {
+  public static registerModelParser(
+    modelParser: ModelParser<any, any>,
+    ids?: string[]
+  ) {
     ModelParserRegistry.registerModelParser(modelParser, ids);
   }
 
@@ -285,7 +288,7 @@ export class AIConfigRuntime implements AIConfig {
         )}: ModelParser for model ${modelName} does not exist`
       );
     }
-    
+
     const prompts = modelParser.serialize(promptName, data, this, params);
     return prompts;
   }

--- a/typescript/lib/parsers/hf.ts
+++ b/typescript/lib/parsers/hf.ts
@@ -1,0 +1,193 @@
+import { HfInference, TextGenerationArgs } from "@huggingface/inference";
+
+import {
+  Prompt,
+  Output,
+  PromptInput,
+  ModelMetadata,
+  ExecuteResult,
+} from "../../types";
+import { CompletionCreateParams } from "openai/resources";
+import _ from "lodash";
+import { getAPIKeyFromEnv } from "../utils";
+import { ParameterizedModelParser } from "../parameterizedModelParser";
+import { JSONObject } from "../../common";
+import { AIConfigRuntime } from "../config";
+import { InferenceOptions } from "../modelParser";
+
+export class HuggingFaceTextGenerationModelParser extends ParameterizedModelParser<
+  TextGenerationArgs,
+  TextGenerationArgs
+> {
+  private hfClient: HfInference;
+
+  public constructor(modelId: string, use_api_token?: Boolean) {
+    super();
+    let token = use_api_token
+      ? getAPIKeyFromEnv("HUGGING_FACE_API_TOKEN")
+      : undefined;
+    this.hfClient = new HfInference(token);
+    this.id = modelId;
+  }
+
+  public serialize(
+    promptName: string,
+    data: TextGenerationArgs,
+    aiConfig: AIConfigRuntime,
+    params?: JSONObject | undefined
+  ): Prompt | Prompt[] {
+    const input: PromptInput = data.inputs;
+
+    let modelMetadata: ModelMetadata | string;
+    const promptModelMetadata: JSONObject = { ...data.parameters };
+
+    // Check if AIConfig already has the model settings in its metadata
+    const modelName = data.model ?? this.id;
+    const globalModelMetadata = aiConfig.metadata.models?.[modelName];
+
+    if (globalModelMetadata != null) {
+      // Check if the model settings from the input data are the same as the global model settings
+
+      // Compute the difference between the global model settings and the model settings from the input data
+      // If there is a difference, then we need to add the different model settings as overrides on the prompt's metadata
+      const keys = _.union(
+        _.keys(globalModelMetadata),
+        _.keys(promptModelMetadata)
+      );
+      const overrides = _.reduce(
+        keys,
+        (result: JSONObject, key) => {
+          if (!_.isEqual(globalModelMetadata[key], promptModelMetadata[key])) {
+            result[key] = promptModelMetadata[key];
+          }
+          return result;
+        },
+        {}
+      );
+
+      if (Object.keys(overrides).length > 0) {
+        modelMetadata = {
+          name: modelName,
+          settings: overrides,
+        };
+      } else {
+        modelMetadata = modelName;
+      }
+    } else {
+      modelMetadata = {
+        name: modelName,
+        settings: promptModelMetadata,
+      };
+    }
+
+    const prompt: Prompt = {
+      name: promptName,
+      input,
+      metadata: {
+        model: modelMetadata,
+        parameters: params ?? {},
+      },
+    };
+
+    return [prompt];
+  }
+
+  public refineCompletionParams(
+    input: string,
+    params: JSONObject
+  ): TextGenerationArgs {
+    return {
+      model: params.model as string,
+      inputs: input,
+      parameters: {
+        do_sample:
+          params.do_sample != null ? (params.do_sample as boolean) : undefined,
+        max_new_tokens:
+          params.max_new_tokens != null
+            ? (params.max_new_tokens as number)
+            : undefined,
+        max_time:
+          params.max_time != null ? (params.max_time as number) : undefined,
+        num_return_sequences:
+          params.num_return_sequences != null
+            ? (params.num_return_sequences as number)
+            : undefined,
+        repetition_penalty:
+          params.repetition_penalty != null
+            ? (params.repetition_penalty as number)
+            : undefined,
+        return_full_text:
+          params.return_full_text != null
+            ? (params.return_full_text as boolean)
+            : undefined,
+        temperature:
+          params.temperature != null
+            ? (params.temperature as number)
+            : undefined,
+        top_k: params.top_k != null ? (params.top_k as number) : undefined,
+        top_p: params.top_p != null ? (params.top_p as number) : undefined,
+        truncate:
+          params.truncate != null ? (params.truncate as number) : undefined,
+        stop_sequences:
+          params.stop_sequences != null
+            ? (params.stop_sequences as string[])
+            : undefined,
+      },
+    };
+  }
+
+  public deserialize(
+    prompt: Prompt,
+    aiConfig: AIConfigRuntime,
+    params?: JSONObject | undefined
+  ): TextGenerationArgs {
+    // Resolve the prompt template with the given parameters, and update the completion params
+    const resolvedPrompt = this.resolvePromptTemplate(
+      prompt.input as string,
+      prompt,
+      aiConfig,
+      params
+    );
+
+    // Build the text generation args
+    const modelMetadata = this.getModelSettings(prompt, aiConfig) ?? {};
+    return this.refineCompletionParams(resolvedPrompt, modelMetadata);
+  }
+
+  public async run(
+    prompt: Prompt,
+    aiConfig: AIConfigRuntime,
+    options?: InferenceOptions | undefined,
+    params?: JSONObject | undefined
+  ): Promise<Output | Output[]> {
+    const textGenerationArgs = this.deserialize(prompt, aiConfig, params);
+    const response = await this.hfClient.textGeneration(textGenerationArgs);
+    const output: ExecuteResult = {
+      output_type: "execute_result",
+      data: { ...response }, // generated_text: "..."
+      execution_count: 0,
+    };
+
+    return output;
+  }
+
+  public getOutputText(
+    aiConfig: AIConfigRuntime,
+    output?: Output,
+    prompt?: Prompt
+  ): string {
+    if (output == null && prompt != null) {
+      output = aiConfig.getLatestOutput(prompt);
+    }
+
+    if (output == null) {
+      return "";
+    }
+
+    if (output.output_type === "execute_result") {
+      return output.data as string;
+    } else {
+      return "";
+    }
+  }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@google-ai/generativelanguage": "^1.1.0",
+    "@huggingface/inference": "^2.6.4",
     "axios": "^1.5.1",
     "google-auth-library": "^9.1.0",
     "gpt-3-encoder": "^1.1.4",

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -329,6 +329,11 @@
     protobufjs "^7.2.4"
     yargs "^17.7.2"
 
+"@huggingface/inference@^2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@huggingface/inference/-/inference-2.6.4.tgz#a17d73e6e6558670a607752c44ac5868286ceb09"
+  integrity sha512-Xna7arltBSBoKaH3diGi3sYvkExgJMd/pF4T6vl2YbmDccbr1G/X5EPZ2048p+YgrJYG1jTYFCtY6Dr3HvJaow==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
[Typescript] Added HuggingFace Text Generation Parser.






HF text gen model parser.
- Built off Ryan's previous diff on building Model Parser
- Doesn't require an api key but it can be specified.

TS HuggingFace api differs from the Python side in a couple of ways ie:
- different apis for streaming,
- Python lets you specify details to be included, is default in TS


- Modified aiconfig.registerModelParser() with generic Any, otherwise it defaults to JSONObject inside ModelParser and doesn't allow other types

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/48).
* __->__ #48
* #57