### PR TITLE
[Typescript] Introduce GenerateModelMetadata API method.

### DIFF
--- a/typescript/__tests__/testProgramaticallyCreateConfig.ts
+++ b/typescript/__tests__/testProgramaticallyCreateConfig.ts
@@ -1,5 +1,8 @@
 import { AIConfigRuntime } from "../lib/config";
-import { InferenceSettings } from "../types";
+import { JSONObject } from "../common";
+
+import { InferenceSettings, ModelMetadata } from "../types";
+import { extractOverrideSettings } from "../lib/utils";
 
 describe("test Get Global Settings", () => {
   // shared state
@@ -16,5 +19,71 @@ describe("test Get Global Settings", () => {
     const globalSettingsForTestModel =
       aiConfigRuntime.getGlobalSettings(modelId);
     expect(globalSettingsForTestModel).toEqual({ topP: 0.9 });
+  });
+});
+
+describe("ExtractOverrideSettings function", () => {
+  // shared state
+  let aiConfigRuntime: AIConfigRuntime =
+    AIConfigRuntime.create("Untitled AIConfig");
+
+  test("Should return initial settings when no global settings are defined", () => {
+    const initialSettings: InferenceSettings = { topP: 0.9 };
+    const modelId: string = "testmodel";
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      initialSettings,
+      modelId
+    );
+    expect(override).toEqual(initialSettings);
+  });
+
+  test("Should return an override when initial settings differ from global settings", () => {
+    const initialSettings: InferenceSettings = { topP: 0.9 };
+    const modelId: string = "testmodel";
+
+    // Add a global setting that differs
+    aiConfigRuntime.addModel({ name: modelId, settings: { topP: 0.8 } });
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      initialSettings,
+      modelId
+    );
+    expect(override).toEqual(initialSettings);
+  });
+
+  test("Should return empty override when global settings match initial settings", () => {
+    const initialSettings: InferenceSettings = { topP: 0.9 };
+    const modelId: string = "testmodel";
+
+    // Update the global setting to match initialSettings
+    aiConfigRuntime.updateModel({
+      name: modelId,
+      settings: { topP: 0.9 },
+    } as ModelMetadata);
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      initialSettings,
+      modelId
+    );
+    console.log("overidess: ", override);
+
+    expect(override).toEqual({});
+  });
+
+  it("Should return empty override when Global settings defined and initial settings are empty", () => {
+    const modelId: string = "testmodel";
+
+    const inferenceSettings = {} as JSONObject;
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      inferenceSettings,
+      modelId
+    );
+    expect(override).toEqual({});
   });
 });

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -15,6 +15,7 @@ import _ from "lodash";
 import { getAPIKeyFromEnv } from "./utils";
 import { ParameterizedModelParser } from "./parameterizedModelParser";
 import { OpenAIChatModelParser, OpenAIModelParser } from "./parsers/openai";
+import { extractOverrideSettings } from "./utils";
 
 export type PromptWithOutputs = Prompt & { outputs?: Output[] };
 
@@ -820,6 +821,30 @@ export class AIConfigRuntime implements AIConfig {
    */
   public getGlobalSettings(modelName: string): InferenceSettings | undefined {
     return this.metadata.models?.[modelName];
+  }
+
+  /**
+   * Generates a ModelMetadata object from the inferene settings by extracting the settings that override the global settings.
+   *
+   * @param inferenceSettings - The inference settings to be used for the model.
+   * @param modelName - The unique identifier for the model.
+   * @returns A ModelMetadata object that includes the model's name and optional settings.
+   */
+  public getModelMetadata(
+    inferenceSettings: InferenceSettings,
+    modelName: string
+  ) {
+    const overrideSettings = extractOverrideSettings(
+      this,
+      inferenceSettings,
+      modelName
+    );
+
+    if (!overrideSettings || Object.keys(overrideSettings).length === 0) {
+      return { name: modelName } as ModelMetadata;
+    } else {
+      return { name: modelName, settings: overrideSettings } as ModelMetadata;
+    }
   }
 
   //#endregion

--- a/typescript/lib/utils.ts
+++ b/typescript/lib/utils.ts
@@ -1,7 +1,59 @@
+import _ from "lodash";
+import { AIConfigRuntime } from "./config";
+import { InferenceSettings, ModelMetadata } from "../types";
+import { JSONObject } from "../common";
+
 export function getAPIKeyFromEnv(apiKeyName: string) {
   const apiKeyValue = process.env[apiKeyName];
   if (!apiKeyValue) {
     throw new Error(`Missing API key ${apiKeyName} in environment`);
   }
   return apiKeyValue;
+}
+
+/**
+ *  Extract inference settings with overrides based on inference settings.
+ *
+ *    This function takes the inference settings and a model ID and returns a subset
+ *    of inference settings that have been overridden by model-specific settings. It
+ *    compares the provided settings with global settings, and returns only those that
+ *    differ or have no corresponding global setting.
+ * @param configRuntime The AIConfigRuntime that the prompt belongs to.
+ * @param inferenceSettings The model settings from the input data.
+ * @param modelName The model ID of the prompt.
+ * @returns The model settings from the input data.
+ */
+export function extractOverrideSettings(
+  configRuntime: AIConfigRuntime,
+  inferenceSettings: InferenceSettings,
+  modelName: string
+) {
+  let modelMetadata: ModelMetadata | string;
+  const globalModelSettings: InferenceSettings =
+    {...(configRuntime.getGlobalSettings(modelName)) ?? {}};
+  inferenceSettings = {...(inferenceSettings) ?? {}}
+
+  if (globalModelSettings != null) {
+    // Check if the model settings from the input data are the same as the global model settings
+
+    // Compute the difference between the global model settings and the model settings from the input data
+    // If there is a difference, then we need to add the different model settings as overrides on the prompt's metadata
+    const keys = _.union(
+      _.keys(globalModelSettings),
+      _.keys(inferenceSettings)
+    );
+    const overrides = _.reduce(
+      keys,
+      (result: JSONObject, key) => {
+        if (!_.isEqual(globalModelSettings[key], inferenceSettings[key])) {
+          result[key] = inferenceSettings[key];
+        }
+        return result;
+      },
+      {}
+    );
+
+    return overrides;
+  }
+  return inferenceSettings;
 }


### PR DESCRIPTION
[Typescript] Introduce GenerateModelMetadata API method.





This diff introduces a new api method to config, `generateModelMetadata()` to make it much easier to implement `serialize()` when writing a modelParser

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/55).
* #91
* #76
* #75
* __->__ #55
* #52