### PR TITLE
[py] bump version 1.1.1 -> 1.1.2 -> 1.1.3

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "python-aiconfig"
-version = "1.1.0"
+version = "1.1.3"
 authors = [
   { name="Sarmad Qadri", email="sarmad@lastmileai.dev" },
 ]


### PR DESCRIPTION
[py] bump version 1.1.1 -> 1.1.2 -> 1.1.3



## What

bump pytoml version to encompass Bug Fix in diff below. Package was republished under 1.1.2

Edit:

bumped to 1.1.3 to incorporate PR#318
