### PR TITLE
Apply Schema to Existing Config JSON Files

### DIFF
--- a/cookbooks/Basic-Prompt-Routing/assistant_aiconfig.json
+++ b/cookbooks/Basic-Prompt-Routing/assistant_aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "assistant_config",
   "schema_version": "latest",
   "metadata": {

--- a/cookbooks/Chain-of-Verification/cove_config.json
+++ b/cookbooks/Chain-of-Verification/cove_config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "Chain of Verification (CoVe) ",
   "schema_version": "latest",
   "metadata": {

--- a/cookbooks/Cli-Mate/cli-mate.aiconfig.json
+++ b/cookbooks/Cli-Mate/cli-mate.aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "cli-mate",
   "schema_version": "latest",
   "metadata": {
@@ -14,7 +15,8 @@
   "prompts": [
     {
       "name": "query",
-      "input": "{{the_input}}"
+      "input": "{{the_input}}",
+      "metadata": {}
     }
   ]
 }

--- a/cookbooks/Create-AIConfig-Programmatically/programmatic.aiconfig.json
+++ b/cookbooks/Create-AIConfig-Programmatically/programmatic.aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "create_programmatically_demo",
   "schema_version": "latest",
   "metadata": {

--- a/cookbooks/Custom-Callbacks/travel.aiconfig.json
+++ b/cookbooks/Custom-Callbacks/travel.aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "NYC Trip Planner",
   "description": "Intrepid explorer with ChatGPT and AIConfig",
   "schema_version": "latest",
@@ -20,7 +21,8 @@
   "prompts": [
     {
       "name": "get_activities",
-      "input": "Tell me 10 fun attractions to do in NYC."
+      "input": "Tell me 10 fun attractions to do in NYC.",
+      "metadata": {}
     },
     {
       "name": "gen_itinerary",
@@ -34,5 +36,3 @@
     }
   ]
 }
-
-

--- a/cookbooks/Function-Calling-OpenAI/function-call.aiconfig.json
+++ b/cookbooks/Function-Calling-OpenAI/function-call.aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "function-call-demo",
   "description": "this is a demo AIConfig to show function calling using OpenAI",
   "schema_version": "latest",

--- a/cookbooks/Getting-Started/travel.aiconfig.json
+++ b/cookbooks/Getting-Started/travel.aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "NYC Trip Planner",
   "description": "Intrepid explorer with ChatGPT and AIConfig",
   "schema_version": "latest",
@@ -20,7 +21,8 @@
   "prompts": [
     {
       "name": "get_activities",
-      "input": "Tell me 10 fun attractions to do in NYC."
+      "input": "Tell me 10 fun attractions to do in NYC.",
+      "metadata": {}
     },
     {
       "name": "gen_itinerary",
@@ -34,5 +36,3 @@
     }
   ]
 }
-
-

--- a/cookbooks/HuggingFace/Mistral-aiconfig.json
+++ b/cookbooks/HuggingFace/Mistral-aiconfig.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "exploring nyc through chatgpt config",
     "description": "",
     "schema_version": "latest",
@@ -20,7 +21,8 @@
     "prompts": [
         {
             "name": "prompt1",
-            "input": "What is your favorite condiment?"
+            "input": "What is your favorite condiment?",
+            "metadata": {}
         }
     ]
 }

--- a/cookbooks/Multi-LLM-Consistency/Multi-LLM Consistency Prompting & LLM-based Quorum_aiconfig.json
+++ b/cookbooks/Multi-LLM-Consistency/Multi-LLM Consistency Prompting & LLM-based Quorum_aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "Multi-LLM Consistency Prompting & LLM-based Quorum",
   "schema_version": "latest",
   "metadata": {

--- a/cookbooks/Multi-LLM-Consistency/multi_llm_consistency.json
+++ b/cookbooks/Multi-LLM-Consistency/multi_llm_consistency.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "Multi-LLM Consistency Prompting & LLM-based Quorum",
   "schema_version": "latest",
   "metadata": {

--- a/cookbooks/RAG-with-AIConfig/rag_aiconfig.json
+++ b/cookbooks/RAG-with-AIConfig/rag_aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "",
   "schema_version": "latest",
   "metadata": {

--- a/cookbooks/Wizard-GPT/wizard.aiconfig.json
+++ b/cookbooks/Wizard-GPT/wizard.aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "Wizard GPT",
   "schema_version": "latest",
   "metadata": {
@@ -21,6 +22,5 @@
     "default_model": "gpt-3.5-turbo"
   },
   "description": "Wizard Chatbot built on AI Config",
-  "prompts": [
-  ]
+  "prompts": []
 }

--- a/cookbooks/llama/llama-aiconfig.json
+++ b/cookbooks/llama/llama-aiconfig.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "exploring nyc through llama config",
     "description": "",
     "schema_version": "latest",

--- a/extensions/llama/typescript/llama-aiconfig.json
+++ b/extensions/llama/typescript/llama-aiconfig.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "exploring nyc through llama config",
     "description": "",
     "schema_version": "latest",

--- a/python/demo/Chained-Config.json
+++ b/python/demo/Chained-Config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "gpt4 as your data engineer",
     "description": "",
     "schema_version": "latest",

--- a/python/demo/GPT3-WhatAreTransformers-Stream-Enabled.json
+++ b/python/demo/GPT3-WhatAreTransformers-Stream-Enabled.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "gpt4 as your data engineer",
     "description": "",
     "schema_version": "latest",

--- a/python/demo/GPT3-WhatAreTransformers.json
+++ b/python/demo/GPT3-WhatAreTransformers.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "gpt4 as your data engineer",
     "description": "",
     "schema_version": "latest",

--- a/python/demo/PaLM-Chat-WhatAreTransformers.json
+++ b/python/demo/PaLM-Chat-WhatAreTransformers.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "hi",
   "schema_version": "latest",
   "metadata": {},

--- a/python/demo/function-call.aiconfig.json
+++ b/python/demo/function-call.aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "function-call-demo",
   "description": "this is a demo AIConfig to show function calling using OpenAI",
   "schema_version": "latest",

--- a/python/demo/parameterized_data_config.json
+++ b/python/demo/parameterized_data_config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "gpt4 as your data engineer",
     "description": "",
     "schema_version": "latest",

--- a/python/demo/stream_parameterized_data_config.json
+++ b/python/demo/stream_parameterized_data_config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "gpt4 as your data engineer",
     "description": "",
     "schema_version": "latest",

--- a/python/demo/updated_aiconfig.json
+++ b/python/demo/updated_aiconfig.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "gpt4 as your data engineer",
     "schema_version": "latest",
     "metadata": {
@@ -26,10 +27,8 @@
             "input": "Write me a {{sql_language}} query to get this final output: {{output_data}}. Use the tables relationships defined here: {{table_relationships}}.",
             "metadata": {
                 "model": {
-                    "name": "gpt-3.5-turbo",
-                    "settings": null
+                    "name": "gpt-3.5-turbo"
                 },
-                "tags": null,
                 "parameters": {}
             }
         },
@@ -46,7 +45,6 @@
                         "temperature": 1
                     }
                 },
-                "tags": null,
                 "parameters": {}
             }
         },
@@ -55,7 +53,6 @@
             "input": "How do transformers work?",
             "metadata": {
                 "model": "gpt-3.5-turbo",
-                "tags": null,
                 "parameters": {}
             }
         }

--- a/python/tests/aiconfigs/GPT4 Coding Assistant_aiconfig.json
+++ b/python/tests/aiconfigs/GPT4 Coding Assistant_aiconfig.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "GPT4 Coding Assistant",
     "schema_version": "latest",
     "metadata": {},

--- a/python/tests/aiconfigs/basic_chatgpt_query_config.json
+++ b/python/tests/aiconfigs/basic_chatgpt_query_config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "exploring nyc through chatgpt config",
     "description": "",
     "schema_version": "latest",

--- a/python/tests/aiconfigs/basic_default_model_aiconfig.json
+++ b/python/tests/aiconfigs/basic_default_model_aiconfig.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "exploring nyc through chatgpt config",
     "description": "",
     "schema_version": "latest",
@@ -19,7 +20,8 @@
     "prompts": [
         {
             "name": "prompt1",
-            "input": "Hi! Tell me 10 cool things to do in NYC."
+            "input": "Hi! Tell me 10 cool things to do in NYC.",
+            "metadata": {}
         }
     ]
 }

--- a/python/tests/aiconfigs/basic_palm_chat_query_config.json
+++ b/python/tests/aiconfigs/basic_palm_chat_query_config.json
@@ -1,12 +1,12 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "exploring nyc through chatgpt config",
     "description": "",
     "schema_version": "latest",
     "metadata": {
         "parameters": {},
         "models": {
-            "palm-chat": {
-            }
+            "palm-chat": {}
         }
     },
     "prompts": [
@@ -21,4 +21,3 @@
         }
     ]
 }
-

--- a/python/tests/aiconfigs/basic_palm_text_query_config.json
+++ b/python/tests/aiconfigs/basic_palm_text_query_config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "exploring nyc through chatgpt config",
     "description": "",
     "schema_version": "latest",

--- a/python/tests/aiconfigs/chained_gpt_config.json
+++ b/python/tests/aiconfigs/chained_gpt_config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "json helper config",
     "description": "",
     "schema_version": "latest",

--- a/python/tests/aiconfigs/parametrized_data_config.json
+++ b/python/tests/aiconfigs/parametrized_data_config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "gpt4 as your data engineer",
     "description": "",
     "schema_version": "latest",
@@ -42,7 +43,6 @@
                         "top_p": 1,
                         "max_tokens": 3000,
                         "temperature": 1
-                        
                     }
                 }
             }

--- a/python/tests/aiconfigs/system_prompt_parameters_config.json
+++ b/python/tests/aiconfigs/system_prompt_parameters_config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
     "name": "exploring nyc through chatgpt config",
     "description": "",
     "schema_version": "latest",

--- a/typescript/__tests__/samples/basic_chatgpt_query_config.json
+++ b/typescript/__tests__/samples/basic_chatgpt_query_config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "exploring nyc through chatgpt config",
   "description": "",
   "schema_version": "latest",

--- a/typescript/__tests__/samples/basic_palm_chat_query_config.json
+++ b/typescript/__tests__/samples/basic_palm_chat_query_config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "exploring nyc through chatgpt config",
   "description": "",
   "schema_version": "latest",

--- a/typescript/__tests__/samples/basic_palm_text_query_config.json
+++ b/typescript/__tests__/samples/basic_palm_text_query_config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "exploring nyc through chatgpt config",
   "description": "",
   "schema_version": "latest",

--- a/typescript/__tests__/samples/chained_gpt_config.json
+++ b/typescript/__tests__/samples/chained_gpt_config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "json helper config",
   "description": "",
   "schema_version": "latest",

--- a/typescript/__tests__/samples/parametrized_data_config.json
+++ b/typescript/__tests__/samples/parametrized_data_config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "gpt4 as your data engineer",
   "description": "",
   "schema_version": "latest",

--- a/typescript/demo/demo.aiconfig.json
+++ b/typescript/demo/demo.aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "demo",
   "description": "this is a demo AIConfig",
   "schema_version": "latest",

--- a/typescript/demo/function-call.aiconfig.json
+++ b/typescript/demo/function-call.aiconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "function-call-demo",
   "description": "this is a demo AIConfig to show function calling using OpenAI",
   "schema_version": "latest",

--- a/typescript/demo/mistral-config.json
+++ b/typescript/demo/mistral-config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
   "name": "exploring nyc through chatgpt config",
   "description": "",
   "schema_version": "latest",


### PR DESCRIPTION
# Apply Schema to Existing Config JSON Files

As it turns out, we already have a valid schema representation for the AIConfig in the repo! We can immediately start linting against it in VS Code by adding the appropriate `$schema` property pointed to that file: 
```
"$schema": "https://github.com/lastmile-ai/aiconfig/raw/main/schema/aiconfig.schema.json",
```

A couple discussion points:
- Do we want to version this schema file under a v1 folder to point to that, so we can add new versions without 'breaking' existing configs (i.e. having VS Code lint warnings show up for them)?
- Looks like quite a few configs were already not matching the schema (and linted accordingly), mainly missing metadata of having `null` instead of undefined keys for some values (programmatic creation)
- Do we want to include this schema value in the serialized JSON so that the files immediately lint in VS Code when opening after serializing to disk?
