### PR TITLE
[ts] Add outputs to Prompt in HF Parser

### DIFF
--- a/typescript/lib/parsers/hf.ts
+++ b/typescript/lib/parsers/hf.ts
@@ -140,20 +140,23 @@ export class HuggingFaceTextGenerationParser extends ParameterizedModelParser<Te
     // if no options are passed in, don't stream because streaming is dependent on a callback handler
     const stream = options ? (options.stream ? options.stream : true) : false;
 
+    let output: Output | undefined;
+
     if (stream) {
       const response = await this.hfClient.textGenerationStream(
         textGenerationArgs
       );
-      const output = await ConstructStreamOutput(
+      output = await ConstructStreamOutput(
         response,
         options as InferenceOptions
       );
-      return output;
     } else {
       const response = await this.hfClient.textGeneration(textGenerationArgs);
-      const output = constructOutput(response);
-      return output;
+      output = constructOutput(response);
     }
+
+    prompt.outputs = [output];
+    return prompt.outputs;
   }
 
   public getOutputText(


### PR DESCRIPTION
# [ts] Add outputs to Prompt in HF Parser

When using the HF parser as an example for Llama, I noticed it didn't correctly set the prompt output during `run`. This PR correctly sets it, similar to the openai parser

## Testing:
- Added jest tests in https://github.com/lastmile-ai/aiconfig/pull/283

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/279).
* #283
* #282
* #281
* #280
* __->__ #279