### PR TITLE
[Python] Refactor `generate_model_metadata()` Name

### DIFF
--- a/python/demo/aiconfig_demo.ipynb
+++ b/python/demo/aiconfig_demo.ipynb
@@ -116,7 +116,7 @@
     "from aiconfig import AIConfigRuntime\n",
     "\n",
     "config_file_path = \"parametrized_data_config.json\"\n",
-    "config = AIConfigRuntime.from_config(config_file_path)"
+    "config = AIConfigRuntime.load(config_file_path)"
    ]
   },
   {
@@ -415,7 +415,7 @@
     }
    ],
    "source": [
-    "config2 = AIConfigRuntime.from_config(\"updated_aiconfig.json\")\n",
+    "config2 = AIConfigRuntime.load(\"updated_aiconfig.json\")\n",
     "\n",
     "# Resolve\n",
     "print(await config2.resolve( \"prompt3\",{}, inference_options))\n",

--- a/python/demo/function_calling_demo.py
+++ b/python/demo/function_calling_demo.py
@@ -10,7 +10,7 @@ from pprint import pprint
 
 async def function_calling():
     config_file_path = "function-call.aiconfig.json"
-    config = AIConfigRuntime.from_config(config_file_path)
+    config = AIConfigRuntime.load(config_file_path)
 
     params = {
         "book": "Where the Crawdads Sing",

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -70,7 +70,7 @@ class AIConfigRuntime(AIConfig):
         )
 
     @classmethod
-    def from_config(cls, json_config_filepath) -> "AIConfigRuntime":
+    def load(cls, json_config_filepath) -> "AIConfigRuntime":
         """
         Constructs AIConfigRuntime from a JSON file given its file path and returns it.
 

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -227,8 +227,10 @@ class AIConfigRuntime(AIConfig):
                 self.model_dump(
                     mode="json",
                     exclude=exclude_options,
+                    exclude_none=True,
                 ),
                 file,
+                indent=2,
             )
 
     def get_output_text(self, prompt: str | Prompt, output: Optional[dict] = None) -> str:

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -69,7 +69,7 @@ class OpenAIInference(ParameterizedModelParser):
         # Get the global settings for the model
         model_name = conversation_data["model"] if "model" in conversation_data else self.id()
 
-        model_metadata = ai_config.generate_model_metadata(conversation_data, model_name)
+        model_metadata = ai_config.get_model_metadata(conversation_data, model_name)
         # Remove messages array from model metadata. Handled separately
         model_metadata.settings.pop("messages", None)
 

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -16,7 +16,7 @@ class ExecuteResult(BaseModel):
     # Type of output
     output_type: Literal["execute_result"]
     # nth choice.
-    execution_count: Union[float, None]
+    execution_count: Union[int, None]
     # The result of the executing prompt.
     data: Any
     # The MIME type of the result. If not specified, the MIME type will be assumed to be plain text.

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -380,7 +380,7 @@ class AIConfig(BaseModel):
         # remove from prompt list
         self.prompts = [prompt for prompt in self.prompts if prompt.name != prompt_name]
 
-    def generate_model_metadata(
+    def get_model_metadata(
         self, inference_settings: InferenceSettings, model_id: str
     ) -> ModelMetadata:
         """

--- a/python/tests/parsers/test_openai_util.py
+++ b/python/tests/parsers/test_openai_util.py
@@ -32,7 +32,7 @@ def test_refine_chat_completion_params():
 async def test_get_output_text(mock_method):
     config_relative_path = "../aiconfigs/basic_chatgpt_query_config.json"
     config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
-    aiconfig = AIConfigRuntime.from_config(config_absolute_path)
+    aiconfig = AIConfigRuntime.load(config_absolute_path)
 
     await aiconfig.run("prompt1", {})
 

--- a/python/tests/test_library_helpers.py
+++ b/python/tests/test_library_helpers.py
@@ -40,7 +40,7 @@ def test_collect_prompt_references():
     # collect_prompt_references should return references to 1 and 2. 3 is the prompt we are collecting references for, 4 is after. Both are expected to be skipped
     config_relative_path = "aiconfigs/GPT4 Coding Assistant_aiconfig.json"
     config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
-    aiconfig = AIConfigRuntime.from_config(config_absolute_path)
+    aiconfig = AIConfigRuntime.load(config_absolute_path)
 
     prompt3 = aiconfig.prompts[2]
 

--- a/python/tests/test_load_config.py
+++ b/python/tests/test_load_config.py
@@ -17,7 +17,7 @@ async def test_load_basic_chatgpt_query_config(set_temporary_env_vars):
     """Test loading a basic chatgpt query config"""
     config_relative_path = "aiconfigs/basic_chatgpt_query_config.json"
     config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
-    config = AIConfigRuntime.from_config(config_absolute_path)
+    config = AIConfigRuntime.load(config_absolute_path)
 
     data_for_inference = await config.resolve("prompt1")
 
@@ -34,7 +34,7 @@ async def test_chained_gpt_config(set_temporary_env_vars):
     """Test loading a chained gpt config and resolving it, with chat context enabled"""
     config_relative_path = "aiconfigs/chained_gpt_config.json"
     config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
-    config = AIConfigRuntime.from_config(config_absolute_path)
+    config = AIConfigRuntime.load(config_absolute_path)
 
     data_for_inference1 = await config.resolve("prompt1")
 
@@ -79,7 +79,7 @@ async def test_resolve_system_prompt():
     """
     config_relative_path = "aiconfigs/system_prompt_parameters_config.json"
     config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
-    config = AIConfigRuntime.from_config(config_absolute_path)
+    config = AIConfigRuntime.load(config_absolute_path)
 
     data_for_inference = await config.resolve("prompt1", {"system": "skip odd numbers"})
     assert data_for_inference == {

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -334,7 +334,7 @@ def test_load_saved_config(tmp_path):
     json_config_filepath = tmp_path / "my_aiconfig.json"
     config_runtime.save(json_config_filepath)
 
-    loaded_config = AIConfigRuntime.from_config(json_config_filepath)
+    loaded_config = AIConfigRuntime.load(json_config_filepath)
 
     # Ensure the loaded AIConfig contains the expected data
     assert loaded_config.name == "My AIConfig"

--- a/python/tests/test_resolve.py
+++ b/python/tests/test_resolve.py
@@ -13,7 +13,7 @@ async def test_resolve_default_model_config_with_openai_parser():
     """
     config_relative_path = "aiconfigs/basic_default_model_aiconfig.json"
     config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
-    config = AIConfigRuntime.from_config(config_absolute_path)
+    config = AIConfigRuntime.load(config_absolute_path)
     resolved_params = await config.resolve("prompt1")
 
     assert resolved_params == {

--- a/python/tests/test_run_config.py
+++ b/python/tests/test_run_config.py
@@ -16,7 +16,7 @@ async def test_load_parametrized_data_config(mock_method, set_temporary_env_vars
     """
     config_relative_path = "aiconfigs/parametrized_data_config.json"
     config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
-    config = AIConfigRuntime.from_config(config_absolute_path)
+    config = AIConfigRuntime.load(config_absolute_path)
 
     prompt1_params = {
         "sql_language": "MySQL",


### PR DESCRIPTION
[Python] Refactor `generate_model_metadata()` Name




## WHAT

Previously:
- `generate_model_metadata()`

Refactored to:
- `get_model_metadta()`

## WHY
- Provide better Name for method. `Generate` doesn't really tell the developer what the method does.
- Align on library reqs. Updated in TS already

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/96).
* __->__ #96
* #95
* #94