### PR TITLE
[Typescript][easy] Refactor updateModel to correctly propogate settings

### DIFF
--- a/python/src/aiconfig/util/config_utils.py
+++ b/python/src/aiconfig/util/config_utils.py
@@ -3,8 +3,9 @@ from typing import TYPE_CHECKING
 
 import copy
 
+
 if TYPE_CHECKING:
-    from aiconfig import AIConfigSettings
+    from ..AIConfigSettings import AIConfig
     from aiconfig.AIConfigSettings import InferenceSettings
     from aiconfig.Config import AIConfigRuntime
 
@@ -17,7 +18,7 @@ def get_api_key_from_environment(api_key_name: str):
 
 
 def extract_override_settings(
-    config_runtime: "AIConfigSettings", inference_settings: "InferenceSettings", model_id: str
+    config_runtime: "AIConfig", inference_settings: "InferenceSettings", model_id: str
 ):
     """
     Extract inference settings with overrides based on inference settings.

--- a/typescript/__tests__/testProgramaticallyCreateConfig.ts
+++ b/typescript/__tests__/testProgramaticallyCreateConfig.ts
@@ -1,0 +1,20 @@
+import { AIConfigRuntime } from "../lib/config";
+import { InferenceSettings } from "../types";
+
+describe("test Get Global Settings", () => {
+  // shared state
+  let aiConfigRuntime: AIConfigRuntime = AIConfigRuntime.create(
+    "Untitled AIConfig",
+    /*param description*/ undefined,
+    "latest",
+    { models: { testmodel: { topP: 0.9 } } }
+  );
+
+  test("Retrieving global setting from AIConfig with 1 model", () => {
+    const modelId: string = "testmodel";
+
+    const globalSettingsForTestModel =
+      aiConfigRuntime.getGlobalSettings(modelId);
+    expect(globalSettingsForTestModel).toEqual({ topP: 0.9 });
+  });
+});

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -1,6 +1,7 @@
 import { JSONObject, JSONValue } from "../common";
 import {
   AIConfig,
+  InferenceSettings,
   ModelMetadata,
   Output,
   Prompt,
@@ -810,6 +811,13 @@ export class AIConfigRuntime implements AIConfig {
 
     // TODO: saqadri - log a warning if the model parser isn't parameterized
     return "";
+  }
+
+  /**
+   *  Returns the global settings for a given model.
+   */
+  public getGlobalSettings(modelName: string): InferenceSettings | undefined {
+    return this.metadata.models?.[modelName];
   }
 
   //#endregion

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -508,8 +508,10 @@ export class AIConfigRuntime implements AIConfig {
       if (!this.metadata.models) {
         this.metadata.models = {};
       }
-
-      this.metadata.models[modelMetadata.name] = modelMetadata;
+      if (!modelMetadata.settings) {
+        modelMetadata.settings = {};
+      }
+      this.metadata.models[modelMetadata.name] = modelMetadata.settings;
     }
   }
 


### PR DESCRIPTION
[Typescript][easy] Refactor updateModel to correctly propogate settings


Refactored updateModel to correctly propogate inference settinsg into global settings when no prompt is specified.

updateModel() takes in two Parameters:
- `ModelMetadata` and an Optional `Prompt`
- `ModelMetadata` has a name field and a settings field
- Global settings on aiconfig, `aiconfig.metadata.models` has type `models?: GlobalModelMetadata;`

where GlobalModelMetadata is a mime typed map/dict, NOT ModelMetadata.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/54).
* #76
* #75
* #55
* #52
* __->__ #54
* #51
* #50