### PR TITLE
Close Open Handle in `withTimeout`

### DIFF
--- a/typescript/lib/callback.ts
+++ b/typescript/lib/callback.ts
@@ -21,13 +21,17 @@ async function withTimeout(
   promise: Promise<any>,
   timeout: number
 ): Promise<any> {
+  let timer: NodeJS.Timeout | undefined;
   const timeoutPromise = new Promise((_, reject) => {
-    setTimeout(() => {
+    timer = setTimeout(() => {
       reject(new Error("Timeout"));
     }, timeout * 1000);
   });
 
-  return Promise.race([promise, timeoutPromise]);
+  return Promise.race([
+    promise.finally(() => clearTimeout(timer)),
+    timeoutPromise,
+  ]);
 }
 
 export class CallbackManager {

--- a/typescript/lib/parsers/hf.ts
+++ b/typescript/lib/parsers/hf.ts
@@ -140,20 +140,23 @@ export class HuggingFaceTextGenerationParser extends ParameterizedModelParser<Te
     // if no options are passed in, don't stream because streaming is dependent on a callback handler
     const stream = options ? (options.stream ? options.stream : true) : false;
 
+    let output: Output | undefined;
+
     if (stream) {
       const response = await this.hfClient.textGenerationStream(
         textGenerationArgs
       );
-      const output = await ConstructStreamOutput(
+      output = await ConstructStreamOutput(
         response,
         options as InferenceOptions
       );
-      return output;
     } else {
       const response = await this.hfClient.textGeneration(textGenerationArgs);
-      const output = constructOutput(response);
-      return output;
+      output = constructOutput(response);
     }
+
+    prompt.outputs = [output];
+    return prompt.outputs;
   }
 
   public getOutputText(


### PR DESCRIPTION
# Close Open Handle in `withTimeout`

When running `yarn test` there's an informative warning:
> Jest did not exit one second after the test run has completed.

'This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.


Re-running with `--detectOpenHandles` surfaced:
```
Jest has detected the following 4 open handles potentially keeping Jest from exiting:

  ●  Timeout

      23 | ): Promise<any> {
      24 |   const timeoutPromise = new Promise((_, reject) => {
    > 25 |     setTimeout(() => {
         |     ^
      26 |       reject(new Error("Timeout"));
      27 |     }, timeout * 1000);
      28 |   });

      at lib/callback.ts:25:5
      at lib/callback.ts:24:26
```

The problem is the timeout is still active ones the Promise is resolved. We can close the open handle by clearing the timeout if the input Promise resolves before the timeout promise.

## Testing:
Re-running `yarn test` has no warning about open handles & callback tests work

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/281).
* #283
* #282
* __->__ #281
* #280
* #279