### PR TITLE
Make prompt.metadata Optional in Schema and TS Prompt Type

### DIFF
--- a/schema/aiconfig.schema.json
+++ b/schema/aiconfig.schema.json
@@ -113,7 +113,6 @@
         },
         "required": [
           "input",
-          "metadata",
           "name"
         ]
       }

--- a/typescript/__tests__/config.test.ts
+++ b/typescript/__tests__/config.test.ts
@@ -142,15 +142,15 @@ describe("Loading an AIConfig", () => {
     expect(prompt1.input).toEqual(
       "I need to create a JSON representation of a list of products for our e-commerce website. Please provide the JSON structure with placeholders for product details. Product names: MacBook, Apple Watch"
     );
-    expect(prompt1.metadata.model).toBe("gpt-3.5-turbo");
-    expect(prompt1.metadata.parameters).toEqual({ products: "Thunderbolt" });
+    expect(prompt1.metadata?.model).toBe("gpt-3.5-turbo");
+    expect(prompt1.metadata?.parameters).toEqual({ products: "Thunderbolt" });
 
     const prompt2 = prompts[1];
     expect(prompt2.input).toEqual(
       "Now, fill in the placeholders with the details of three products, including their names, prices, and descriptions."
     );
-    expect(prompt2.metadata.model).toBe("gpt-3.5-turbo");
-    expect(prompt2.metadata.parameters).toEqual({ products: "Thunderbolt" });
+    expect(prompt2.metadata?.model).toBe("gpt-3.5-turbo");
+    expect(prompt2.metadata?.parameters).toEqual({ products: "Thunderbolt" });
   });
 
   test("serialize a prompt chain with different settings", async () => {
@@ -197,21 +197,21 @@ describe("Loading an AIConfig", () => {
       "I need to create a JSON representation of a list of products for our e-commerce website. Please provide the JSON structure with placeholders for product details. Product names: MacBook, Apple Watch"
     );
     // Prompt Model metadata should override just the differences from the global model metadata
-    expect(prompt1.metadata.model).toEqual({
+    expect(prompt1.metadata?.model).toEqual({
       name: "gpt-3.5-turbo",
       settings: { temperature: 0.75, max_tokens: 3250 },
     });
-    expect(prompt1.metadata.parameters).toEqual({ products: "Thunderbolt" });
+    expect(prompt1.metadata?.parameters).toEqual({ products: "Thunderbolt" });
 
     const prompt2 = prompts[1];
     expect(prompt2.input).toEqual(
       "Now, fill in the placeholders with the details of three products, including their names, prices, and descriptions."
     );
-    expect(prompt1.metadata.model).toEqual({
+    expect(prompt1.metadata?.model).toEqual({
       name: "gpt-3.5-turbo",
       settings: { temperature: 0.75, max_tokens: 3250 },
     });
-    expect(prompt2.metadata.parameters).toEqual({ products: "Thunderbolt" });
+    expect(prompt2.metadata?.parameters).toEqual({ products: "Thunderbolt" });
   });
 });
 

--- a/typescript/__tests__/parsers/hf/hf.test.ts
+++ b/typescript/__tests__/parsers/hf/hf.test.ts
@@ -139,7 +139,7 @@ describe("HuggingFaceTextGeneration ModelParser", () => {
     expect(prompt.input).toEqual(
       "What are 5 interesting things to do in Toronto?"
     );
-    expect(prompt.metadata.model).toEqual({
+    expect(prompt.metadata?.model).toEqual({
       name: "mistralai/Mistral-7B-v0.1",
       settings: {
         temperature: 0.8,

--- a/typescript/__tests__/testProgramaticallyCreateConfig.ts
+++ b/typescript/__tests__/testProgramaticallyCreateConfig.ts
@@ -69,7 +69,6 @@ describe("ExtractOverrideSettings function", () => {
       initialSettings,
       modelId
     );
-    console.log("overidess: ", override);
 
     expect(override).toEqual({});
   });

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -546,7 +546,10 @@ export class AIConfigRuntime implements AIConfig {
         );
       }
 
-      prompt.metadata.model = modelMetadata;
+      prompt.metadata = {
+        ...prompt.metadata,
+        model: modelMetadata,
+      };
     } else {
       if (!this.metadata.models) {
         this.metadata.models = {};
@@ -570,7 +573,10 @@ export class AIConfigRuntime implements AIConfig {
         );
       }
 
-      prompt.metadata.model = modelMetadata;
+      prompt.metadata = {
+        ...prompt.metadata,
+        model: modelMetadata,
+      };
     } else {
       if (!this.metadata.models) {
         this.metadata.models = {};
@@ -641,11 +647,13 @@ export class AIConfigRuntime implements AIConfig {
         );
       }
 
-      if (prompt.metadata.parameters == null) {
-        prompt.metadata.parameters = {};
-      }
-
-      prompt.metadata.parameters[name] = value;
+      prompt.metadata = {
+        ...prompt.metadata,
+        parameters: {
+          ...prompt.metadata?.parameters,
+          [name]: value,
+        },
+      };
     } else {
       if (this.metadata.parameters == null) {
         this.metadata.parameters = {};
@@ -672,7 +680,7 @@ export class AIConfigRuntime implements AIConfig {
         );
       }
 
-      if (prompt.metadata.parameters == null) {
+      if (prompt.metadata?.parameters == null) {
         return;
       }
 
@@ -701,7 +709,10 @@ export class AIConfigRuntime implements AIConfig {
         );
       }
 
-      prompt.metadata[key] = value;
+      prompt.metadata = {
+        ...prompt.metadata,
+        [key]: value,
+      };
     } else {
       this.metadata[key] = value;
     }
@@ -721,7 +732,7 @@ export class AIConfigRuntime implements AIConfig {
         );
       }
 
-      delete prompt.metadata[key];
+      delete prompt.metadata?.[key];
     } else {
       delete this.metadata[key];
     }

--- a/typescript/types.ts
+++ b/typescript/types.ts
@@ -113,7 +113,7 @@ export type Prompt = {
    */
   input: PromptInput;
 
-  metadata: {
+  metadata?: {
     /**
      * Parameter definitions that are accessible to this prompt.
      * These parameters can be referenced in the prompt using {{param_name}} handlebars syntax.


### PR DESCRIPTION
Make prompt.metadata Optional in Schema and TS Prompt Type

# Make prompt.metadata Optional in Schema and TS Prompt Type
This ensure the typescript implementation and the schema definition match existing python implementation and desired functionality -- the metadata isn't always needed and no point in having it be an empty object

## Testing
```
ryanholinshead@Ryans-MacBook-Pro typescript % yarn test
yarn run v1.22.19
$ jest --runInBand
 PASS  __tests__/testProgramaticallyCreateConfig.ts
  test Get Global Settings
    ✓ Retrieving global setting from AIConfig with 1 model (1 ms)
  ExtractOverrideSettings function
    ✓ Should return initial settings when no global settings are defined
    ✓ Should return an override when initial settings differ from global settings
    ✓ Should return empty override when global settings match initial settings (10 ms)
    ✓ Should return empty override when Global settings defined and initial settings are empty (2 ms)

 PASS  __tests__/config.test.ts
  Loading an AIConfig
    ✓ loading a basic chatgpt query config (7 ms)
    ✓ loading a prompt chain (4 ms)
    ✓ deserialize and re-serialize a prompt chain (3 ms)
    ✓ serialize a prompt chain with different settings (1 ms)

 PASS  __tests__/parsers/hf/hf.test.ts
  HuggingFaceTextGeneration ModelParser
    ✓ uses HuggingFace API token from environment variable if it exists (6 ms)
    ✓ serializing params to config prompt (1 ms)
    ✓ serialize callbacks (1 ms)
    ✓ deserializing config prompt to params (1 ms)
    ✓ deserialize callbacks
    ✓ run prompt, non-streaming (3 ms)
    ✓ run prompt, streaming (3 ms)
    ✓ run callbacks (1 ms)

Test Suites: 3 passed, 3 total
Tests:       17 passed, 17 total
Snapshots:   0 total
Time:        1.118 s
Ran all test suites.
✨  Done in 2.08s.
```
