### PR TITLE
[py] Bump to 1.0.9

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "python-aiconfig"
-version = "1.0.7"
+version = "1.0.9"
 authors = [
   { name="Sarmad Qadri", email="sarmad@lastmileai.dev" },
 ]
@@ -26,6 +26,8 @@ dependencies = [
   "openai>=1.0.0",
   "python-dotenv",
   "huggingface_hub",
+  "result",
+  "nest_asyncio",
   ]
 
 [project.urls]


### PR DESCRIPTION
[py] Bump to 1.0.9


Republished AIConfig to 1.0.8 Changes Made Locally:
updated dependencies in pyproject.toml, should be good to go on that front.
(small) added an await statement that was missing for a callback
changes made locally
If any problems arise please let me know, I will fix asap.

1.0.9:

- Updated openai version to >1.0.0
- updated model parser and wrapper as well
