### PR TITLE
[Python] Refactor save() to use file from load()

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -39,6 +39,7 @@ class AIConfigRuntime(AIConfig):
     # TODO: Define a default constructor that will construct with default values. This seems a little complicated because of the way pydantic works. Pydantic creates its own constructors.
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.file_path = None
 
     @classmethod
     def create(
@@ -83,6 +84,9 @@ class AIConfigRuntime(AIConfig):
             # validated_data =  AIConfig.model_validate_json(file.read())
             aiconfigruntime = cls.model_validate_json(file.read())
             update_model_parser_registry_with_config_runtime(aiconfigruntime)
+
+            # set the file path. This is used when saving the config
+            aiconfigruntime.file_path = json_config_filepath
             return aiconfigruntime
 
     @classmethod
@@ -207,7 +211,7 @@ class AIConfigRuntime(AIConfig):
     #    @param saveOptions Options that determine how to save the AIConfig to the file.
     #    */
 
-    def save(self, json_config_filepath: str = "aiconfig.json", include_outputs: bool = True):
+    def save(self, json_config_filepath: str = None, include_outputs: bool = True):
         """
         Save the AI Configuration to a JSON file.
 
@@ -216,11 +220,17 @@ class AIConfigRuntime(AIConfig):
                 Defaults to "aiconfig.json".
         """
         exclude_options = {
-            "prompt_index": True,
+            "prompt_index": True, 
+            "file_path": True
         }
+
         if not include_outputs:
             exclude_options["prompts"] = {"__all__": {"outputs"}}
             pass
+
+        if not json_config_filepath:
+            json_config_filepath = self.file_path or "aiconfig.json"
+
         with open(json_config_filepath, "w") as file:
             # Serialize the AI Configuration to JSON and save it to the file
             json.dump(

--- a/test.py
+++ b/test.py
@@ -1,0 +1,5 @@
+from aiconfig import AIConfigRuntime
+
+x = AIConfigRuntime.load("python/demo/GPT3-WhatAreTransformers-Stream-Enabled.json")
+
+x.save()


### PR DESCRIPTION
[Python] Refactor save() to use file from load()






## WHAT

The Config.save() method has been updated to automatically save the aiconfig back to the original source file unless an alternative file path is provided

- Added attribute `file_path` to AIConfigRuntime.
- on `config.load()` `file_path` attribute is set to the file
- Modified save() to use file path if available else default to `aiconfig.json`

## WHY
The flow from loading and saving a config should be as easy as possible. This way the user can easily update their config without having the extra step of specifying the same file path that was used to load.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/98).
* #99
* __->__ #98