### PR TITLE
Update Llama Extension Package Info With Links

### DIFF
--- a/cookbooks/llama/typescript/README.md
+++ b/cookbooks/llama/typescript/README.md
@@ -43,8 +43,4 @@ Run with
 npx ts-node ask-llama.ts
 ```
 
-<p align="center">
-<video controls height="480" width="800">
-    <source src="https://github.com/lastmile-ai/aiconfig/assets/5060851/f2ecf6ce-7601-469c-aea1-5c0f776d7b73"/>
-  </video>
-</p>
+https://github.com/lastmile-ai/aiconfig/assets/5060851/f2ecf6ce-7601-469c-aea1-5c0f776d7b73

--- a/extensions/llama/typescript/README.md
+++ b/extensions/llama/typescript/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This package is a lightweight ModelParser extension for AIConfig which provides support for running local GGUF LLaMA models in AIConfig prompts. All GGUF LLaMA models from https://huggingface.co/TheBloke?search_models=gguf should be supported. Under the hood, this package leverages [node-llama-cpp](https://withcatai.github.io/node-llama-cpp/) for prompt execution.
+This package is a lightweight ModelParser extension for [AIConfig](https://github.com/lastmile-ai/aiconfig) which provides support for running local GGUF LLaMA models in AIConfig prompts. All GGUF LLaMA models from https://huggingface.co/TheBloke?search_models=gguf should be supported. Under the hood, this package leverages [node-llama-cpp](https://withcatai.github.io/node-llama-cpp/) for prompt execution.
 
 ## Install
 
@@ -50,7 +50,7 @@ const response = await config.run("promptName");
 
 ## Testing Package Before Publishing
 
-Before publishing the package, ensure it works locally within the [`ask-llama.ts` cookbook](../../../cookbooks/llama/typescript/ask-llama.ts).
+Before publishing the package, ensure it works locally within the [`ask-llama.ts` cookbook](https://github.com/lastmile-ai/aiconfig/blob/main/cookbooks/llama/typescript/ask-llama.ts).
 
 Note, if a local tarball already exists, remove it before continuing. e.g.:
 

--- a/extensions/llama/typescript/package.json
+++ b/extensions/llama/typescript/package.json
@@ -1,9 +1,13 @@
 {
     "name": "aiconfig-extension-llama",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "license": "MIT",
     "main": "./dist/llama.js",
     "types": "./dist/llama.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/lastmile-ai/aiconfig.git"
+    },
     "files": [
         "dist"
     ],


### PR DESCRIPTION
# Update Llama Extension Package Info With Links

A few minor things:
- fix cookbook README video (should play video inline in GH README, as opposed to the video element needed for the doc site)
- link to the GH repo in the package metadata and the package README

Will publish once accepted