### PR TITLE
Update getting-started.md

### DIFF
--- a/aiconfig-docs/docs/getting-started.md
+++ b/aiconfig-docs/docs/getting-started.md
@@ -44,7 +44,7 @@ $ yarn add aiconfig
 <TabItem value="pip">
 
 ```bash
-$ pip install python-aiconfig
+$ pip install --user python-aiconfig
 ```
 
 </TabItem>


### PR DESCRIPTION
When using `pip install ...` I received `pip Permission denied: 'LICENSE'` on my jupyter stack which is pretty vanilla (https://github.com/activescott/my-jupyter). I fixed it by using `pip install --user ...`. 

My understanding is that if not using virtualenv then using `--user` is at least perfectly fine and often preferred. A couple other references:
- https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-user
- https://stackoverflow.com/questions/33004708/osx-el-capitan-sudo-pip-install-oserror-errno-1-operation-not-permitted

Or maybe this should just be a note about possible errors and an alternative way of installing. Hope this helps!