### PR TITLE
[Python] Fixed a bug that  let Global Parameters take precendence over User Paramaters

### DIFF
--- a/python/src/aiconfig/util/params.py
+++ b/python/src/aiconfig/util/params.py
@@ -308,6 +308,6 @@ def resolve_prompt_string(
     augmented_params.update(ai_config.get_prompt_parameters(current_prompt))
 
     # Combine input_params and augmented_params
-    combined_params = dict(input_params, **augmented_params)
+    combined_params = dict(augmented_params, **input_params)
 
     return resolve_parametrized_prompt(prompt_string, combined_params)


### PR DESCRIPTION
[Python] Fixed a bug that  let Global Parameters take precendence over User Paramaters


Identified in Tanya's notebook: https://colab.research.google.com/drive/1OpDWyI_2aLg8VfWb5VbD864vQDdQjv-m#scrollTo=TBhwhp-b4ajx
