### PR TITLE
[Python] Refactor out InferenceOptions from `Resolve` and `Deserialize`

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -143,7 +143,6 @@ class AIConfigRuntime(AIConfig):
         self,
         prompt_name: str,
         params: Optional[dict] = {},
-        options: Optional[InferenceOptions] = None,
         **kwargs,
     ):
         """
@@ -167,7 +166,7 @@ class AIConfigRuntime(AIConfig):
         model_name = self.get_model_name(prompt_data)
         model_provider = AIConfigRuntime.get_model_parser(model_name)
 
-        response = await model_provider.deserialize(prompt_data, self, options, params)
+        response = await model_provider.deserialize(prompt_data, self, params)
 
         return response
 

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -122,7 +122,7 @@ class OpenAIInference(ParameterizedModelParser):
         return prompts
 
     async def deserialize(
-        self, prompt: Prompt, aiconfig: "AIConfigRuntime", options, params: Optional[Dict] = {}
+        self, prompt: Prompt, aiconfig: "AIConfigRuntime", params: Optional[Dict] = {}
     ) -> Dict:
         """
         Defines how to parse a prompt in the .aiconfig for a particular model
@@ -155,10 +155,6 @@ class OpenAIInference(ParameterizedModelParser):
                 completion_params["messages"].append(
                     {"content": resolved_system_prompt, "role": "system"}
                 )
-
-            # Handle Streaming
-            if options and options.stream:
-                completion_params["stream"] = options.stream
 
             # Default to always use chat context
             if not hasattr(prompt.metadata, "remember_chat_context") or (
@@ -203,7 +199,7 @@ class OpenAIInference(ParameterizedModelParser):
         if not openai.api_key:
             openai.api_key = get_api_key_from_environment("OPENAI_API_KEY")
 
-        completion_data = await self.deserialize(prompt, aiconfig, options, parameters)
+        completion_data = await self.deserialize(prompt, aiconfig, parameters)
         # if stream enabled in runtime options and config, then stream. Otherwise don't stream.
         stream = (options.stream if options else False) and (
             "stream" in completion_data and completion_data.get("stream") == True
@@ -368,6 +364,7 @@ def refine_chat_completion_params(model_settings):
         "n",
         "presence_penalty",
         "stop",
+        "stream",
         "temperature",
         "top_p",
         "user",

--- a/python/src/aiconfig/default_parsers/palm.py
+++ b/python/src/aiconfig/default_parsers/palm.py
@@ -150,7 +150,7 @@ class PaLMChatParser(ParameterizedModelParser):
         )
 
     async def deserialize(
-        self, prompt: Prompt, aiconfig: "AIConfigRuntime", options, params: Optional[Dict] = {}
+        self, prompt: Prompt, aiconfig: "AIConfigRuntime", params: Optional[Dict] = {}
     ) -> Dict:
         """
         Defines how to parse a prompt in the .aiconfig for a particular model
@@ -221,7 +221,7 @@ class PaLMChatParser(ParameterizedModelParser):
             ExecuteResult: The response from the model.
         """
         # TODO: check and handle api key here
-        completion_data = await self.deserialize(prompt, aiconfig, options, parameters)
+        completion_data = await self.deserialize(prompt, aiconfig, parameters)
         response = palm.chat(**completion_data)
         outputs = []
         for i, candidate in enumerate(response.candidates):

--- a/python/src/aiconfig/model_parser.py
+++ b/python/src/aiconfig/model_parser.py
@@ -45,7 +45,6 @@ class ModelParser(ABC):
         self,
         prompt: Prompt,
         aiConfig: "AIConfigRuntime",
-        options: Optional["InferenceOptions"] = None,
         params: Optional[Dict] = None,
     ) -> Any:
         """

--- a/python/tests/parsers/test_openai_util.py
+++ b/python/tests/parsers/test_openai_util.py
@@ -22,7 +22,7 @@ def test_refine_chat_completion_params():
     refined_params = refine_chat_completion_params(model_settings_with_stream_and_system_prompt)
 
     assert "system_prompt" not in refined_params
-    assert "stream" not in refined_params
+    assert "stream" in refined_params
     assert "random_attribute" not in refined_params
     assert refined_params["n"] == "3"
 


### PR DESCRIPTION
[Python] Refactor out InferenceOptions from `Resolve` and `Deserialize`











## What
Removed dependency on `Inference Options` for
- config.resolve()
- ModelParser.deserialize()
- - Sets `stream` based on config, not InferenceOptions

## Why
`Resolve()` in Config and `Deserialize()` in ModelParser should not use Inference Options. Settings should be derived directly from config. Discussed Offline @saqadri 
