### PR TITLE
[RFC][AIC-py] wrapper: drop-in replacement for whole openai lib

### DIFF
--- a/cookbooks/OpenAI-ChatCompletion-AIConfigWrapper/my-second-aiconfig.json
+++ b/cookbooks/OpenAI-ChatCompletion-AIConfigWrapper/my-second-aiconfig.json
@@ -1,0 +1,42 @@
+{
+  "name": "",
+  "schema_version": "latest",
+  "metadata": {
+    "parameters": {},
+    "models": {}
+  },
+  "description": "",
+  "prompts": [
+    {
+      "name": "prompt_0",
+      "input": "Tell me a riveting story",
+      "metadata": {
+        "model": {
+          "name": "gpt-3.5-turbo",
+          "settings": {
+            "model": "gpt-3.5-turbo",
+            "top_p": 1,
+            "max_tokens": 3000,
+            "temperature": 1,
+            "stream": true
+          }
+        },
+        "parameters": {},
+        "remember_chat_context": true
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Once upon a time, in a small and peaceful village, there lived a young girl named Lily. Lily was always looking for adventure and excitement in her otherwise mundane life. One day, as she walked through the dense forest on the outskirts of the village, she stumbled upon an old, mysterious book lying on the ground.\n\nCuriosity got the better of her, and Lily picked up the book to examine it. The worn-out cover had a strange symbol engraved on it. Intrigued, she opened the book and found pages filled with cryptic symbols and ancient writings that she couldn't decipher.\n\nDetermined to uncover the secrets hidden within the book, Lily embarked on a journey to seek the help of an old sage who lived atop a nearby mountain. Legends whispered that the sage possessed wisdom that surpassed generations.\n\nAfter a long and arduous climb, Lily finally reached the sage's humble abode. She was greeted by an elderly man with a long white beard and eyes twinkling with wisdom. Lily explained her quest and showed him the mysterious book. The sage examined the pages carefully and revealed that the book contained ancient spells and enchantments. He warned Lily about the great power it wielded.\n\nFascinated by the possibilities, Lily decided to learn the magical arts with the sage's guidance. Day after day, they delved deeper into the book's secrets, unraveling spells and understanding their consequences. Lily discovered her innate talent for magic and became an exceptional sorceress.\n\nHowever, the more Lily studied the book, the more she became consumed by its power. Its allure was irresistible, manipulating her intentions. The ancient writings tempted her with promises, urging her to use its magic for personal gain. Lily's once-noble quest for knowledge turned into a quest for power.\n\nThe neighboring kingdom had long been at war, and the villagers suffered greatly. Lily, now intoxicated by the book's power, decided to take matters into her own hands. She summoned powerful storms, conjured illusions, and raised an army of enchanted creatures. With her newfound strength, she attacked the kingdom, intending to seize control and bring about peace by force.\n\nBut as the battle raged on, Lily soon realized the devastation and chaos she had unleashed upon innocent lives. The once peaceful village was now in ruins, and the people she had sworn to protect were fleeing in terror. Overwhelmed by guilt and regret, she knew she had lost her way.\n\nIn an act of redemption, Lily used the last of her strength to seal the book's power, sacrificing her own magical abilities. She spent years aiding in the kingdom's reconstruction, helping the people heal from the wounds of war. The villagers saw her transformation and forgave her, acknowledging her once again as their protector.\n\nFrom that day forward, Lily devoted her life to the service of others. She became a symbol of hope and taught the importance of using power responsibly. The book, now locked away, served as a reminder of the dangers of unchecked ambition.\n\nAnd so, the village thrived under Lily's wise leadership, with peace and harmony restored. Her story spread throughout the land, reminding everyone of the importance of staying true to oneself and using power for the greater good.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cookbooks/OpenAI-ChatCompletion-AIConfigWrapper/openai_wrapper.ipynb
+++ b/cookbooks/OpenAI-ChatCompletion-AIConfigWrapper/openai_wrapper.ipynb
@@ -2,19 +2,127 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aiconfig.ChatCompletion import get_wrapped_openai\n",
+    "openai = get_wrapped_openai('my-second-aiconfig.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Api Key\n",
     "from dotenv import load_dotenv\n",
-    "import openai\n",
     "import os\n",
+    "\n",
+    "# original_create = openai.chat.completions.create\n",
+    "\n",
+    "\n",
     "\n",
     "load_dotenv()\n",
     "\n",
-    "openai.api_key = os.getenv(\"OPENAI_API_KEY\")\n",
-    "original_create = openai.chat.completions.create"
+    "openai.api_key = os.getenv(\"OPENAI_API_KEY\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Once upon a time, in a small and peaceful village, there lived a young girl named Lily. Lily was always looking for adventure and excitement in her otherwise mundane life. One day, as she walked through the dense forest on the outskirts of the village, she stumbled upon an old, mysterious book lying on the ground.\\n\\nCuriosity got the better of her, and Lily picked up the book to examine it. The worn-out cover had a strange symbol engraved on it. Intrigued, she opened the book and found pages filled with cryptic symbols and ancient writings that she couldn't decipher.\\n\\nDetermined to uncover the secrets hidden within the book, Lily embarked on a journey to seek the help of an old sage who lived atop a nearby mountain. Legends whispered that the sage possessed wisdom that surpassed generations.\\n\\nAfter a long and arduous climb, Lily finally reached the sage's humble abode. She was greeted by an elderly man with a long white beard and eyes twinkling with wisdom. Lily explained her quest and showed him the mysterious book. The sage examined the pages carefully and revealed that the book contained ancient spells and enchantments. He warned Lily about the great power it wielded.\\n\\nFascinated by the possibilities, Lily decided to learn the magical arts with the sage's guidance. Day after day, they delved deeper into the book's secrets, unraveling spells and understanding their consequences. Lily discovered her innate talent for magic and became an exceptional sorceress.\\n\\nHowever, the more Lily studied the book, the more she became consumed by its power. Its allure was irresistible, manipulating her intentions. The ancient writings tempted her with promises, urging her to use its magic for personal gain. Lily's once-noble quest for knowledge turned into a quest for power.\\n\\nThe neighboring kingdom had long been at war, and the villagers suffered greatly. Lily, now intoxicated by the book's power, decided to take matters into her own hands. She summoned powerful storms, conjured illusions, and raised an army of enchanted creatures. With her newfound strength, she attacked the kingdom, intending to seize control and bring about peace by force.\\n\\nBut as the battle raged on, Lily soon realized the devastation and chaos she had unleashed upon innocent lives. The once peaceful village was now in ruins, and the people she had sworn to protect were fleeing in terror. Overwhelmed by guilt and regret, she knew she had lost her way.\\n\\nIn an act of redemption, Lily used the last of her strength to seal the book's power, sacrificing her own magical abilities. She spent years aiding in the kingdom's reconstruction, helping the people heal from the wounds of war. The villagers saw her transformation and forgave her, acknowledging her once again as their protector.\\n\\nFrom that day forward, Lily devoted her life to the service of others. She became a symbol of hope and taught the importance of using power responsibly. The book, now locked away, served as a reminder of the dangers of unchecked ambition.\\n\\nAnd so, the village thrived under Lily's wise leadership, with peace and harmony restored. Her story spread throughout the land, reminding everyone of the importance of staying true to oneself and using power for the greater good.None\""
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "completion_params = {\n",
+    "            \"model\": \"gpt-3.5-turbo\",\n",
+    "            \"top_p\": 1,\n",
+    "            \"max_tokens\": 3000,\n",
+    "            \"temperature\": 1,\n",
+    "            \"stream\": True,\n",
+    "            \"messages\": [\n",
+    "                {\n",
+    "                    \"content\": \"Tell me a riveting story\",\n",
+    "                    \"role\": \"user\",\n",
+    "                }\n",
+    "            ],\n",
+    "        }\n",
+    "\n",
+    "response_stream = openai.chat.completions.create(**completion_params) # Creates a config saved to aiconfig_file_path = \"my-second-aiconfig.json\"\n",
+    "response = list(response_stream)\n",
+    "len(response)\n",
+    "whole_resp = [r.choices[0].delta.content for r in response]\n",
+    "\"\".join(map(str, whole_resp))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"name\": \"\",\n",
+      "  \"schema_version\": \"latest\",\n",
+      "  \"metadata\": {\n",
+      "    \"parameters\": {},\n",
+      "    \"models\": {}\n",
+      "  },\n",
+      "  \"description\": \"\",\n",
+      "  \"prompts\": [\n",
+      "    {\n",
+      "      \"name\": \"prompt_0\",\n",
+      "      \"input\": \"Tell me a riveting story\",\n",
+      "      \"metadata\": {\n",
+      "        \"model\": {\n",
+      "          \"name\": \"gpt-3.5-turbo\",\n",
+      "          \"settings\": {\n",
+      "            \"model\": \"gpt-3.5-turbo\",\n",
+      "            \"top_p\": 1,\n",
+      "            \"max_tokens\": 3000,\n",
+      "            \"temperature\": 1,\n",
+      "            \"stream\": true\n",
+      "          }\n",
+      "        },\n",
+      "        \"parameters\": {},\n",
+      "        \"remember_chat_context\": true\n",
+      "      },\n",
+      "      \"outputs\": [\n",
+      "        {\n",
+      "          \"output_type\": \"execute_result\",\n",
+      "          \"execution_count\": 0,\n",
+      "          \"data\": {\n",
+      "            \"content\": \"Once upon a time, in a small and peaceful village, there lived a young girl named Lily. Lily was always looking for adventure and excitement in her otherwise mundane life. One day, as she walked through the dense forest on the outskirts of the village, she stumbled upon an old, mysterious book lying on the ground.\\n\\nCuriosity got the better of her, and Lily picked up the book to examine it. The worn-out cover had a strange symbol engraved on it. Intrigued, she opened the book and found pages filled with cryptic symbols and ancient writings that she couldn't decipher.\\n\\nDetermined to uncover the secrets hidden within the book, Lily embarked on a journey to seek the help of an old sage who lived atop a nearby mountain. Legends whispered that the sage possessed wisdom that surpassed generations.\\n\\nAfter a long and arduous climb, Lily finally reached the sage's humble abode. She was greeted by an elderly man with a long white beard and eyes twinkling with wisdom. Lily explained her quest and showed him the mysterious book. The sage examined the pages carefully and revealed that the book contained ancient spells and enchantments. He warned Lily about the great power it wielded.\\n\\nFascinated by the possibilities, Lily decided to learn the magical arts with the sage's guidance. Day after day, they delved deeper into the book's secrets, unraveling spells and understanding their consequences. Lily discovered her innate talent for magic and became an exceptional sorceress.\\n\\nHowever, the more Lily studied the book, the more she became consumed by its power. Its allure was irresistible, manipulating her intentions. The ancient writings tempted her with promises, urging her to use its magic for personal gain. Lily's once-noble quest for knowledge turned into a quest for power.\\n\\nThe neighboring kingdom had long been at war, and the villagers suffered greatly. Lily, now intoxicated by the book's power, decided to take matters into her own hands. She summoned powerful storms, conjured illusions, and raised an army of enchanted creatures. With her newfound strength, she attacked the kingdom, intending to seize control and bring about peace by force.\\n\\nBut as the battle raged on, Lily soon realized the devastation and chaos she had unleashed upon innocent lives. The once peaceful village was now in ruins, and the people she had sworn to protect were fleeing in terror. Overwhelmed by guilt and regret, she knew she had lost her way.\\n\\nIn an act of redemption, Lily used the last of her strength to seal the book's power, sacrificing her own magical abilities. She spent years aiding in the kingdom's reconstruction, helping the people heal from the wounds of war. The villagers saw her transformation and forgave her, acknowledging her once again as their protector.\\n\\nFrom that day forward, Lily devoted her life to the service of others. She became a symbol of hope and taught the importance of using power responsibly. The book, now locked away, served as a reminder of the dangers of unchecked ambition.\\n\\nAnd so, the village thrived under Lily's wise leadership, with peace and harmony restored. Her story spread throughout the land, reminding everyone of the importance of staying true to oneself and using power for the greater good.\",\n",
+      "            \"role\": \"assistant\"\n",
+      "          },\n",
+      "          \"metadata\": {\n",
+      "            \"finish_reason\": \"stop\"\n",
+      "          }\n",
+      "        }\n",
+      "      ]\n",
+      "    }\n",
+      "  ]\n",
+      "}"
+     ]
+    }
+   ],
+   "source": [
+    "less my-second-aiconfig.json"
    ]
   },
   {


### PR DESCRIPTION
[RFC][AIC-py] wrapper: drop-in replacement for whole openai lib

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/340).
* __->__ #340
* #325