### PR TITLE
[cookbooks] wrapper notebook fix last cell

### DIFF
--- a/cookbooks/OpenAI-ChatCompletion-AIConfigWrapper/openai_wrapper.ipynb
+++ b/cookbooks/OpenAI-ChatCompletion-AIConfigWrapper/openai_wrapper.ipynb
@@ -283,7 +283,10 @@
    "source": [
     "from aiconfig import AIConfigRuntime\n",
     "from aiconfig import InferenceOptions\n",
-    "import openai\n",
+    "# Reset Chat Completion to Original\n",
+    "from aiconfig.ChatCompletion import openai_chat_completion_create\n",
+    "openai.chat.completions.create = openai_chat_completion_create\n",
+    "\n",
     "\n",
     "config = AIConfigRuntime.load(\"aiconfig.json\")\n",
     "inference_options = InferenceOptions()\n",


### PR DESCRIPTION
[cookbooks] wrapper notebook fix last cell

## What

update aiconfig run cell to use original chat completion api

## Why

openai wrapper is used to create configs. It must be reset to the original api, `openai.chat.completions.create()` in order for the OpenAI model parser to work.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/333).
* #334
* __->__ #333