### PR TITLE
[Typescript] Refactor save() to use file from load()

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-from aiconfig import AIConfigRuntime
-
-x = AIConfigRuntime.load("python/demo/GPT3-WhatAreTransformers-Stream-Enabled.json")
-
-x.save()

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -69,6 +69,8 @@ export class AIConfigRuntime implements AIConfig {
   metadata: AIConfig["metadata"];
   prompts: PromptWithOutputs[];
 
+  filePath?: string;
+
   public constructor(
     name: string,
     description?: string,
@@ -92,7 +94,11 @@ export class AIConfigRuntime implements AIConfig {
   public static load(aiConfigFilePath: string) {
     const aiConfigString = fs.readFileSync(aiConfigFilePath, "utf8");
     const aiConfigObj = JSON.parse(aiConfigString);
-    return this.loadJSON(aiConfigObj);
+
+    const config = this.loadJSON(aiConfigObj);
+    config.filePath = aiConfigFilePath;
+
+    return config;
   }
 
   /**
@@ -201,9 +207,10 @@ export class AIConfigRuntime implements AIConfig {
    * @param filePath The path to the file to save to.
    * @param saveOptions Options that determine how to save the AIConfig to the file.
    */
-  public save(filePath: string, saveOptions?: SaveOptions) {
+  public save(filePath?: string, saveOptions?: SaveOptions) {
     try {
       let aiConfigObj: AIConfigRuntime = _.cloneDeep(this);
+
       if (!saveOptions?.serializeOutputs) {
         const prompts = [];
         for (const prompt of aiConfigObj.prompts) {
@@ -211,9 +218,16 @@ export class AIConfigRuntime implements AIConfig {
         }
         aiConfigObj.prompts = prompts;
       }
+      // Remove the filePath property from the to-be-saved AIConfig
+      aiConfigObj.filePath = undefined;
 
       // TODO: saqadri - make sure that the object satisfies the AIConfig schema
       const aiConfigString = JSON.stringify(aiConfigObj, null, 2);
+  
+      if (!filePath) {
+        filePath = this.filePath ?? "aiconfig.json";
+      }
+
       fs.writeFileSync(filePath, aiConfigString);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
[Typescript] Refactor save() to use file from load()







## WHAT

The Config.save() method has been updated to automatically save the aiconfig back to the original source file unless an alternative file path is provided

- Added attribute `file_path` to AIConfigRuntime.
- on `config.load()` `file_path` attribute is set to the file
- Modified save() to use file path if available else default to `aiconfig.json`

## WHY
The flow from loading and saving a config should be as easy as possible. This way the user can easily update their config without having the extra step of specifying the same file path that was used to load.

# Test Plan:
Local testing
- Load Config()
- Save config() with no params specified.
- Config saved under original file path
