### PR TITLE
[dall-e parser][5/n] Add mime type for urls (png) and base64 (plaintext)

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -3,7 +3,7 @@ import sys
 import os
 from aiconfig.callback import CallbackEvent, CallbackManager
 from .default_parsers.hf import HuggingFaceTextGenerationParser
-from .default_parsers.dalle import DallEImageGenerationParser
+from .default_parsers.dalle import DalleImageGenerationParser
 import requests
 from typing import ClassVar, Dict, List, Optional
 
@@ -42,7 +42,7 @@ dalle_image_generation_models = [
         "dall-e-3",
     ]
 for model in dalle_image_generation_models:
-    ModelParserRegistry.register_model_parser(DallEImageGenerationParser(model))
+    ModelParserRegistry.register_model_parser(DalleImageGenerationParser(model))
 
 class AIConfigRuntime(AIConfig):
     # A mapping of model names to their respective parsers

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -3,7 +3,7 @@ import sys
 import os
 from aiconfig.callback import CallbackEvent, CallbackManager
 from .default_parsers.hf import HuggingFaceTextGenerationParser
-from .default_parsers.dalle import DallE3ImageGenerationParser
+from .default_parsers.dalle import DallEImageGenerationParser
 import requests
 from typing import ClassVar, Dict, List, Optional
 
@@ -37,7 +37,12 @@ for model in gpt_models:
 ModelParserRegistry.register_model_parser(PaLMChatParser())
 ModelParserRegistry.register_model_parser(PaLMTextParser())
 ModelParserRegistry.register_model_parser(HuggingFaceTextGenerationParser())
-ModelParserRegistry.register_model_parser(DallE3ImageGenerationParser())
+dalle_image_generation_models = [
+        "dall-e-2",
+        "dall-e-3",
+    ]
+for model in dalle_image_generation_models:
+    ModelParserRegistry.register_model_parser(DallEImageGenerationParser(model))
 
 class AIConfigRuntime(AIConfig):
     # A mapping of model names to their respective parsers

--- a/python/src/aiconfig/default_parsers/dalle.py
+++ b/python/src/aiconfig/default_parsers/dalle.py
@@ -57,12 +57,13 @@ def construct_output(image_data: Image, execution_count: int) -> Output:
             "data": image_data.b64_json or image_data.url,
             "execution_count": execution_count,
             "metadata": {"revised_prompt": image_data.revised_prompt},
+            "mime_type": "image/png",
         }
     )
     return output
 
 
-class DallEImageGenerationParser(ParameterizedModelParser):
+class DalleImageGenerationParser(ParameterizedModelParser):
     """
     A model parser for Dall-E 2 and Dall-E 3 text-->image generation models.
     """
@@ -72,7 +73,7 @@ class DallEImageGenerationParser(ParameterizedModelParser):
         Usage:
 
         1. Create a new model parser object
-                parser = DallEImageGenerationParser("dall-e-3")
+                parser = DalleImageGenerationParser("dall-e-3")
         2. Add the model parser to the registry.
                 config.register_model_parser(parser)
 

--- a/python/src/aiconfig/default_parsers/dalle.py
+++ b/python/src/aiconfig/default_parsers/dalle.py
@@ -62,30 +62,39 @@ def construct_output(image_data: Image, execution_count: int) -> Output:
     return output
 
 
-class DallE3ImageGenerationParser(ParameterizedModelParser):
+class DallEImageGenerationParser(ParameterizedModelParser):
     """
-    A model parser for Dall-E 3 text-->image generation models.
+    A model parser for Dall-E 2 and Dall-E 3 text-->image generation models.
     """
     
-    def __init__(self):
+    def __init__(self, model_id: str = "dall-e-3"):
         """
         Usage:
 
         1. Create a new model parser object
-                parser = DallE3ImageGenerationParser()
+                parser = DallEImageGenerationParser("dall-e-3")
         2. Add the model parser to the registry.
                 config.register_model_parser(parser)
 
         The model parser will require an API token to be set in the environment variable OPENAI_API_KEY.
         """
         super().__init__()
+
+        supported_models = {
+            "dall-e-2",
+            "dall-e-3",
+        }
+        if model_id.lower() not in supported_models:
+            raise ValueError('{model_id}' + " is not a valid model ID for Dall-E image generation. Supported models: {supported_models}.")
+        self.model_id = model_id
+        
         self.client = None
 
     def id(self) -> str:
         """
         Returns an identifier for the model (e.g. dall-e-2, dall-e-3, etc.).
         """
-        return "dall-e-3"
+        return self.model_id
 
 
     async def serialize(

--- a/python/tests/aiconfigs/basic_dalle2_config.json
+++ b/python/tests/aiconfigs/basic_dalle2_config.json
@@ -1,0 +1,32 @@
+{
+    "name": "Panda Eating Dumplings Image Generator",
+    "description": "Testing Dall-E 2 image generation",
+    "schema_version": "latest",
+    "metadata": {
+      "models": {
+        "dall-e-2": {
+          "model": "dall-e-2",
+          "system_prompt": "What color do you want to see as a background?"
+        }
+      },
+      "default_model": "dall-e-2"
+    },
+    "prompts": [
+      {
+        "name": "panda_eating_dumplings",
+        "input": "Panda eating dumplings on a {{color}} mountain",
+        "metadata": {
+          "model": {
+            "name": "dall-e-2",
+            "settings": {
+                "n": 4,
+                "size": "1024x1024"
+            }
+          },
+          "parameters": {
+            "color": "yellow"
+          }
+        }
+      }
+    ]
+  }

--- a/python/tests/test_load_config.py
+++ b/python/tests/test_load_config.py
@@ -30,6 +30,22 @@ async def test_load_basic_chatgpt_query_config(set_temporary_env_vars):
     }
 
 @pytest.mark.asyncio
+async def test_load_basic_dalle2_config(set_temporary_env_vars):
+    """Test loading a basic Dall-E 2 config"""
+    config_relative_path = "aiconfigs/basic_dalle2_config.json"
+    config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
+    config = AIConfigRuntime.load(config_absolute_path)
+
+    data_for_inference = await config.resolve("panda_eating_dumplings")
+
+    assert data_for_inference == {
+        "model": "dall-e-2",
+        'n': 4,
+        'prompt': 'Panda eating dumplings on a yellow mountain',
+        'size': '1024x1024'
+    }
+
+@pytest.mark.asyncio
 async def test_load_basic_dalle3_config(set_temporary_env_vars):
     """Test loading a basic Dall-E 3 config"""
     config_relative_path = "aiconfigs/basic_dalle3_config.json"


### PR DESCRIPTION
[dall-e parser][5/n] Add mime type for urls (png) and base64 (plaintext)


Didn't know about this until now, wasn't adding it earlier.

The common MIME types are listed here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types

| Before | After |
|---|---|
| <img width="672" alt="Screenshot 2023-11-20 at 18 11 17" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/75bc9b3a-494a-400f-8405-afdff5bcf093"> | <img width="684" alt="Screenshot 2023-11-20 at 18 15 55" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/b2a1f88a-c0a7-4b73-ac7b-076ca5e0ea5a"> |


---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/298).
* __->__ #298
* #297