### PR TITLE
[TypeScript] Changes to HuggingFaceModel Parser

### DIFF
--- a/typescript/__tests__/testProgramaticallyCreateConfig.ts
+++ b/typescript/__tests__/testProgramaticallyCreateConfig.ts
@@ -1,5 +1,8 @@
 import { AIConfigRuntime } from "../lib/config";
-import { InferenceSettings } from "../types";
+import { JSONObject } from "../common";
+
+import { InferenceSettings, ModelMetadata } from "../types";
+import { extractOverrideSettings } from "../lib/utils";
 
 describe("test Get Global Settings", () => {
   // shared state
@@ -16,5 +19,71 @@ describe("test Get Global Settings", () => {
     const globalSettingsForTestModel =
       aiConfigRuntime.getGlobalSettings(modelId);
     expect(globalSettingsForTestModel).toEqual({ topP: 0.9 });
+  });
+});
+
+describe("ExtractOverrideSettings function", () => {
+  // shared state
+  let aiConfigRuntime: AIConfigRuntime =
+    AIConfigRuntime.create("Untitled AIConfig");
+
+  test("Should return initial settings when no global settings are defined", () => {
+    const initialSettings: InferenceSettings = { topP: 0.9 };
+    const modelId: string = "testmodel";
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      initialSettings,
+      modelId
+    );
+    expect(override).toEqual(initialSettings);
+  });
+
+  test("Should return an override when initial settings differ from global settings", () => {
+    const initialSettings: InferenceSettings = { topP: 0.9 };
+    const modelId: string = "testmodel";
+
+    // Add a global setting that differs
+    aiConfigRuntime.addModel({ name: modelId, settings: { topP: 0.8 } });
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      initialSettings,
+      modelId
+    );
+    expect(override).toEqual(initialSettings);
+  });
+
+  test("Should return empty override when global settings match initial settings", () => {
+    const initialSettings: InferenceSettings = { topP: 0.9 };
+    const modelId: string = "testmodel";
+
+    // Update the global setting to match initialSettings
+    aiConfigRuntime.updateModel({
+      name: modelId,
+      settings: { topP: 0.9 },
+    } as ModelMetadata);
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      initialSettings,
+      modelId
+    );
+    console.log("overidess: ", override);
+
+    expect(override).toEqual({});
+  });
+
+  it("Should return empty override when Global settings defined and initial settings are empty", () => {
+    const modelId: string = "testmodel";
+
+    const inferenceSettings = {} as JSONObject;
+
+    const override = extractOverrideSettings(
+      aiConfigRuntime,
+      inferenceSettings,
+      modelId
+    );
+    expect(override).toEqual({});
   });
 });

--- a/typescript/demo/mistral-config.json
+++ b/typescript/demo/mistral-config.json
@@ -11,6 +11,9 @@
         "temperature": 0.9,
         "stream": true
       }
+    },
+    "model_parsers": {
+      "mistralai/Mistral-7B-v0.1": "HuggingFaceTextGenerationModelParser"
     }
   },
   "prompts": [

--- a/typescript/demo/mistral-config.json
+++ b/typescript/demo/mistral-config.json
@@ -1,0 +1,28 @@
+{
+  "name": "exploring nyc through chatgpt config",
+  "description": "",
+  "schema_version": "latest",
+  "metadata": {
+    "parameters": {},
+    "models": {
+      "mistralai/Mistral-7B-v0.1": {
+        "model": "mistralai/Mistral-7B-v0.1",
+        "top_p": 0.9,
+        "temperature": 0.9,
+        "stream": true
+      }
+    }
+  },
+  "prompts": [
+    {
+      "name": "prompt1",
+      "input": "Hi! Tell me 10 cool things to do in NYC.",
+      "metadata": {
+        "model": {
+          "name": "mistralai/Mistral-7B-v0.1"
+        },
+        "remember_chat_context": true
+      }
+    }
+  ]
+}

--- a/typescript/demo/test-hf.ts
+++ b/typescript/demo/test-hf.ts
@@ -1,0 +1,66 @@
+import OpenAI from "openai";
+import * as path from "path";
+import { AIConfigRuntime } from "../lib/config";
+import { HuggingFaceTextGenerationModelParser } from "../lib/parsers/hf";
+import { Prompt } from "../types";
+
+async function run() {
+  const config = AIConfigRuntime.load(
+    path.join(__dirname, "/mistral-config.json")
+  );
+
+  // register HF MP
+  const mistralModelParser = new HuggingFaceTextGenerationModelParser(
+    "mistralai/Mistral-7B-v0.1",
+    true
+  );
+  AIConfigRuntime.registerModelParser(mistralModelParser, [
+    "mistralai/Mistral-7B-v0.1",
+  ]);
+
+  console.log("Deserialize Prompt1: ");
+  console.log(await config.resolve("prompt1"));
+  console.log("\nRun Prompt1: ");
+  console.log(await config.run("prompt1"));
+
+  console.log("Latest output: ", config.getOutputText("prompt1"));
+
+  console.log("serialize prompt2: ");
+  const prompts = (await config.serialize(
+    "mistralai/Mistral-7B-v0.1",
+    { inputs: "Hello, world!" },
+    "prompt2"
+  )) as Prompt[];
+
+  const prompt2 = prompts[0];
+
+  console.log("Prompt2: ", prompt2);
+  console.log("adding prompt2, ", config.addPrompt(prompt2, prompt2.name));
+
+  console.log("Deserialize Prompt2: ");
+  console.log(await config.resolve("prompt2"));
+  console.log("\nRun Prompt2: ");
+  console.log(await config.run("prompt2"));
+
+  //stream
+  const inferenceOptions = {
+    callbacks: {
+      streamCallback: (data: any, _accumulatedData: any, _index: any) => {
+        process.stdout.write(data);
+      },
+    },
+  };
+
+  console.log("starting to stream: \n");
+  await config.run("prompt1", undefined, inferenceOptions);
+
+  config.save("config.json");
+}
+
+run();
+
+const hfMP = new HuggingFaceTextGenerationModelParser(
+  "mistralai/Mistral-7B-v0.1",
+  true
+);
+AIConfigRuntime.registerModelParser(hfMP, ["mistralai/Mistral-7B-v0.1"]);

--- a/typescript/demo/test-hf.ts
+++ b/typescript/demo/test-hf.ts
@@ -5,18 +5,13 @@ import { HuggingFaceTextGenerationModelParser } from "../lib/parsers/hf";
 import { Prompt } from "../types";
 
 async function run() {
+  const huggingFaceTextGenerationModelParser =
+    new HuggingFaceTextGenerationModelParser();
+  AIConfigRuntime.registerModelParser(huggingFaceTextGenerationModelParser);
+
   const config = AIConfigRuntime.load(
     path.join(__dirname, "/mistral-config.json")
   );
-
-  // register HF MP
-  const mistralModelParser = new HuggingFaceTextGenerationModelParser(
-    "mistralai/Mistral-7B-v0.1",
-    true
-  );
-  AIConfigRuntime.registerModelParser(mistralModelParser, [
-    "mistralai/Mistral-7B-v0.1",
-  ]);
 
   console.log("Deserialize Prompt1: ");
   console.log(await config.resolve("prompt1"));
@@ -58,9 +53,3 @@ async function run() {
 }
 
 run();
-
-const hfMP = new HuggingFaceTextGenerationModelParser(
-  "mistralai/Mistral-7B-v0.1",
-  true
-);
-AIConfigRuntime.registerModelParser(hfMP, ["mistralai/Mistral-7B-v0.1"]);

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -15,6 +15,7 @@ import _ from "lodash";
 import { getAPIKeyFromEnv } from "./utils";
 import { ParameterizedModelParser } from "./parameterizedModelParser";
 import { OpenAIChatModelParser, OpenAIModelParser } from "./parsers/openai";
+import { extractOverrideSettings } from "./utils";
 
 export type PromptWithOutputs = Prompt & { outputs?: Output[] };
 
@@ -820,6 +821,30 @@ export class AIConfigRuntime implements AIConfig {
    */
   public getGlobalSettings(modelName: string): InferenceSettings | undefined {
     return this.metadata.models?.[modelName];
+  }
+
+  /**
+   * Generates a ModelMetadata object from the inferene settings by extracting the settings that override the global settings.
+   *
+   * @param inferenceSettings - The inference settings to be used for the model.
+   * @param modelName - The unique identifier for the model.
+   * @returns A ModelMetadata object that includes the model's name and optional settings.
+   */
+  public getModelMetadata(
+    inferenceSettings: InferenceSettings,
+    modelName: string
+  ) {
+    const overrideSettings = extractOverrideSettings(
+      this,
+      inferenceSettings,
+      modelName
+    );
+
+    if (!overrideSettings || Object.keys(overrideSettings).length === 0) {
+      return { name: modelName } as ModelMetadata;
+    } else {
+      return { name: modelName, settings: overrideSettings } as ModelMetadata;
+    }
   }
 
   //#endregion

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -243,7 +243,10 @@ export class AIConfigRuntime implements AIConfig {
    * @param modelParser The model parser to add to the registry.
    * @param ids Optional list of model IDs to register the model parser for. If unspecified, the model parser will be registered for modelParser.id.
    */
-  public static registerModelParser(modelParser: ModelParser, ids?: string[]) {
+  public static registerModelParser(
+    modelParser: ModelParser<any, any>,
+    ids?: string[]
+  ) {
     ModelParserRegistry.registerModelParser(modelParser, ids);
   }
 

--- a/typescript/lib/parsers/hf.ts
+++ b/typescript/lib/parsers/hf.ts
@@ -1,0 +1,220 @@
+import {
+  HfInference,
+  TextGenerationArgs,
+  TextGenerationOutput,
+  TextGenerationStreamOutput,
+} from "@huggingface/inference";
+
+import {
+  Prompt,
+  Output,
+  PromptInput,
+  ModelMetadata,
+  ExecuteResult,
+} from "../../types";
+import { CompletionCreateParams } from "openai/resources";
+import _ from "lodash";
+import { getAPIKeyFromEnv } from "../utils";
+import { ParameterizedModelParser } from "../parameterizedModelParser";
+import { JSONObject } from "../../common";
+import { AIConfigRuntime } from "../config";
+import { InferenceOptions } from "../modelParser";
+
+export class HuggingFaceTextGenerationModelParser extends ParameterizedModelParser<TextGenerationArgs> {
+  private hfClient: HfInference;
+
+  public constructor(modelId: string, use_api_token?: Boolean) {
+    super();
+    let token = use_api_token
+      ? getAPIKeyFromEnv("HUGGING_FACE_API_TOKEN")
+      : undefined;
+    this.hfClient = new HfInference(token);
+    this.id = modelId;
+  }
+
+  public serialize(
+    promptName: string,
+    data: TextGenerationArgs,
+    aiConfig: AIConfigRuntime,
+    params?: JSONObject | undefined
+  ): Prompt | Prompt[] {
+    const input: PromptInput = data.inputs;
+
+    let modelMetadata: ModelMetadata | string;
+    const promptModelMetadata: JSONObject = { ...data.parameters };
+
+    // Check if AIConfig already has the model settings in its metadata
+    const modelName = data.model ?? this.id;
+
+    modelMetadata = aiConfig.getModelMetadata(
+      data.parameters as JSONObject,
+      this.id
+    );
+
+    const prompt: Prompt = {
+      name: promptName,
+      input,
+      metadata: {
+        model: modelMetadata,
+        parameters: params ?? {},
+      },
+    };
+
+    return [prompt];
+  }
+
+  public refineCompletionParams(
+    input: string,
+    params: JSONObject
+  ): TextGenerationArgs {
+    return {
+      model: params.model as string,
+      inputs: input,
+      parameters: {
+        do_sample:
+          params.do_sample != null ? (params.do_sample as boolean) : undefined,
+        max_new_tokens:
+          params.max_new_tokens != null
+            ? (params.max_new_tokens as number)
+            : undefined,
+        max_time:
+          params.max_time != null ? (params.max_time as number) : undefined,
+        num_return_sequences:
+          params.num_return_sequences != null
+            ? (params.num_return_sequences as number)
+            : undefined,
+        repetition_penalty:
+          params.repetition_penalty != null
+            ? (params.repetition_penalty as number)
+            : undefined,
+        return_full_text:
+          params.return_full_text != null
+            ? (params.return_full_text as boolean)
+            : undefined,
+        temperature:
+          params.temperature != null
+            ? (params.temperature as number)
+            : undefined,
+        top_k: params.top_k != null ? (params.top_k as number) : undefined,
+        top_p: params.top_p != null ? (params.top_p as number) : undefined,
+        truncate:
+          params.truncate != null ? (params.truncate as number) : undefined,
+        stop_sequences:
+          params.stop_sequences != null
+            ? (params.stop_sequences as string[])
+            : undefined,
+      },
+    };
+  }
+
+  public deserialize(
+    prompt: Prompt,
+    aiConfig: AIConfigRuntime,
+    params?: JSONObject | undefined
+  ): TextGenerationArgs {
+    // Resolve the prompt template with the given parameters, and update the completion params
+    const resolvedPrompt = this.resolvePromptTemplate(
+      prompt.input as string,
+      prompt,
+      aiConfig,
+      params
+    );
+
+    // Build the text generation args
+    const modelMetadata = this.getModelSettings(prompt, aiConfig) ?? {};
+    return this.refineCompletionParams(resolvedPrompt, modelMetadata);
+  }
+
+  public async run(
+    prompt: Prompt,
+    aiConfig: AIConfigRuntime,
+    options?: InferenceOptions | undefined,
+    params?: JSONObject | undefined
+  ): Promise<Output | Output[]> {
+    const textGenerationArgs = this.deserialize(prompt, aiConfig, params);
+
+    // if no options are passed in, don't stream because streaming is dependent on a callback handler
+    const stream = options ? (options.stream ? options.stream : true) : false;
+
+    if (stream) {
+      const response = await this.hfClient.textGenerationStream(
+        textGenerationArgs
+      );
+      const output = await ConstructStreamOutput(
+        response,
+        options as InferenceOptions
+      );
+      return output;
+    } else {
+      const response = await this.hfClient.textGeneration(textGenerationArgs);
+      const output = constructOutput(response);
+      return output;
+    }
+  }
+
+  public getOutputText(
+    aiConfig: AIConfigRuntime,
+    output?: Output,
+    prompt?: Prompt
+  ): string {
+    if (output == null && prompt != null) {
+      output = aiConfig.getLatestOutput(prompt);
+    }
+
+    if (output == null) {
+      return "";
+    }
+
+    if (output.output_type === "execute_result") {
+      return output.data as string;
+    } else {
+      return "";
+    }
+  }
+}
+
+/**
+ * Handles and constructs the output for a stream response.
+ * @param response
+ * @param options
+ * @returns
+ */
+async function ConstructStreamOutput(
+  response: AsyncGenerator<TextGenerationStreamOutput>,
+  options: InferenceOptions
+): Promise<Output> {
+  let accumulatedMessage = "";
+  let output = {} as ExecuteResult;
+
+  for await (const iteration of response) {
+    const data = iteration.token.text;
+    const metadata = iteration;
+
+    accumulatedMessage += data;
+    const delta = data;
+    const index = 0;
+    options.callbacks!.streamCallback(delta, accumulatedMessage, 0);
+
+    output = {
+      output_type: "execute_result",
+      data: delta,
+      execution_count: index,
+      metadata: metadata,
+    } as ExecuteResult;
+  }
+  return output;
+}
+
+function constructOutput(response: TextGenerationOutput): Output {
+  const metadata = {};
+  const data = response;
+
+  const output = {
+    output_type: "execute_result",
+    data: data,
+    execution_count: 0,
+    metadata: metadata,
+  } as ExecuteResult;
+
+  return output;
+}

--- a/typescript/lib/parsers/hf.ts
+++ b/typescript/lib/parsers/hf.ts
@@ -20,16 +20,17 @@ import { JSONObject } from "../../common";
 import { AIConfigRuntime } from "../config";
 import { InferenceOptions } from "../modelParser";
 
+/**
+ * A model parser for HuggingFace text generation models. 
+ * Set the environment variable HUGGING_FACE_API_TOKEN to use your HuggingFace API token.
+ * A HuggingFace API token is not required to use this model parser. 
+ */
 export class HuggingFaceTextGenerationModelParser extends ParameterizedModelParser<TextGenerationArgs> {
-  private hfClient: HfInference;
+  private hfClient: HfInference | undefined;
+  _id = "HuggingFaceTextGenerationModelParser";
 
-  public constructor(modelId: string, use_api_token?: Boolean) {
+  public constructor() {
     super();
-    let token = use_api_token
-      ? getAPIKeyFromEnv("HUGGING_FACE_API_TOKEN")
-      : undefined;
-    this.hfClient = new HfInference(token);
-    this.id = modelId;
   }
 
   public serialize(
@@ -133,6 +134,10 @@ export class HuggingFaceTextGenerationModelParser extends ParameterizedModelPars
   ): Promise<Output | Output[]> {
     const textGenerationArgs = this.deserialize(prompt, aiConfig, params);
 
+    if (!this.hfClient) {
+      this.hfClient = createHuggingFaceClient();
+    }
+
     // if no options are passed in, don't stream because streaming is dependent on a callback handler
     const stream = options ? (options.stream ? options.stream : true) : false;
 
@@ -217,4 +222,18 @@ function constructOutput(response: TextGenerationOutput): Output {
   } as ExecuteResult;
 
   return output;
+}
+
+/**
+ * Creates a new HuggingFace Inference client. Checks for an api token in the environment variables. If no api token is found, the client is created without an api token.
+ * @returns
+ */
+function createHuggingFaceClient() {
+  let huggingFaceAPIToken;
+  try {
+    huggingFaceAPIToken = getAPIKeyFromEnv("HUGGING_FACE_API_TOKEN");
+  } catch (err) {
+  } finally {
+    return new HfInference(huggingFaceAPIToken);
+  }
 }

--- a/typescript/lib/utils.ts
+++ b/typescript/lib/utils.ts
@@ -1,7 +1,59 @@
+import _ from "lodash";
+import { AIConfigRuntime } from "./config";
+import { InferenceSettings, ModelMetadata } from "../types";
+import { JSONObject } from "../common";
+
 export function getAPIKeyFromEnv(apiKeyName: string) {
   const apiKeyValue = process.env[apiKeyName];
   if (!apiKeyValue) {
     throw new Error(`Missing API key ${apiKeyName} in environment`);
   }
   return apiKeyValue;
+}
+
+/**
+ *  Extract inference settings with overrides based on inference settings.
+ *
+ *    This function takes the inference settings and a model ID and returns a subset
+ *    of inference settings that have been overridden by model-specific settings. It
+ *    compares the provided settings with global settings, and returns only those that
+ *    differ or have no corresponding global setting.
+ * @param configRuntime The AIConfigRuntime that the prompt belongs to.
+ * @param inferenceSettings The model settings from the input data.
+ * @param modelName The model ID of the prompt.
+ * @returns The model settings from the input data.
+ */
+export function extractOverrideSettings(
+  configRuntime: AIConfigRuntime,
+  inferenceSettings: InferenceSettings,
+  modelName: string
+) {
+  let modelMetadata: ModelMetadata | string;
+  const globalModelSettings: InferenceSettings =
+    {...(configRuntime.getGlobalSettings(modelName)) ?? {}};
+  inferenceSettings = {...(inferenceSettings) ?? {}}
+
+  if (globalModelSettings != null) {
+    // Check if the model settings from the input data are the same as the global model settings
+
+    // Compute the difference between the global model settings and the model settings from the input data
+    // If there is a difference, then we need to add the different model settings as overrides on the prompt's metadata
+    const keys = _.union(
+      _.keys(globalModelSettings),
+      _.keys(inferenceSettings)
+    );
+    const overrides = _.reduce(
+      keys,
+      (result: JSONObject, key) => {
+        if (!_.isEqual(globalModelSettings[key], inferenceSettings[key])) {
+          result[key] = inferenceSettings[key];
+        }
+        return result;
+      },
+      {}
+    );
+
+    return overrides;
+  }
+  return inferenceSettings;
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@google-ai/generativelanguage": "^1.1.0",
+    "@huggingface/inference": "^2.6.4",
     "axios": "^1.5.1",
     "google-auth-library": "^9.1.0",
     "gpt-3-encoder": "^1.1.4",

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -329,6 +329,11 @@
     protobufjs "^7.2.4"
     yargs "^17.7.2"
 
+"@huggingface/inference@^2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@huggingface/inference/-/inference-2.6.4.tgz#a17d73e6e6558670a607752c44ac5868286ceb09"
+  integrity sha512-Xna7arltBSBoKaH3diGi3sYvkExgJMd/pF4T6vl2YbmDccbr1G/X5EPZ2048p+YgrJYG1jTYFCtY6Dr3HvJaow==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
[TypeScript] Changes to HuggingFaceModel Parser

- Move construction of the HF Client to `run()` stepto address api key
- Does not require modelName; id will always return `HuggingFaceTextGeneration` parser
- API key check is implicit. Not required but if it exists it will use it.
- test harness doesn't need to instantiate a modelParser specific to Model or mistral. Just needs to instantiate the ModelParser for HuggingFace

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/91).
* __->__ #91
* #76
* #75
* #55
* #52