### PR TITLE
[eng week] Set run output type to be list[Output] instead of Output

### DIFF
--- a/cookbooks/HuggingFace/hf.py
+++ b/cookbooks/HuggingFace/hf.py
@@ -1,5 +1,5 @@
 import copy
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 # HuggingFace API imports
 from huggingface_hub import InferenceClient
@@ -232,7 +232,7 @@ class HuggingFaceTextParser(ParameterizedModelParser):
 
     async def run_inference(
         self, prompt: Prompt, aiconfig, options, parameters
-    ) -> Output:
+    ) -> List[Output]:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform
         the actual model inference based on the provided prompt and inference settings.

--- a/cookbooks/HuggingFace/python/hf.py
+++ b/cookbooks/HuggingFace/python/hf.py
@@ -1,5 +1,5 @@
 import copy
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 # HuggingFace API imports
 from huggingface_hub import InferenceClient
@@ -232,7 +232,7 @@ class HuggingFaceTextParser(ParameterizedModelParser):
 
     async def run_inference(
         self, prompt: Prompt, aiconfig, options, parameters
-    ) -> Output:
+    ) -> List[Output]:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform
         the actual model inference based on the provided prompt and inference settings.

--- a/extensions/HuggingFace/python/hf.py
+++ b/extensions/HuggingFace/python/hf.py
@@ -1,5 +1,5 @@
 import copy
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 # HuggingFace API imports
 from huggingface_hub import InferenceClient
@@ -232,7 +232,7 @@ class HuggingFaceTextParser(ParameterizedModelParser):
 
     async def run_inference(
         self, prompt: Prompt, aiconfig, options, parameters
-    ) -> Output:
+    ) -> List[Output]:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform
         the actual model inference based on the provided prompt and inference settings.

--- a/extensions/llama/python/llama.py
+++ b/extensions/llama/python/llama.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 
 from aiconfig.Config import AIConfigRuntime
 from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
@@ -61,16 +61,16 @@ class LlamaModelParser(ParameterizedModelParser):
         aiconfig: AIConfigRuntime,
         options: InferenceOptions | None,
         parameters: dict,
-    ) -> ExecuteResult:
+    ) -> List[Output]:
         resolved = await self.deserialize(prompt, aiconfig, parameters)
         model_input = resolved["model_input"]
         result = await self._run_inference_helper(model_input, options)
 
         self.qa.append((model_input, result.data[0]))
 
-        return result
+        return [result]
 
-    async def _run_inference_helper(self, model_input, options) -> ExecuteResult:
+    async def _run_inference_helper(self, model_input, options) -> List[Output]:
         llm = Llama(self.model_path)
         acc = ""
         stream = options.stream if options else True

--- a/python/src/aiconfig/default_parsers/dalle.py
+++ b/python/src/aiconfig/default_parsers/dalle.py
@@ -1,5 +1,5 @@
 import copy
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import openai
 from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
@@ -151,7 +151,7 @@ class DalleImageGenerationParser(ParameterizedModelParser):
 
     async def run_inference(
         self, prompt: Prompt, aiconfig, _options, parameters
-    ) -> Output:
+    ) -> List[Output]:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform
         the actual model inference based on the provided prompt and inference settings.

--- a/python/src/aiconfig/default_parsers/hf.py
+++ b/python/src/aiconfig/default_parsers/hf.py
@@ -1,5 +1,5 @@
 import copy
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
 from aiconfig.model_parser import InferenceOptions
@@ -228,7 +228,7 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
 
     async def run_inference(
         self, prompt: Prompt, aiconfig, options, parameters
-    ) -> Output:
+    ) -> List[Output]:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform
         the actual model inference based on the provided prompt and inference settings.

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -233,7 +233,7 @@ class OpenAIInference(ParameterizedModelParser):
         aiconfig: "AIConfigRuntime",
         options: InferenceOptions,
         parameters,
-    ) -> Output:
+    ) -> List[Output]:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform
         the actual model inference based on the provided prompt and inference settings.

--- a/python/src/aiconfig/default_parsers/palm.py
+++ b/python/src/aiconfig/default_parsers/palm.py
@@ -126,7 +126,7 @@ class PaLMTextParser(ParameterizedModelParser):
         aiconfig: "AIConfigRuntime",
         options: InferenceOptions,
         parameters,
-    ) -> Output:
+    ) -> List[Output]:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform
         the actual model inference based on the provided prompt and inference settings.
@@ -325,7 +325,7 @@ class PaLMChatParser(ParameterizedModelParser):
         aiconfig: "AIConfigRuntime",
         options: InferenceOptions,
         parameters,
-    ) -> Output:
+    ) -> List[Output]:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform
         the actual model inference based on the provided prompt and inference settings.


### PR DESCRIPTION
[eng week] Set run output type to be list[Output] instead of Output


Makes it more scalable. The Prompt schema already refers to `outputs` as `List[Output]` anyways
