### PR TITLE
[dall-e parser][3/n] Add basic tests for load and serialize

### DIFF
--- a/python/src/aiconfig/default_parsers/dalle.py
+++ b/python/src/aiconfig/default_parsers/dalle.py
@@ -88,8 +88,7 @@ class DallE3ImageGenerationParser(ParameterizedModelParser):
         return "dall-e-3"
 
 
-    # TODO: Test this sometime from getting a response from the API and saving it to a file
-    def serialize(
+    async def serialize(
         self,
         prompt_name: str,
         data: Any,

--- a/python/tests/aiconfigs/basic_dalle3_config.json
+++ b/python/tests/aiconfigs/basic_dalle3_config.json
@@ -1,0 +1,32 @@
+{
+    "name": "Panda Eating Dumplings Image Generator",
+    "description": "Testing Dall-E 3 image generation",
+    "schema_version": "latest",
+    "metadata": {
+      "models": {
+        "dall-e-3": {
+          "model": "dall-e-3",
+          "system_prompt": "What color do you want to see as a background?"
+        }
+      },
+      "default_model": "dall-e-3"
+    },
+    "prompts": [
+      {
+        "name": "panda_eating_dumplings",
+        "input": "Panda eating dumplings on a {{color}} mountain",
+        "metadata": {
+          "model": {
+            "name": "dall-e-3",
+            "settings": {
+                "n": 1,
+                "size": "1024x1024"
+            }
+          },
+          "parameters": {
+            "color": "yellow"
+          }
+        }
+      }
+    ]
+  }

--- a/python/tests/parsers/test_dalle_parser.py
+++ b/python/tests/parsers/test_dalle_parser.py
@@ -1,0 +1,36 @@
+from aiconfig.schema import Prompt, PromptMetadata
+from aiconfig.Config import AIConfigRuntime
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_serialize_basic(set_temporary_env_vars: None):
+    # Test with one input prompt and system. No output
+    completion_params = {
+        "model": "dall-e-3",
+        'n': 1,
+        'prompt': 'Panda eating dumplings on a yellow mountain',
+        'size': '1024x1024'
+    }
+    aiconfig = AIConfigRuntime.create()
+    serialized_prompts = await aiconfig.serialize(
+        "dall-e-3", completion_params, prompt_name="panda_eating_dumplings"
+    )
+    new_prompt = serialized_prompts[0]
+    assert new_prompt == Prompt(
+        name="panda_eating_dumplings",
+        input="Panda eating dumplings on a yellow mountain",
+        metadata=PromptMetadata(
+            **{
+                "model": {
+                    "name": "dall-e-3",
+                    "settings": {
+                        'model': 'dall-e-3',
+                        "n": 1,
+                        "size": "1024x1024"
+                    },
+                },
+            }
+        ),
+        outputs=[]
+    )

--- a/python/tests/test_load_config.py
+++ b/python/tests/test_load_config.py
@@ -29,6 +29,22 @@ async def test_load_basic_chatgpt_query_config(set_temporary_env_vars):
         "messages": [{"content": "Hi! Tell me 10 cool things to do in NYC.", "role": "user"}],
     }
 
+@pytest.mark.asyncio
+async def test_load_basic_dalle3_config(set_temporary_env_vars):
+    """Test loading a basic Dall-E 3 config"""
+    config_relative_path = "aiconfigs/basic_dalle3_config.json"
+    config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
+    config = AIConfigRuntime.load(config_absolute_path)
+
+    data_for_inference = await config.resolve("panda_eating_dumplings")
+
+    assert data_for_inference == {
+        "model": "dall-e-3",
+        'n': 1,
+        'prompt': 'Panda eating dumplings on a yellow mountain',
+        'size': '1024x1024'
+    }
+
 
 @pytest.mark.asyncio
 async def test_chained_gpt_config(set_temporary_env_vars):


### PR DESCRIPTION
[dall-e parser][3/n] Add basic tests for load and serialize



Pretty simple, just adding in the tests which I already did manually to test the previous commits

Specifically I added tests for `load()` and `serialize()`. Found an error on serialize through this test (had to define function as `async`!

Should now be able to run tests by entering:
```
cd ~/Projects/aiconfig/python && pytest --disable-warnings -vv
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/294).
* #301
* #298
* #297
* __->__ #294