### PR TITLE
[Python][Easy] reformat helper method to be an instance method

### DIFF
--- a/cookbook/HuggingFace/Mistral-aiconfig.json
+++ b/cookbook/HuggingFace/Mistral-aiconfig.json
@@ -1,0 +1,26 @@
+{
+    "name": "exploring nyc through chatgpt config",
+    "description": "",
+    "schema_version": "latest",
+    "metadata": {
+        "parameters": {},
+        "models": {
+            "mistralai/Mistral-7B-v0.1": {
+                "model": "mistralai/Mistral-7B-v0.1",
+                "top_p": 0.9,
+                "temperature": 0.9,
+                "stream": true
+            }
+        },
+        "default_model": "mistralai/Mistral-7B-v0.1",
+        "model_parsers": {
+            "mistralai/Mistral-7B-v0.1": "HuggingFaceTextParser"
+        }
+    },
+    "prompts": [
+        {
+            "name": "prompt1",
+            "input": "What is your favorite condiment?"
+        }
+    ]
+}

--- a/cookbook/HuggingFace/README.md
+++ b/cookbook/HuggingFace/README.md
@@ -1,0 +1,3 @@
+Example use case for creating a HuggingFace ModelParser for aiconfig.
+
+In this example, we will be creating a ModelParser for the Text-Generation task for HuggingFace. This will allow us to use any TextGeneration HuggingFace Model through the HuggingFace api with AIConfig

--- a/python/src/aiconfig/__init__.py
+++ b/python/src/aiconfig/__init__.py
@@ -1,14 +1,23 @@
+# Core Data Classes
 from .AIConfigSettings import (
     AIConfig,
     ConfigMetadata,
     ExecuteResult,
+    JSONObject,
     ModelMetadata,
     Output,
     Prompt,
     PromptInput,
     PromptMetadata,
     SchemaVersion,
-    JSONObject,
 )
+
+# ModelParser Utilities
+from .model_parser import ModelParser, InferenceOptions
+from .default_parsers.parameterized_model_parser import ParameterizedModelParser
+from .util.params import resolve_prompt
+from .util.config_utils import get_api_key_from_environment
+from .registry import ModelParserRegistry
+
+# The AIConfigRuntime class. This is the main class that you will use to run your AIConfig.
 from .Config import AIConfigRuntime
-from .model_parser import ModelParser

--- a/python/src/aiconfig/default_parsers/parameterized_model_parser.py
+++ b/python/src/aiconfig/default_parsers/parameterized_model_parser.py
@@ -131,7 +131,7 @@ class ParameterizedModelParser(ModelParser):
         """
         return resolve_prompt_string(prompt, params, ai_config, prompt_template)
 
-    def get_prompt_template(prompt: Prompt, aiConfig: "AIConfigRuntime") -> str:
+    def get_prompt_template(self, prompt: Prompt, aiConfig: "AIConfigRuntime") -> str:
         """
         An overrideable method that returns a template for a prompt.
         """


### PR DESCRIPTION
[Python][Easy] reformat helper method to be an instance method

title

method() -> method(self,)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/84).
* #86
* #85
* __->__ #84
* #83
* #82