### PR TITLE
Minor Cleanup of Extensibility Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ AIConfig is a source-control friendly way to manage prompts and model parameters
 
 ## Features
 
-- [X] **Source-control friendly** [`aiconfig` format](https://aiconfig.lastmileai.dev/docs/overview/ai-config-format) to save prompts and model settings, which you can use for evaluation, reproducibility and simplifying your application code.
-- [X] **Multi-modal and model agnostic**. Use with any model, and serialize/deserialize data with the same `aiconfig` format.
-- [X] **Prompt chaining and parameterization** with [{{handlebars}}](https://handlebarsjs.com/) templating syntax, allowing you to pass dynamic data into prompts (as well as between prompts).
-- [X] **Streaming** supported out of the box, allowing you to get playground-like streaming wherever you use `aiconfig`.
-- [X] **Notebook editor**. [AI Workbooks editor](https://lastmileai.dev/workbooks/clooqs3p200kkpe53u6n2rhr9) to visually create your `aiconfig`, and use the SDK to connect it to your application code.
+- [x] **Source-control friendly** [`aiconfig` format](https://aiconfig.lastmileai.dev/docs/overview/ai-config-format) to save prompts and model settings, which you can use for evaluation, reproducibility and simplifying your application code.
+- [x] **Multi-modal and model agnostic**. Use with any model, and serialize/deserialize data with the same `aiconfig` format.
+- [x] **Prompt chaining and parameterization** with [{{handlebars}}](https://handlebarsjs.com/) templating syntax, allowing you to pass dynamic data into prompts (as well as between prompts).
+- [x] **Streaming** supported out of the box, allowing you to get playground-like streaming wherever you use `aiconfig`.
+- [x] **Notebook editor**. [AI Workbooks editor](https://lastmileai.dev/workbooks/clooqs3p200kkpe53u6n2rhr9) to visually create your `aiconfig`, and use the SDK to connect it to your application code.
 
 ## Install
 
@@ -311,10 +311,8 @@ AIConfig is designed to be customized and extended for your use-case. There are 
 You can use any generative AI model with the `aiconfig` format. All you need to do is define a `ModelParser` class. This class is responsible for 3 key operations:
 
 - **serialize** prompts, model parameters and inference outputs into an `aiconfig`.
-- **deserialize** existing `aiconfig` prompts for that model into the data that the model accepts (e.g. OpenAI chat completion params).
+- **deserialize** existing `aiconfig` `Prompts` for that model into the data that the model accepts (e.g. OpenAI chat completion params).
 - **run** inference using a model (e.g. calling the OpenAI API or a model running locally).
-
-### Getting Started with Model Parsers
 
 # Defining Your Own Model Parser
 
@@ -338,6 +336,11 @@ The `ModelParser` is an abstract base class that serves as the foundation for al
 ## Model Parser Extensibility
 
 When defining your custom Model Parser, you can inherit from the `ModelParser` class and override its methods as needed to customize the behavior for your specific AI models. This extensibility allows you to seamlessly integrate your Model Parser into the AIConfig framework and manage AI models with ease.
+
+Here are some helpful resources to get started:
+
+1. `ModelParser` class ([Python](https://github.com/lastmile-ai/aiconfig/blob/main/python/src/aiconfig/model_parser.py), [TypeScript](https://github.com/lastmile-ai/aiconfig/blob/main/typescript/lib/modelParser.ts)).
+2. OpenAI Chat `ModelParser` ([Python](https://github.com/lastmile-ai/aiconfig/blob/main/python/src/aiconfig/default_parsers/openai.py#L25), [TypeScript](https://github.com/lastmile-ai/aiconfig/blob/main/typescript/lib/parsers/openai.ts#L261))
 
 ### Parameterized Model Parser
 
@@ -381,12 +384,7 @@ To facilitate parameterization, AIConfig provides a set of helper utilities:
 
 These utilities enable dynamic parameterization of prompts and customization of prompt templates to meet specific requirements.
 
-Here are some helpful resources to get started:
-
-1. `ModelParser` class ([Python](https://github.com/lastmile-ai/aiconfig/blob/main/python/src/aiconfig/model_parser.py), [TypeScript](https://github.com/lastmile-ai/aiconfig/blob/main/typescript/lib/modelParser.ts)).
-2. OpenAI Chat `ModelParser` ([Python](https://github.com/lastmile-ai/aiconfig/blob/main/python/src/aiconfig/default_parsers/openai.py#L25), [TypeScript](https://github.com/lastmile-ai/aiconfig/blob/main/typescript/lib/parsers/openai.ts#L261))
-
-### Callback handlers
+## Callback handlers
 
 The AIConfig SDK has a `CallbackManager` class which can be used to register callbacks that trace prompt resolution, serialization, deserialization, and inference. This lets you get a stack trace of what's going on under the covers, which is especially useful for complex control flow operations.
 
@@ -512,7 +510,7 @@ callback_manager = CallbackManager([my_logging_callback], custom_timeout)
 
 Custom callbacks should include error handling to manage exceptions. Errors thrown within callbacks are caught by the CallbackManager and can be logged or handled as needed.
 
-### Custom metadata
+## Custom metadata
 
 You can store any kind of JSON-serializable metadata in an `aiconfig`. See the [metadata schema details](https://aiconfig.lastmileai.dev/docs/overview/ai-config-format#metadata) to learn more.
 

--- a/aiconfig-docs/docs/extensibility.md
+++ b/aiconfig-docs/docs/extensibility.md
@@ -4,10 +4,6 @@ sidebar_position: 14
 
 # Extensibility
 
-## ModelParser Extensibility
-
-## Contributing
-
 ## Extending AIConfig
 
 AIConfig is designed to be customized and extended for your use-case. There are some key extension points for AIConfig:
@@ -17,10 +13,8 @@ AIConfig is designed to be customized and extended for your use-case. There are 
 You can use any generative AI model with the `aiconfig` format. All you need to do is define a `ModelParser` class. This class is responsible for 3 key operations:
 
 - **serialize** prompts, model parameters and inference outputs into an `aiconfig`.
-- **deserialize** existing `aiconfig` prompts for that model into the data that the model accepts (e.g. OpenAI chat completion params).
+- **deserialize** existing `aiconfig` `Prompts` for that model into the data that the model accepts (e.g. OpenAI chat completion params).
 - **run** inference using a model (e.g. calling the OpenAI API or a model running locally).
-
-### Getting Started with Model Parsers
 
 # Defining Your Own Model Parser
 
@@ -44,6 +38,11 @@ The `ModelParser` is an abstract base class that serves as the foundation for al
 ## Model Parser Extensibility
 
 When defining your custom Model Parser, you can inherit from the `ModelParser` class and override its methods as needed to customize the behavior for your specific AI models. This extensibility allows you to seamlessly integrate your Model Parser into the AIConfig framework and manage AI models with ease.
+
+Here are some helpful resources to get started:
+
+1. `ModelParser` class ([Python](https://github.com/lastmile-ai/aiconfig/blob/main/python/src/aiconfig/model_parser.py), [TypeScript](https://github.com/lastmile-ai/aiconfig/blob/main/typescript/lib/modelParser.ts)).
+2. OpenAI Chat `ModelParser` ([Python](https://github.com/lastmile-ai/aiconfig/blob/main/python/src/aiconfig/default_parsers/openai.py#L25), [TypeScript](https://github.com/lastmile-ai/aiconfig/blob/main/typescript/lib/parsers/openai.ts#L261))
 
 ### Parameterized Model Parser
 
@@ -87,12 +86,11 @@ To facilitate parameterization, AIConfig provides a set of helper utilities:
 
 These utilities enable dynamic parameterization of prompts and customization of prompt templates to meet specific requirements.
 
-Here are some helpful resources to get started:
+### Contributing
 
-1. `ModelParser` class ([Python](https://github.com/lastmile-ai/aiconfig/blob/main/python/src/aiconfig/model_parser.py), [TypeScript](https://github.com/lastmile-ai/aiconfig/blob/main/typescript/lib/modelParser.ts)).
-2. OpenAI Chat `ModelParser` ([Python](https://github.com/lastmile-ai/aiconfig/blob/main/python/src/aiconfig/default_parsers/openai.py#L25), [TypeScript](https://github.com/lastmile-ai/aiconfig/blob/main/typescript/lib/parsers/openai.ts#L261))
+Have a custom `ModelParser` implementation that others may find useful? Please consider packaging it as an AIConfig Extension by following our [Contributing Guidelines](https://aiconfig.lastmileai.dev/docs/contributing)!
 
-### Callback handlers
+## Callback handlers
 
 The AIConfig SDK has a `CallbackManager` class which can be used to register callbacks that trace prompt resolution, serialization, deserialization, and inference. This lets you get a stack trace of what's going on under the covers, which is especially useful for complex control flow operations.
 
@@ -218,7 +216,7 @@ callback_manager = CallbackManager([my_logging_callback], custom_timeout)
 
 Custom callbacks should include error handling to manage exceptions. Errors thrown within callbacks are caught by the CallbackManager and can be logged or handled as needed.
 
-### Custom metadata
+## Custom metadata
 
 You can store any kind of JSON-serializable metadata in an `aiconfig`. See the [metadata schema details](https://aiconfig.lastmileai.dev/docs/overview/ai-config-format#metadata) to learn more.
 


### PR DESCRIPTION
# Minor Cleanup of Extensibility Page

I realized there is already documentation for ModelParsers and extensibility, and don't think there's much more to add. This just cleans up the page a bit to get rid of some redundant headers, split some stuff (Callbacks & Metadata) outside of ModelParsers and point to Contributing Guidelines for those who want to share their ModelParsers as extensions

<img width="1502" alt="Screenshot 2023-11-16 at 3 37 44 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/4ad25840-c765-463e-b773-61c41feb00f3">

