### PR TITLE
[TS] HuggingFaceTextGenerationParser as a default parser

### DIFF
--- a/cookbooks/HuggingFace/Mistral-aiconfig.json
+++ b/cookbooks/HuggingFace/Mistral-aiconfig.json
@@ -14,7 +14,7 @@
         },
         "default_model": "mistralai/Mistral-7B-v0.1",
         "model_parsers": {
-            "mistralai/Mistral-7B-v0.1": "HuggingFaceTextParser"
+            "mistralai/Mistral-7B-v0.1": "HuggingFaceTextGenerationParser"
         }
     },
     "prompts": [

--- a/cookbooks/HuggingFace/python/ask-mistral.py
+++ b/cookbooks/HuggingFace/python/ask-mistral.py
@@ -5,10 +5,8 @@ from hf import HuggingFaceTextParser
 
 
 async def main():
-    text_generation_model_parser = HuggingFaceTextParser(use_api_token=False)
-    AIConfigRuntime.register_model_parser(text_generation_model_parser, "HuggingFaceTextParser")
 
-    config = AIConfigRuntime.load("Mistral-aiconfig.json")
+    config = AIConfigRuntime.load("../Mistral-aiconfig.json")
 
     def stream_callback(data, accumulated_message, index):
         print(data, end="")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "python-aiconfig"
-version = "1.0.4"
+version = "1.0.7"
 authors = [
   { name="Sarmad Qadri", email="sarmad@lastmileai.dev" },
 ]
@@ -23,10 +23,10 @@ dependencies = [
   "pydantic>=2.1",
   "pybars3",
   "google-generativeai",
-  "openai",
+  "openai<1.0.0",
   "python-dotenv",
   "huggingface_hub",
-]
+  ]
 
 [project.urls]
 "Homepage" = "https://github.com/lastmile-ai/aiconfig"

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -2,6 +2,7 @@ import json
 import sys
 import os
 from aiconfig.callback import CallbackEvent, CallbackManager
+from .default_parsers.hf import HuggingFaceTextGenerationParser
 import requests
 from typing import ClassVar, Dict, List, Optional
 
@@ -33,6 +34,7 @@ gpt_models = [
 for model in gpt_models:
     ModelParserRegistry.register_model_parser(DefaultOpenAIParser(model))
 ModelParserRegistry.register_model_parser(PaLMChatParser())
+ModelParserRegistry.register_model_parser(HuggingFaceTextGenerationParser())
 
 class AIConfigRuntime(AIConfig):
     # A mapping of model names to their respective parsers

--- a/python/src/aiconfig/default_parsers/hf.py
+++ b/python/src/aiconfig/default_parsers/hf.py
@@ -1,0 +1,277 @@
+import copy
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+# Type hint imports
+from aiconfig import (
+    ExecuteResult,
+    Output,
+    Prompt,
+    PromptMetadata,
+)
+
+# ModelParser Utils
+from aiconfig import ParameterizedModelParser
+from aiconfig import get_api_key_from_environment
+from aiconfig import resolve_prompt
+from aiconfig import InferenceOptions
+
+# HuggingFace API imports
+from huggingface_hub import InferenceClient
+from huggingface_hub.inference._text_generation import (
+    TextGenerationResponse,
+    TextGenerationStreamResponse,
+)
+
+# Circuluar Dependency Type Hints
+if TYPE_CHECKING:
+    from aiconfig.Config import AIConfigRuntime
+
+
+# Step 1: define Helpers
+
+
+def refine_chat_completion_params(model_settings):
+    """
+    Refines the completion params for the HF text generation api. Removes any unsupported params.
+    The supported keys were found by looking at the HF text generation api. `huggingface_hub.InferenceClient.text_generation()`
+    """
+
+    supported_keys = {
+        "details",
+        "stream",
+        "model",
+        "do_sample",
+        "max_new_tokens",
+        "best_of",
+        "repetition_penalty",
+        "return_full_text",
+        "seed",
+        "stop_sequences",
+        "stream" "temperature",
+        "top_k",
+        "top_p",
+        "truncate",
+        "typical_p",
+        "watermark",
+        "decoder_input_details",
+    }
+
+    completion_data = {}
+    for key in model_settings:
+        if key.lower() in supported_keys:
+            completion_data[key.lower()] = model_settings[key]
+
+    return completion_data
+
+
+def construct_stream_output(
+    response: TextGenerationStreamResponse,
+    response_includes_details: bool,
+    options: InferenceOptions,
+) -> Output:
+    """
+    Constructs the output for a stream response.
+
+    Args:
+        response (TextGenerationStreamResponse): The response from the model.
+        response_includes_details (bool): Whether or not the response includes details.
+        options (InferenceOptions): The inference options. Used to determine the stream callback.
+
+    """
+    accumulated_message = ""
+    for iteration in response:
+        metadata = {}
+        data = iteration
+        if response_includes_details:
+            iteration: TextGenerationStreamResponse
+            data = iteration.token.text
+            metadata = {"token": iteration.token, "details": iteration.details}
+        else:
+            data: str
+
+        # Reduce
+        accumulated_message += data
+
+        index = 0  # HF Text Generation api doesn't support multiple outputs
+        delta = data
+        options.stream_callback(delta, accumulated_message, index)
+
+        output = ExecuteResult(
+            **{
+                "output_type": "execute_result",
+                "data": copy.deepcopy(accumulated_message),
+                "execution_count": index,
+                "metadata": metadata,
+            }
+        )
+
+    return output
+
+
+def construct_regular_output(response, response_includes_details: bool) -> Output:
+    metadata = {}
+    data = response
+    if response_includes_details:
+        response: TextGenerationResponse  # Expect response to be of type TextGenerationResponse
+        data = response.generated_text
+        metadata = {"details": response.details}
+
+    output = ExecuteResult(
+        **{
+            "output_type": "execute_result",
+            "data": data,
+            "execution_count": 0,
+            "metadata": metadata,
+        }
+    )
+    return output
+
+
+class HuggingFaceTextGenerationParser(ParameterizedModelParser):
+    """
+    A model parser for HuggingFace text generation models.
+    """
+
+    def __init__(self, model_id: str = None, use_api_token=False):
+        """
+        Args:
+            model_id (str): The model ID of the model to use.
+            no_token (bool): Whether or not to require an API token. Set to False if you don't have an api key.
+
+        Returns:
+            HuggingFaceTextParser: The HuggingFaceTextParser object.
+
+        Usage:
+
+        1. Create a new model parser object with the model ID of the model to use.
+                parser = HuggingFaceTextParser("mistralai/Mistral-7B-Instruct-v0.1", use_api_token=False)
+        2. Add the model parser to the registry.
+                config.register_model_parser(parser)
+
+        If use_api_token is set to True, then the model parser will require an API token to be set in the environment variable HUGGING_FACE_API_TOKEN.
+
+
+        """
+        super().__init__()
+
+        token = None
+
+        if use_api_token:
+            token = get_api_key_from_environment("HUGGING_FACE_API_TOKEN")
+
+        self.client = InferenceClient(model_id, token=token)
+
+    def id(self) -> str:
+        """
+        Returns an identifier for the Model Parser
+        """
+        return "HuggingFaceTextGenerationParser"
+
+    def serialize(
+        self,
+        prompt_name: str,
+        data: Any,
+        ai_config: "AIConfigRuntime",
+        parameters: Optional[Dict] = None,
+        **kwargs,
+    ) -> Prompt:
+        """
+        Defines how a prompt and model inference settings get serialized in the .aiconfig.
+
+        Args:
+            prompt (str): The prompt to be serialized.
+            inference_settings (dict): Model-specific inference settings to be serialized.
+
+        Returns:
+            str: Serialized representation of the prompt and inference settings.
+        """
+        data = copy.deepcopy(data)
+
+        # assume data is completion params for HF text generation
+        prompt_input = data["prompt"]
+
+        # Prompt is handled, remove from data
+        data.pop("prompt", None)
+
+        model_metadata = ai_config.generate_model_metadata(data, self.id())
+        prompt = Prompt(
+            name=prompt_name,
+            input=prompt_input,
+            metadata=PromptMetadata(model=model_metadata, parameters=parameters, **kwargs),
+        )
+        return [prompt]
+
+    async def deserialize(
+        self, prompt: Prompt, aiconfig: "AIConfigRuntime", options, params: Optional[Dict] = {}
+    ) -> Dict:
+        """
+        Defines how to parse a prompt in the .aiconfig for a particular model
+        and constructs the completion params for that model.
+
+        Args:
+            serialized_data (str): Serialized data from the .aiconfig.
+
+        Returns:
+            dict: Model-specific completion parameters.
+        """
+        resolved_prompt = resolve_prompt(prompt, params, aiconfig)
+
+        # Build Completion data
+        model_settings = self.get_model_settings(prompt, aiconfig)
+
+        completion_data = refine_chat_completion_params(model_settings)
+
+        completion_data["prompt"] = resolved_prompt
+
+        return completion_data
+
+    async def run_inference(self, prompt: Prompt, aiconfig, options, parameters) -> Output:
+        """
+        Invoked to run a prompt in the .aiconfig. This method should perform
+        the actual model inference based on the provided prompt and inference settings.
+
+        Args:
+            prompt (str): The input prompt.
+            inference_settings (dict): Model-specific inference settings.
+
+        Returns:
+            InferenceResponse: The response from the model.
+        """
+        completion_data = await self.deserialize(prompt, aiconfig, options, parameters)
+
+        # if stream enabled in runtime options and config, then stream. Otherwise don't stream.
+        stream = (options.stream if options else False) and (
+            not "stream" in completion_data or completion_data.get("stream") != False
+        )
+
+        response = self.client.text_generation(**completion_data)
+        response_is_detailed = completion_data.get("details", False)
+        outputs = []
+
+        # HF Text Generation api doesn't support multiple outputs. Expect only one output.
+        # Output spec: .data to to the actual string, and metadata to the details and any other info present.
+        if not stream:
+            output = construct_regular_output(response, response_is_detailed)
+            outputs.append(output)
+        else:
+            # Handles stream callback
+            output = construct_stream_output(response, response_is_detailed, options)
+            outputs.append(output)
+
+        prompt.outputs = outputs
+        return prompt.outputs
+
+    def get_output_text(
+        self, prompt: Prompt, aiconfig: "AIConfigRuntime", output: Optional[Output] = None
+    ) -> str:
+        if not output:
+            output = aiconfig.get_latest_output(prompt)
+
+        if not output:
+            return ""
+
+        if output.output_type == "execute_result":
+            if isinstance(output.data, str):
+                return output.data
+        else:
+            return ""

--- a/typescript/demo/test-hf.ts
+++ b/typescript/demo/test-hf.ts
@@ -1,7 +1,7 @@
 import OpenAI from "openai";
 import * as path from "path";
 import { AIConfigRuntime } from "../lib/config";
-import { HuggingFaceTextGenerationModelParser } from "../lib/parsers/hf";
+import { HuggingFaceTextGenerationParser } from "../lib/parsers/hf";
 import { Prompt } from "../types";
 
 async function run() {
@@ -10,10 +10,7 @@ async function run() {
   );
 
   // register HF MP
-  const mistralModelParser = new HuggingFaceTextGenerationModelParser(
-    "mistralai/Mistral-7B-v0.1",
-    true
-  );
+  const mistralModelParser = new HuggingFaceTextGenerationParser();
   AIConfigRuntime.registerModelParser(mistralModelParser, [
     "mistralai/Mistral-7B-v0.1",
   ]);
@@ -59,8 +56,3 @@ async function run() {
 
 run();
 
-const hfMP = new HuggingFaceTextGenerationModelParser(
-  "mistralai/Mistral-7B-v0.1",
-  true
-);
-AIConfigRuntime.registerModelParser(hfMP, ["mistralai/Mistral-7B-v0.1"]);

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -16,6 +16,7 @@ import { getAPIKeyFromEnv } from "./utils";
 import { ParameterizedModelParser } from "./parameterizedModelParser";
 import { OpenAIChatModelParser, OpenAIModelParser } from "./parsers/openai";
 import { extractOverrideSettings } from "./utils";
+import { HuggingFaceTextGenerationParser } from "./parsers/hf";
 
 export type PromptWithOutputs = Prompt & { outputs?: Output[] };
 
@@ -55,6 +56,8 @@ ModelParserRegistry.registerModelParser(new OpenAIChatModelParser(), [
   "gpt-3.5-turbo-0613",
   "gpt-3.5-turbo-16k-0613",
 ]);
+
+ModelParserRegistry.registerModelParser(new HuggingFaceTextGenerationParser());
 
 /**
  * Represents an AIConfig. This is the main class for interacting with AIConfig files.

--- a/typescript/lib/parsers/hf.ts
+++ b/typescript/lib/parsers/hf.ts
@@ -5,31 +5,31 @@ import {
   TextGenerationStreamOutput,
 } from "@huggingface/inference";
 
-import {
-  Prompt,
-  Output,
-  PromptInput,
-  ModelMetadata,
-  ExecuteResult,
-} from "../../types";
-import { CompletionCreateParams } from "openai/resources";
 import _ from "lodash";
-import { getAPIKeyFromEnv } from "../utils";
 import { ParameterizedModelParser } from "../parameterizedModelParser";
-import { JSONObject } from "../../common";
 import { AIConfigRuntime } from "../config";
+import {
+  ExecuteResult,
+  ModelMetadata,
+  Output,
+  Prompt,
+  PromptInput,
+} from "../../types";
 import { InferenceOptions } from "../modelParser";
+import { JSONObject } from "../../common";
+import { getAPIKeyFromEnv } from "../utils";
 
-export class HuggingFaceTextGenerationModelParser extends ParameterizedModelParser<TextGenerationArgs> {
-  private hfClient: HfInference;
+/**
+ * A model parser for HuggingFace text generation models.
+ * Set the environment variable HUGGING_FACE_API_TOKEN to use your HuggingFace API token.
+ * A HuggingFace API token is not required to use this model parser.
+ */
+export class HuggingFaceTextGenerationParser extends ParameterizedModelParser<TextGenerationArgs> {
+  private hfClient: HfInference | undefined;
+  _id = "HuggingFaceTextGenerationParser";
 
-  public constructor(modelId: string, use_api_token?: Boolean) {
+  public constructor() {
     super();
-    let token = use_api_token
-      ? getAPIKeyFromEnv("HUGGING_FACE_API_TOKEN")
-      : undefined;
-    this.hfClient = new HfInference(token);
-    this.id = modelId;
   }
 
   public serialize(
@@ -133,6 +133,10 @@ export class HuggingFaceTextGenerationModelParser extends ParameterizedModelPars
   ): Promise<Output | Output[]> {
     const textGenerationArgs = this.deserialize(prompt, aiConfig, params);
 
+    if (!this.hfClient) {
+      this.hfClient = createHuggingFaceClient();
+    }
+
     // if no options are passed in, don't stream because streaming is dependent on a callback handler
     const stream = options ? (options.stream ? options.stream : true) : false;
 
@@ -217,4 +221,18 @@ function constructOutput(response: TextGenerationOutput): Output {
   } as ExecuteResult;
 
   return output;
+}
+
+/**
+ * Creates a new HuggingFace Inference client. Checks for an api token in the environment variables. If no api token is found, the client is created without an api token.
+ * @returns
+ */
+function createHuggingFaceClient() {
+  let huggingFaceAPIToken;
+  try {
+    huggingFaceAPIToken = getAPIKeyFromEnv("HUGGING_FACE_API_TOKEN");
+  } catch (err) {
+  } finally {
+    return new HfInference(huggingFaceAPIToken);
+  }
 }


### PR DESCRIPTION
[TS] HuggingFaceTextGenerationParser as a default parser



- Bring back HuggingFaceTextGenerationParser into AIConfig.

- Modified Cookbook to test; will be updating cookbook with extension later

- Updated modelParser name to `HuggingFaceTextGenerationParser` everywhere used
Discussed offline @Saquadri

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/188).
* __->__ #188
* #187
* #185