### PR TITLE
[Docs] Set CNAME in docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,6 +41,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./aiconfig-docs/build
+          cname: aiconfig.lastmileai.dev
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212


### PR DESCRIPTION
[Docs] Set CNAME in docs deployment

Setting up `aiconfig.lastmileai.dev`

For more info, see:
* https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-add-cname-file-cname

* https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/138).
* __->__ #138
* #137
* #136
* #134
* #133
* #132
* #131
* #130
* #129
* #128