### PR TITLE
[Python] link requirements.txt in pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,18 +15,8 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 
-dependencies = [
-  "requests==2.30.0",
-  "black",
-  "flake8",
-  "pytest",
-  "pydantic>=2.1",
-  "pybars3",
-  "google-generativeai",
-  "openai",
-  "python-dotenv",
-  "huggingface_hub",
-]
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
 
 [project.urls]
 "Homepage" = "https://github.com/lastmile-ai/aiconfig"


### PR DESCRIPTION
[Python] link requirements.txt in pyproject.toml



## What

Modified pyproject.toml to dynamically link to requirements.txt

## WHY

Don't need to update requirements.txt and pyproject.toml for requirements

## Testplan:
- Will test mock publishing before marking ready for review
