### PR TITLE
AIConfig Schema updates

### DIFF
--- a/schema/aiconfig.schema.json
+++ b/schema/aiconfig.schema.json
@@ -4,6 +4,7 @@
   "additionalProperties": {},
   "properties": {
     "name": {
+      "description": "Friendly name descriptor for the AIConfig. Could default to the filename if not specified.",
       "type": "string"
     },
     "description": {
@@ -11,7 +12,121 @@
       "type": "string"
     },
     "schema_version": {
-      "description": "The version of the AIConfig schema.",
+      "$ref": "#/definitions/SchemaVersion",
+      "description": "The version of the AIConfig schema."
+    },
+    "metadata": {
+      "description": "Root-level metadata that applies to the entire AIConfig.",
+      "type": "object",
+      "additionalProperties": {},
+      "properties": {
+        "parameters": {
+          "description": "Parameter definitions that are accessible to all prompts in this AIConfig.\nThese parameters can be referenced in the prompts using {{param_name}} handlebars syntax.\nFor more information, see https://handlebarsjs.com/guide/#basic-usage.",
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "models": {
+          "description": "Globally defined model settings. Any prompts that use these models will have these settings applied by default,\nunless they override them with their own model settings.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        },
+        "default_model": {
+          "description": "Default model to use for prompts that do not specify a model.",
+          "type": "string"
+        },
+        "model_parsers": {
+          "description": "Model ID to ModelParser ID mapping.\nThis is useful if you want to use a custom ModelParser for a model, or if a single ModelParser can handle multiple models.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "prompts": {
+      "description": "Array of prompts that make up the AIConfig.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "A unique identifier for the prompt. This is used to reference the prompt in other parts of the AIConfig (such as other prompts)",
+            "type": "string"
+          },
+          "input": {
+            "$ref": "#/definitions/PromptInput",
+            "description": "The prompt string, or a more complex prompt object."
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {},
+            "properties": {
+              "parameters": {
+                "description": "Parameter definitions that are accessible to this prompt.\nThese parameters can be referenced in the prompt using {{param_name}} handlebars syntax.\nFor more information, see https://handlebarsjs.com/guide/#basic-usage.",
+                "type": "object",
+                "additionalProperties": {}
+              },
+              "model": {
+                "description": "Model name/settings that apply to this prompt.\nThese settings override any global model settings that may have been defined in the AIConfig metadata.\nIf this is a string, it is assumed to be the model name.\nIf this is undefined, the default model specified in the default_model property will be used for this Prompt.",
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "The ID of the model to use.",
+                        "type": "string"
+                      },
+                      "settings": {
+                        "description": "Model inference settings that apply to this prompt.",
+                        "type": "object",
+                        "additionalProperties": {}
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "tags": {
+                "description": "Tags for this prompt. Tags must be unique, and must not contain commas.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "outputs": {
+            "description": "Execution, display, or stream outputs.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Output"
+            }
+          }
+        },
+        "required": [
+          "input",
+          "metadata",
+          "name"
+        ]
+      }
+    }
+  },
+  "required": [
+    "metadata",
+    "name",
+    "prompts",
+    "schema_version"
+  ],
+  "definitions": {
+    "SchemaVersion": {
       "anyOf": [
         {
           "type": "object",
@@ -37,314 +152,88 @@
         }
       ]
     },
-    "metadata": {
-      "description": "Root-level metadata that applies to the entire AIConfig.",
-      "type": "object",
-      "additionalProperties": {},
-      "properties": {
-        "parameters": {
-          "description": "Parameter definitions that are accessible to all prompts in this AIConfig.\nThese parameters can be referenced in the prompts using {{param_name}} handlebars syntax.\nFor more information, see https://handlebarsjs.com/guide/#basic-usage.",
-          "$ref": "#/definitions/JSONObject"
-        },
-        "models": {
-          "description": "Globally defined model settings. Any prompts that use these models will have these settings applied by default,\nunless they override them with their own model settings.",
+    "PromptInput": {
+      "anyOf": [
+        {
           "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/JSONObject"
-          }
-        }
-      }
-    },
-    "prompts": {
-      "description": "Array of prompts that make up the AIConfig.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "description": "A unique identifier for the prompt. This is used to reference the prompt in other parts of the AIConfig (such as other prompts)",
-            "type": "string"
-          },
-          "input": {
-            "description": "The prompt string, or a more complex prompt object.",
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "prompt": {
-                    "description": "The prompt string, which may be a handlebars template.",
-                    "type": "string"
-                  },
-                  "data": {
-                    "description": "Any additional inputs to the model."
-                  }
-                },
-                "required": [
-                  "data",
-                  "prompt"
-                ]
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {},
-            "properties": {
-              "parameters": {
-                "description": "Parameter definitions that are accessible to this prompt.\nThese parameters can be referenced in the prompt using {{param_name}} handlebars syntax.\nFor more information, see https://handlebarsjs.com/guide/#basic-usage.",
-                "$ref": "#/definitions/JSONObject"
-              },
-              "model": {
-                "description": "Model name/settings that apply to this prompt.\nThese settings override any global model settings that may have been defined in the AIConfig metadata.",
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "settings": {
-                        "$ref": "#/definitions/JSONObject"
-                      }
-                    },
-                    "required": [
-                      "name"
-                    ]
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              },
-              "tags": {
-                "description": "Tags for this prompt. Tags must be unique, and must not contain commas.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": [
-              "model"
-            ]
-          },
-          "outputs": {
-            "description": "Execution, display, or stream outputs.\nIgnore: this is a work-in-progress",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/Output"
+          "additionalProperties": {},
+          "properties": {
+            "data": {
+              "description": "Input to the model. This can represent a single input, or multiple inputs.\nThe structure of the data object is up to the ModelParser. For example,\na multi-modal ModelParser can choose to key the data by MIME type."
             }
           }
         },
-        "required": [
-          "input",
-          "metadata",
-          "name"
-        ]
-      }
-    }
-  },
-  "required": [
-    "metadata",
-    "name",
-    "prompts",
-    "schema_version"
-  ],
-  "definitions": {
-    "JSONObject": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/JSONValue"
-      }
-    },
-    "JSONValue": {
-      "anyOf": [
         {
-          "$ref": "#/definitions/JSONObject"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/JSONValue"
-          }
-        },
-        {
-          "type": [
-            "string",
-            "number",
-            "boolean"
-          ]
+          "type": "string"
         }
       ]
     },
     "Output": {
-      "description": "Model inference result.\nIgnore: this is a work-in-progress",
+      "description": "Model inference result.",
       "anyOf": [
         {
-          "$ref": "#/definitions/ExecuteResult"
-        },
-        {
-          "$ref": "#/definitions/DisplayData"
-        },
-        {
-          "$ref": "#/definitions/Stream"
-        },
-        {
-          "$ref": "#/definitions/Error"
-        }
-      ]
-    },
-    "ExecuteResult": {
-      "description": "Result of executing a prompt.",
-      "type": "object",
-      "properties": {
-        "output_type": {
-          "description": "Type of output.",
-          "type": "string",
-          "const": "execute_result"
-        },
-        "execution_count": {
-          "description": "A result's prompt number.",
-          "type": [
-            "null",
-            "number"
+          "description": "Result of executing a prompt.",
+          "type": "object",
+          "properties": {
+            "output_type": {
+              "description": "Type of output.",
+              "type": "string",
+              "const": "execute_result"
+            },
+            "execution_count": {
+              "description": "A result's prompt number.",
+              "type": "number"
+            },
+            "data": {
+              "description": "The result of executing the prompt."
+            },
+            "mime_type": {
+              "description": "The MIME type of the result. If not specified, the MIME type will be assumed to be plain text.",
+              "type": "string"
+            },
+            "metadata": {
+              "description": "Output metadata.",
+              "type": "object",
+              "additionalProperties": {}
+            }
+          },
+          "required": [
+            "data",
+            "output_type"
           ]
         },
-        "data": {
-          "description": "A mime-type keyed dictionary of data",
+        {
+          "description": "Output of an error that occurred during inference.",
           "type": "object",
-          "additionalProperties": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "string"
-              }
-            ]
-          }
-        },
-        "metadata": {
-          "description": "Output metadata.",
-          "type": "object",
-          "additionalProperties": {}
-        }
-      },
-      "required": [
-        "data",
-        "execution_count",
-        "metadata",
-        "output_type"
-      ]
-    },
-    "DisplayData": {
-      "description": "Data displayed as a result of inference.",
-      "type": "object",
-      "properties": {
-        "output_type": {
-          "description": "Type of output.",
-          "type": "string",
-          "const": "display_data"
-        },
-        "data": {
-          "description": "A mime-type keyed dictionary of data",
-          "type": "object",
-          "additionalProperties": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "string"
-              }
-            ]
-          }
-        },
-        "metadata": {
-          "description": "Output metadata.",
-          "type": "object",
-          "additionalProperties": {}
-        }
-      },
-      "required": [
-        "data",
-        "metadata",
-        "output_type"
-      ]
-    },
-    "Stream": {
-      "description": "Stream output from inference.",
-      "type": "object",
-      "properties": {
-        "output_type": {
-          "description": "Type of output.",
-          "type": "string",
-          "const": "stream"
-        },
-        "name": {
-          "description": "The name of the stream (stdout, stderr).",
-          "type": "string"
-        },
-        "text": {
-          "description": "The stream's text output, represented as an array of strings.",
-          "anyOf": [
-            {
+          "properties": {
+            "output_type": {
+              "description": "Type of output.",
+              "type": "string",
+              "const": "error"
+            },
+            "ename": {
+              "description": "The name of the error.",
+              "type": "string"
+            },
+            "evalue": {
+              "description": "The value, or message, of the error.",
+              "type": "string"
+            },
+            "traceback": {
+              "description": "The error's traceback, represented as an array of strings.",
               "type": "array",
               "items": {
                 "type": "string"
               }
-            },
-            {
-              "type": "string"
             }
+          },
+          "required": [
+            "ename",
+            "evalue",
+            "output_type",
+            "traceback"
           ]
         }
-      },
-      "required": [
-        "name",
-        "output_type",
-        "text"
-      ]
-    },
-    "Error": {
-      "description": "Output of an error that occurred during inference.",
-      "type": "object",
-      "properties": {
-        "output_type": {
-          "description": "Type of output.",
-          "type": "string",
-          "const": "error"
-        },
-        "ename": {
-          "description": "The name of the error.",
-          "type": "string"
-        },
-        "evalue": {
-          "description": "The value, or message, of the error.",
-          "type": "string"
-        },
-        "traceback": {
-          "description": "The error's traceback, represented as an array of strings.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "required": [
-        "ename",
-        "evalue",
-        "output_type",
-        "traceback"
       ]
     }
   },

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -117,6 +117,25 @@ export class AIConfigRuntime implements AIConfig {
     );
 
     Object.assign(aiConfig, remainingProps);
+
+    // Update the ModelParserRegistry with any model parsers specified in the AIConfig
+    if (aiConfig.metadata.model_parsers) {
+      for (const [modelName, modelParserId] of Object.entries(
+        aiConfig.metadata.model_parsers
+      )) {
+        const modelParser = ModelParserRegistry.getModelParser(modelParserId);
+        if (!modelParser) {
+          throw new Error(
+            `E1001: Unable to load AIConfig: It specifies ${JSON.stringify(
+              aiConfig.metadata.model_parsers
+            )}, but ModelParser ${modelParserId} for model ${modelName} does not exist. Make sure you have registered the ModelParser before loading the AIConfig.`
+          );
+        }
+
+        ModelParserRegistry.registerModelParser(modelParser, [modelName]);
+      }
+    }
+
     return aiConfig;
   }
 
@@ -139,7 +158,7 @@ export class AIConfigRuntime implements AIConfig {
       .then((response) => {
         if (response.status !== 200) {
           throw new Error(
-            `Failed to load workbook. Status code: ${response.status}`
+            `E1005: Failed to load workbook. Status code: ${response.status}`
           );
         }
 
@@ -275,7 +294,7 @@ export class AIConfigRuntime implements AIConfig {
     modelName: string,
     data: JSONObject,
     promptName: string,
-    params?: JSONObject,
+    params?: JSONObject
   ): Promise<Prompt | Prompt[]> {
     const modelParser = ModelParserRegistry.getModelParser(modelName);
     if (!modelParser) {
@@ -285,7 +304,7 @@ export class AIConfigRuntime implements AIConfig {
         )}: ModelParser for model ${modelName} does not exist`
       );
     }
-    
+
     const prompts = modelParser.serialize(promptName, data, this, params);
     return prompts;
   }
@@ -507,6 +526,37 @@ export class AIConfigRuntime implements AIConfig {
   }
 
   /**
+   * Sets the model to use for all prompts by default in the AIConfig.
+   * @param modelName The name of the model to default to.
+   */
+  public setDefaultModel(modelName: string | undefined) {
+    if (modelName == null) {
+      delete this.metadata.default_model;
+      return;
+    }
+
+    this.metadata.default_model = modelName;
+  }
+
+  /**
+   * Adds a model name : model parser ID mapping to the AIConfig metadata. This model parser will be used to parse Prompts in the AIConfig that use the given model.
+   * @param modelName The name of the model to set the parser for.
+   * @param modelParserId The ID of the model parser to use for the model. If undefined, the model parser for the model will be removed.
+   */
+  public setModelParser(modelName: string, modelParserId: string | undefined) {
+    if (!this.metadata.model_parsers) {
+      this.metadata.model_parsers = {};
+    }
+
+    if (modelParserId == null) {
+      delete this.metadata.model_parsers[modelName];
+      return;
+    }
+
+    this.metadata.model_parsers[modelName] = modelParserId;
+  }
+
+  /**
    * Sets a parameter in the AIConfig to the specified JSON-serializable value.
    * @param name Parameter name.
    * @param value Parameter value (can be a JSON-serializable object with sub-properties).
@@ -722,7 +772,17 @@ export class AIConfigRuntime implements AIConfig {
 
     if (typeof prompt.metadata.model === "string") {
       return prompt.metadata.model;
-    } else {
+    } else if (prompt.metadata.model == null) {
+      const defaultModel = this.metadata.default_model;
+      if (defaultModel == null) {
+        throw new Error(
+          `E2041: No default model specified in AIConfig metadata, and prompt ${prompt.name} does not specify a model`
+        );
+      }
+
+      return defaultModel;
+    }
+    {
       return prompt.metadata.model?.name;
     }
   }
@@ -740,7 +800,10 @@ export class AIConfigRuntime implements AIConfig {
       }
     }
 
-    const modelParser = ModelParserRegistry.getModelParserForPrompt(prompt);
+    const modelParser = ModelParserRegistry.getModelParserForPrompt(
+      prompt,
+      this
+    );
     if (modelParser != null) {
       return modelParser.getOutputText(this, output, prompt);
     }

--- a/typescript/lib/modelParser.ts
+++ b/typescript/lib/modelParser.ts
@@ -117,6 +117,15 @@ export abstract class ModelParser<T = JSONObject, R = T> {
     const modelMetadata = prompt.metadata.model;
     if (typeof modelMetadata === "string") {
       return aiConfig.metadata.models?.[modelMetadata];
+    } else if (modelMetadata == null) {
+      const defaultModel = aiConfig.metadata.default_model;
+      if (defaultModel == null) {
+        throw new Error(
+          `E2040: No default model specified in AIConfig metadata, and prompt ${prompt.name} does not specify a model`
+        );
+      }
+
+      return aiConfig.metadata.models?.[defaultModel];
     } else {
       const globalModelMetadata =
         aiConfig.metadata.models?.[modelMetadata.name];

--- a/typescript/lib/parameterizedModelParser.ts
+++ b/typescript/lib/parameterizedModelParser.ts
@@ -5,7 +5,6 @@ import { InferenceOptions, ModelParser } from "./modelParser";
 import {
   PromptNode,
   getDependencyGraph,
-  resolvePrompt,
   resolvePromptString,
 } from "./parameterize";
 

--- a/typescript/lib/parsers/openai.ts
+++ b/typescript/lib/parsers/openai.ts
@@ -355,7 +355,7 @@ export class OpenAIChatModelParser extends ParameterizedModelParser<Chat.ChatCom
 
         const prompt: Prompt = {
           name: `${promptName}_${prompts.length + 1}`,
-          input: input,
+          input,
           metadata: {
             model: modelMetadata,
             parameters: params ?? {},


### PR DESCRIPTION
AIConfig Schema updates

A few schema updates to AIConfig based on feedback from bug bash and team brainstorming:

1. Add a `default_model` property to AIConfig metadata. If used, we can simplify the prompt to not have to specify any model information at all (see item #5 in Bug Bash: https://docs.google.com/document/d/1tMu-N53AzCKc_uPEeLARLgdnpVLM5HPQjlqOPs3Z0B4/edit)

2. Add `model_parsers` mapping property to AIConfig metadata. This allows us to specify a model parser ID in the config itself. This is based on Ryan's feedback for things like Hugging Face model parsers, which can support hundreds of different models. Now, the models that someone uses in the AIConfig can register the HF model parser in the config, saving us from having to manage a rapidly changing list of model IDs explicitly. (see https://github.com/lastmile-ai/aiconfig/pull/25)

3. Add `mime_type` property to Output type. This will allow us to support multi-modal outputs. Note that for PromptInput type, I have left it as-is intentionally. `PromptInput.data` is currently very flexible -- it can support multiple inputs and in theory can specify mime-types. We can iterate on multi-modal inputs separately.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/61).
* #64
* #63
* #62
* __->__ #61