### PR TITLE
[Python] Update run() to make parameters optional.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,6 +4,6 @@ pytest
 pydantic>=2.1
 pybars3
 google-generativeai
-openai
+openai<1.0.0
 python-dotenv
 huggingface_hub

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -173,8 +173,8 @@ class AIConfigRuntime(AIConfig):
 
     async def run(
         self,
-        prompt_name: Optional[str],
-        params: Optional[dict],        
+        prompt_name: str,
+        params: Optional[dict] = {},        
         options: Optional[InferenceOptions] = None,
         **kwargs,
     ):


### PR DESCRIPTION
[Python] Update run() to make parameters optional.


- run() doesn't need parameters specified. Updated parameters to truly be optional, typehint was misleading here

- pinned openai to <1.0.0. Fixing for new version in a seperate diff.
