### PR TITLE
[Typescript] {WIP} Modified addModel to properly propogate global settings in addModel()

### DIFF
--- a/python/src/aiconfig/util/config_utils.py
+++ b/python/src/aiconfig/util/config_utils.py
@@ -3,8 +3,9 @@ from typing import TYPE_CHECKING
 
 import copy
 
+
 if TYPE_CHECKING:
-    from aiconfig import AIConfigSettings
+    from ..AIConfigSettings import AIConfig
     from aiconfig.AIConfigSettings import InferenceSettings
 
 
@@ -16,7 +17,7 @@ def get_api_key_from_environment(api_key_name: str):
 
 
 def extract_override_settings(
-    config_runtime: "AIConfigSettings", inference_settings: "InferenceSettings", model_id: str
+    config_runtime: "AIConfig", inference_settings: "InferenceSettings", model_id: str
 ):
     """
     Extract inference settings with overrides based on inference settings.

--- a/typescript/__tests__/testProgramaticallyCreateConfig.ts
+++ b/typescript/__tests__/testProgramaticallyCreateConfig.ts
@@ -1,0 +1,72 @@
+import { JSONObject } from "../common";
+import { AIConfigRuntime } from "../lib/config";
+import { extractOverrideSettings } from "../lib/util/configUtils";
+import { InferenceSettings, ModelMetadata } from "../types";
+
+describe("test extract_override_settings", () => {
+// shared state
+  let aiConfigRuntime: AIConfigRuntime =
+    AIConfigRuntime.create("Untitled AIConfig");
+
+  it("Test Case 1: No global setting, Expect an override", () => {
+    const initialSettings: InferenceSettings = { topP: 0.9 };
+    const modelId: string = "testmodel";
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      initialSettings,
+      modelId
+    );
+    expect(override).toEqual(initialSettings);
+  });
+
+  it("Test Case 2: Global Settings differ, expect override", () => {
+    const initialSettings: InferenceSettings = { topP: 0.9 };
+    const modelId: string = "testmodel";
+
+    // Add a global setting that differs
+    aiConfigRuntime.addModel(modelId, { topP: 0.8 });
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      initialSettings,
+      modelId
+    );
+    expect(override).toEqual(initialSettings);
+  });
+
+  it("Test Case 3: Global Settings match settings, expect no override", () => {
+    const initialSettings: InferenceSettings = { topP: 0.9 };
+    const modelId: string = "testmodel";
+
+    // Update the global setting to match initialSettings
+    aiConfigRuntime.updateModel({
+      name: modelId,
+      settings: { topP: 0.9 },
+    } as ModelMetadata);
+
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      initialSettings,
+      modelId
+    );
+    console.log("overidess: ", override);
+
+    
+    expect(override).toEqual({});
+  });
+
+  it("Test Case 4: Global settings defined and empty settings defined, Expect no override", () => {
+    const modelId: string = "testmodel";
+
+    const inferenceSettings = {} as JSONObject;
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      inferenceSettings,
+      modelId
+    );
+    expect(override).toEqual({});
+  });
+});

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -285,7 +285,6 @@ export class AIConfigRuntime implements AIConfig {
         )}: ModelParser for model ${modelName} does not exist`
       );
     }
-    
     const prompts = modelParser.serialize(promptName, data, this, params);
     return prompts;
   }
@@ -747,6 +746,13 @@ export class AIConfigRuntime implements AIConfig {
 
     // TODO: saqadri - log a warning if the model parser isn't parameterized
     return "";
+  }
+
+  /**
+   *  Returns the global settings for a given model.
+   */
+  public getGlobalSettings(modelName: string) {
+    return this.metadata.models?.[modelName];
   }
 
   //#endregion

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -1,6 +1,7 @@
 import { JSONObject, JSONValue } from "../common";
 import {
   AIConfig,
+  InferenceSettings,
   ModelMetadata,
   Output,
   Prompt,
@@ -275,7 +276,7 @@ export class AIConfigRuntime implements AIConfig {
     modelName: string,
     data: JSONObject,
     promptName: string,
-    params?: JSONObject,
+    params?: JSONObject
   ): Promise<Prompt | Prompt[]> {
     const modelParser = ModelParserRegistry.getModelParser(modelName);
     if (!modelParser) {
@@ -460,11 +461,26 @@ export class AIConfigRuntime implements AIConfig {
 
       prompt.metadata.model = modelMetadata;
     } else {
+      // Prompt not specified. Update global model settings.
       if (!this.metadata.models) {
         this.metadata.models = {};
       }
 
-      this.metadata.models[modelMetadata.name] = modelMetadata;
+      const modelName = modelMetadata.name;
+      const modelSettings = modelMetadata.settings;
+      if (!modelSettings) {
+        throw new Error(
+          `E1021: ModelMetadata ${modelMetadata} does not have settings. Cannot update settings`
+        );
+      }
+
+      if (modelName in this.metadata.models) {
+        throw new Error(
+          `E1021: Model ${modelName} already exists. Use "updateMmodel()".`
+        );
+      } else {
+        this.metadata.models[modelName] = modelSettings;
+      }
     }
   }
 

--- a/typescript/lib/util/configUtils.ts
+++ b/typescript/lib/util/configUtils.ts
@@ -1,0 +1,50 @@
+import { JSONObject } from "../../common";
+import { InferenceSettings, ModelMetadata } from "../../types";
+import { AIConfigRuntime } from "../config";
+import _ from "lodash";
+
+/**
+ *  Extract inference settings with overrides based on inference settings.
+ *
+ *    This function takes the inference settings and a model ID and returns a subset
+ *    of inference settings that have been overridden by model-specific settings. It
+ *    compares the provided settings with global settings, and returns only those that
+ *    differ or have no corresponding global setting.
+ * @param configRuntime The AIConfigRuntime that the prompt belongs to.
+ * @param inferenceSettings The model settings from the input data.
+ * @param modelId The model ID of the prompt.
+ * @returns The model settings from the input data.
+ */
+export function extractOverrideSettings(
+  configRuntime: AIConfigRuntime,
+  inferenceSettings: InferenceSettings,
+  modelId: string
+) {
+  let modelMetadata: ModelMetadata | string;
+  const modelName = modelId;
+  const globalModelSettings = configRuntime.getGlobalSettings(modelName);
+
+  if (globalModelSettings != null) {
+    // Check if the model settings from the input data are the same as the global model settings
+
+    // Compute the difference between the global model settings and the model settings from the input data
+    // If there is a difference, then we need to add the different model settings as overrides on the prompt's metadata
+    const keys = _.union(
+      _.keys(globalModelSettings),
+      _.keys(inferenceSettings)
+    );
+    const overrides = _.reduce(
+      keys,
+      (result: JSONObject, key) => {
+        if (!_.isEqual(globalModelSettings[key], inferenceSettings[key])) {
+          result[key] = inferenceSettings[key];
+        }
+        return result;
+      },
+      {}
+    );
+
+    return overrides;
+  }
+  return inferenceSettings;
+}


### PR DESCRIPTION
[Typescript] {WIP} Modified addModel to properly propogate global settings in addModel()



Title

- added in an error check
- should this add to prompt settings? Originally it shouldn't because prompt has to be defined with settings, and then you use update(). But with the introduction of a default model, this is not longer case. come back to this

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/53).
* #55
* #54
* __->__ #53
* #52
* #51
* #50