### PR TITLE
Fix formatting of Callback Event object keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,10 +396,10 @@ Video: https://github.com/lastmile-ai/aiconfig/assets/141073967/ce909fc4-881f-40
 
 Each callback event is an object of the CallbackEvent type, containing:
 
-name: The name of the event (e.g., "on_resolve_start").
-file: The source file where the event is triggered
-data: An object containing relevant data for the event, such as parameters or results.
-ts_ns: An optional timestamp in nanoseconds.
+`name`: The name of the event (e.g., "on_resolve_start").\
+`file`: The source file where the event is triggered\
+`data`: An object containing relevant data for the event, such as parameters or results.\
+`ts_ns`: An optional timestamp in nanoseconds.\
 
 #### Writing Custom Callbacks
 

--- a/aiconfig-docs/docs/basics.md
+++ b/aiconfig-docs/docs/basics.md
@@ -187,8 +187,8 @@ There are 2 areas where we are going beyond what notebooks offer:
 
 AIConfig is meant to be fully customizable and extensible for your use-cases. The specific parts that you can customize include:
 
-- **Model Parsers**: these parsers are responsible for deciding how to run inference, what data to store in the `aiconfig`, and how. You can add model parsers for any model of any input/output modality, and from any provider (including a model running on your local machine).
-- **Callbacks**: callback handlers allow you to hook up `aiconfig` runs to monitoring and observability endpoints of your choosing.
+- **[Model Parsers](https://aiconfig.lastmileai.dev/docs/extensibility#model-parser-extensibility)**: these parsers are responsible for deciding how to run inference, what data to store in the `aiconfig`, and how. You can add model parsers for any model of any input/output modality, and from any provider (including a model running on your local machine).
+- **[Callbacks](https://aiconfig.lastmileai.dev/docs/extensibility#callback-handlers)**: callback handlers allow you to hook up `aiconfig` runs to monitoring and observability endpoints of your choosing.
 - **Evaluation**<div className="label basic coming-soon">Coming Soon</div>: define custom evaluators and run batch evaluation to measure the performance of your `aiconfig`.
 - **Routing**<div className="label basic coming-soon">Coming Soon</div>: define custom routers over a series of `aiconfig`s to intelligently route incoming requests over prompts and models (i.e. prompt routing and model routing).
 

--- a/aiconfig-docs/docs/extensibility.md
+++ b/aiconfig-docs/docs/extensibility.md
@@ -102,10 +102,10 @@ Video: https://github.com/lastmile-ai/aiconfig/assets/141073967/ce909fc4-881f-40
 
 Each callback event is an object of the CallbackEvent type, containing:
 
-name: The name of the event (e.g., "on_resolve_start").
-file: The source file where the event is triggered
-data: An object containing relevant data for the event, such as parameters or results.
-ts_ns: An optional timestamp in nanoseconds.
+`name`: The name of the event (e.g., "on_resolve_start").\
+`file`: The source file where the event is triggered\
+`data`: An object containing relevant data for the event, such as parameters or results.\
+`ts_ns`: An optional timestamp in nanoseconds.\
 
 #### Writing Custom Callbacks
 

--- a/aiconfig-docs/docusaurus.config.js
+++ b/aiconfig-docs/docusaurus.config.js
@@ -39,9 +39,6 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/lastmile-ai/aiconfig/aiconfig-docs",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.scss"),


### PR DESCRIPTION
# Fix formatting of Callback Event object keys

## Before:
<img width="856" alt="Screenshot 2023-11-16 at 5 24 04 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/b216897c-7d94-4765-9738-6c585f5f0b5e">

## After:
<img width="708" alt="Screenshot 2023-11-16 at 5 23 59 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/8730df95-1c3f-4d55-95af-7c1bb1bd984c">


---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/250).
* __->__ #250
* #249
* #246