### PR TITLE
[py][ts] rename prompt name when adding a prompt

### DIFF
--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -333,10 +333,14 @@ class AIConfig(BaseModel):
             prompt_name (str): The name of the prompt to add.
             prompt_data (Prompt): The prompt object containing the prompt data.
         """
+        if prompt_name is None:
+            prompt_name = prompt_data.name
         if prompt_name in self.prompt_index:
             raise Exception(
                 "Prompt with name {} already exists. Use`update_prompt()`".format(prompt_name)
             )
+        
+        prompt_data.name = prompt_name
         self.prompt_index[prompt_name] = prompt_data
         self.prompts.append(prompt_data)
 

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -488,6 +488,8 @@ export class AIConfigRuntime implements AIConfig {
       );
     }
 
+    prompt.name = name;
+
     this.prompts.push(prompt);
   }
 


### PR DESCRIPTION
[py][ts] rename prompt name when adding a prompt

## What
when given a name when adding a prompt, rename the prompt object's name.

## Why

The prompt object wasn't being renamed. If a user provides a different name, the Prompt object and config Names will diverge (unintended side effect)
