### PR TITLE
[dall-e parser][4/n] Extend image generation parser to Dall-E 2

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -3,7 +3,7 @@ import sys
 import os
 from aiconfig.callback import CallbackEvent, CallbackManager
 from .default_parsers.hf import HuggingFaceTextGenerationParser
-from .default_parsers.dalle import DallE3ImageGenerationParser
+from .default_parsers.dalle import DallEImageGenerationParser
 import requests
 from typing import ClassVar, Dict, List, Optional
 
@@ -37,7 +37,12 @@ for model in gpt_models:
 ModelParserRegistry.register_model_parser(PaLMChatParser())
 ModelParserRegistry.register_model_parser(PaLMTextParser())
 ModelParserRegistry.register_model_parser(HuggingFaceTextGenerationParser())
-ModelParserRegistry.register_model_parser(DallE3ImageGenerationParser())
+dalle_image_generation_models = [
+        "dall-e-2",
+        "dall-e-3",
+    ]
+for model in dalle_image_generation_models:
+    ModelParserRegistry.register_model_parser(DallEImageGenerationParser(model))
 
 class AIConfigRuntime(AIConfig):
     # A mapping of model names to their respective parsers

--- a/python/src/aiconfig/default_parsers/dalle.py
+++ b/python/src/aiconfig/default_parsers/dalle.py
@@ -88,8 +88,7 @@ class DallE3ImageGenerationParser(ParameterizedModelParser):
         return "dall-e-3"
 
 
-    # TODO: Test this sometime from getting a response from the API and saving it to a file
-    def serialize(
+    async def serialize(
         self,
         prompt_name: str,
         data: Any,

--- a/python/src/aiconfig/default_parsers/dalle.py
+++ b/python/src/aiconfig/default_parsers/dalle.py
@@ -62,30 +62,39 @@ def construct_output(image_data: Image, execution_count: int) -> Output:
     return output
 
 
-class DallE3ImageGenerationParser(ParameterizedModelParser):
+class DallEImageGenerationParser(ParameterizedModelParser):
     """
-    A model parser for Dall-E 3 text-->image generation models.
+    A model parser for Dall-E 2 and Dall-E 3 text-->image generation models.
     """
     
-    def __init__(self):
+    def __init__(self, model_id: str = "dall-e-3"):
         """
         Usage:
 
         1. Create a new model parser object
-                parser = DallE3ImageGenerationParser()
+                parser = DallEImageGenerationParser("dall-e-3")
         2. Add the model parser to the registry.
                 config.register_model_parser(parser)
 
         The model parser will require an API token to be set in the environment variable OPENAI_API_KEY.
         """
         super().__init__()
+
+        supported_models = {
+            "dall-e-2",
+            "dall-e-3",
+        }
+        if model_id.lower() not in supported_models:
+            raise ValueError('{model_id}' + " is not a valid model ID for Dall-E image generation. Supported models: {supported_models}.")
+        self.model_id = model_id
+        
         self.client = None
 
     def id(self) -> str:
         """
         Returns an identifier for the model (e.g. dall-e-2, dall-e-3, etc.).
         """
-        return "dall-e-3"
+        return self.model_id
 
 
     async def serialize(

--- a/python/tests/aiconfigs/basic_dalle2_config.json
+++ b/python/tests/aiconfigs/basic_dalle2_config.json
@@ -1,0 +1,32 @@
+{
+    "name": "Panda Eating Dumplings Image Generator",
+    "description": "Testing Dall-E 2 image generation",
+    "schema_version": "latest",
+    "metadata": {
+      "models": {
+        "dall-e-2": {
+          "model": "dall-e-2",
+          "system_prompt": "What color do you want to see as a background?"
+        }
+      },
+      "default_model": "dall-e-2"
+    },
+    "prompts": [
+      {
+        "name": "panda_eating_dumplings",
+        "input": "Panda eating dumplings on a {{color}} mountain",
+        "metadata": {
+          "model": {
+            "name": "dall-e-2",
+            "settings": {
+                "n": 4,
+                "size": "1024x1024"
+            }
+          },
+          "parameters": {
+            "color": "yellow"
+          }
+        }
+      }
+    ]
+  }

--- a/python/tests/aiconfigs/basic_dalle3_config.json
+++ b/python/tests/aiconfigs/basic_dalle3_config.json
@@ -1,0 +1,32 @@
+{
+    "name": "Panda Eating Dumplings Image Generator",
+    "description": "Testing Dall-E 3 image generation",
+    "schema_version": "latest",
+    "metadata": {
+      "models": {
+        "dall-e-3": {
+          "model": "dall-e-3",
+          "system_prompt": "What color do you want to see as a background?"
+        }
+      },
+      "default_model": "dall-e-3"
+    },
+    "prompts": [
+      {
+        "name": "panda_eating_dumplings",
+        "input": "Panda eating dumplings on a {{color}} mountain",
+        "metadata": {
+          "model": {
+            "name": "dall-e-3",
+            "settings": {
+                "n": 1,
+                "size": "1024x1024"
+            }
+          },
+          "parameters": {
+            "color": "yellow"
+          }
+        }
+      }
+    ]
+  }

--- a/python/tests/parsers/test_dalle_parser.py
+++ b/python/tests/parsers/test_dalle_parser.py
@@ -1,0 +1,36 @@
+from aiconfig.schema import Prompt, PromptMetadata
+from aiconfig.Config import AIConfigRuntime
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_serialize_basic(set_temporary_env_vars: None):
+    # Test with one input prompt and system. No output
+    completion_params = {
+        "model": "dall-e-3",
+        'n': 1,
+        'prompt': 'Panda eating dumplings on a yellow mountain',
+        'size': '1024x1024'
+    }
+    aiconfig = AIConfigRuntime.create()
+    serialized_prompts = await aiconfig.serialize(
+        "dall-e-3", completion_params, prompt_name="panda_eating_dumplings"
+    )
+    new_prompt = serialized_prompts[0]
+    assert new_prompt == Prompt(
+        name="panda_eating_dumplings",
+        input="Panda eating dumplings on a yellow mountain",
+        metadata=PromptMetadata(
+            **{
+                "model": {
+                    "name": "dall-e-3",
+                    "settings": {
+                        'model': 'dall-e-3',
+                        "n": 1,
+                        "size": "1024x1024"
+                    },
+                },
+            }
+        ),
+        outputs=[]
+    )

--- a/python/tests/test_load_config.py
+++ b/python/tests/test_load_config.py
@@ -30,6 +30,22 @@ async def test_load_basic_chatgpt_query_config(set_temporary_env_vars):
     }
 
 @pytest.mark.asyncio
+async def test_load_basic_dalle2_config(set_temporary_env_vars):
+    """Test loading a basic Dall-E 2 config"""
+    config_relative_path = "aiconfigs/basic_dalle2_config.json"
+    config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
+    config = AIConfigRuntime.load(config_absolute_path)
+
+    data_for_inference = await config.resolve("panda_eating_dumplings")
+
+    assert data_for_inference == {
+        "model": "dall-e-2",
+        'n': 4,
+        'prompt': 'Panda eating dumplings on a yellow mountain',
+        'size': '1024x1024'
+    }
+
+@pytest.mark.asyncio
 async def test_load_basic_dalle3_config(set_temporary_env_vars):
     """Test loading a basic Dall-E 3 config"""
     config_relative_path = "aiconfigs/basic_dalle3_config.json"

--- a/python/tests/test_load_config.py
+++ b/python/tests/test_load_config.py
@@ -29,6 +29,22 @@ async def test_load_basic_chatgpt_query_config(set_temporary_env_vars):
         "messages": [{"content": "Hi! Tell me 10 cool things to do in NYC.", "role": "user"}],
     }
 
+@pytest.mark.asyncio
+async def test_load_basic_dalle3_config(set_temporary_env_vars):
+    """Test loading a basic Dall-E 3 config"""
+    config_relative_path = "aiconfigs/basic_dalle3_config.json"
+    config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
+    config = AIConfigRuntime.load(config_absolute_path)
+
+    data_for_inference = await config.resolve("panda_eating_dumplings")
+
+    assert data_for_inference == {
+        "model": "dall-e-3",
+        'n': 1,
+        'prompt': 'Panda eating dumplings on a yellow mountain',
+        'size': '1024x1024'
+    }
+
 
 @pytest.mark.asyncio
 async def test_chained_gpt_config(set_temporary_env_vars):


### PR DESCRIPTION
[dall-e parser][4/n] Extend image generation parser to Dall-E 2

Before i had it hardcoded to only support Dall-E 3, but now supports Dall-E 2 image generation as well.

Some future notes is that Dall-E 2 has 2 additional APIs, not just image generation:

1. Edit: https://platform.openai.com/docs/api-reference/images/createEdit
2. Create Variation: https://platform.openai.com/docs/api-reference/images/createVariation

We'll have to think about how to support these two seprate API calls in the AIConfig in the future. We can either do:

1. Create distinct models. Ex: "dall-e-2-generate", "dall-e-2-edit"
2. Pass in an "operation" or "execute" option into the model settings that allow us to define which API to request (defaulting to image generation)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/297).
* __->__ #297
* #294
* #290