### PR TITLE
[hf parsers][3/n] Add streaming for text generation transformer

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -5,3 +5,9 @@ pytest-cov
 pytest-mock
 pytest-asyncio
 mock
+
+# TODO (rossdanlm): remove from core lib after moving to extension: https://github.com/lastmile-ai/aiconfig/pull/344
+transformers
+torch
+torchvision
+torchaudio

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,3 +14,10 @@ prompt_toolkit
 mock
 pytest-asyncio
 lastmile_utils==0.0.3
+transformers
+
+# TODO (rossdanlm): remove from core lib after moving to extension: https://github.com/lastmile-ai/aiconfig/pull/344
+transformers
+torch
+torchvision
+torchaudio

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -10,6 +10,7 @@ from aiconfig.model_parser import InferenceOptions, ModelParser
 
 from .default_parsers.dalle import DalleImageGenerationParser
 from .default_parsers.hf import HuggingFaceTextGenerationParser
+from .default_parsers.hugging_face_transformers.text_generation import HuggingFaceTextGenerationTransformer
 from .registry import (
     ModelParserRegistry,
     update_model_parser_registry_with_config_runtime,
@@ -35,6 +36,7 @@ for model in gpt_models:
 ModelParserRegistry.register_model_parser(PaLMChatParser())
 ModelParserRegistry.register_model_parser(PaLMTextParser())
 ModelParserRegistry.register_model_parser(HuggingFaceTextGenerationParser())
+ModelParserRegistry.register_model_parser(HuggingFaceTextGenerationTransformer('gpt2'))
 dalle_image_generation_models = [
     "dall-e-2",
     "dall-e-3",

--- a/python/src/aiconfig/default_parsers/hugging_face_transformers/text_generation.py
+++ b/python/src/aiconfig/default_parsers/hugging_face_transformers/text_generation.py
@@ -20,23 +20,54 @@ def refine_chat_completion_params(model_settings: Dict[str, Any]) -> Dict[str, A
     """
 
     supported_keys = {
-        "details",
-        "stream",
-        "model",
-        "do_sample",
+        "max_length",
         "max_new_tokens",
-        "best_of",
-        "repetition_penalty",
-        "return_full_text",
-        "seed",
-        "stop_sequences",
+        "min_length",
+        "min_new_tokens",
+        "early_stopping",
+        "max_time",
+        "do_sample",
+        "num_beams",
+        "num_beam_groups",
+        "penalty_alpha",
+        "use_cache",
         "temperature",
         "top_k",
         "top_p",
-        "truncate",
         "typical_p",
-        "watermark",
-        "decoder_input_details",
+        "epsilon_cutoff",
+        "eta_cutoff",
+        "diversity_penalty",
+        "repetition_penalty",
+        "encoder_repetition_penalty",
+        "length_penalty",
+        "no_repeat_ngram_size",
+        "bad_words_ids",
+        "force_words_ids",
+        "renormalize_logits",
+        "constraints",
+        "forced_bos_token_id",
+        "forced_eos_token_id",
+        "remove_invalid_values",
+        "exponential_decay_length_penalty",
+        "suppress_tokens",
+        "begin_suppress_tokens",
+        "forced_decoder_ids",
+        "sequence_bias",
+        "guidance_scale",
+        "low_memory",
+        "num_return_sequences",
+        "output_attentions",
+        "output_hidden_states",
+        "output_scores",
+        "return_dict_in_generate",
+        "pad_token_id",
+        "bos_token_id",
+        "eos_token_id",
+        "encoder_no_repeat_ngram_size",
+        "decoder_start_token_id",
+        "num_assistant_tokens",
+        "num_assistant_tokens_schedule"
     }
 
     completion_data = {}
@@ -179,8 +210,8 @@ class HuggingFaceTextGenerationTransformer(ParameterizedModelParser):
         """
         completion_data = await self.deserialize(prompt, aiconfig, options, parameters)
 
-        resolved_prompt : str = completion_data["prompt"]
-        response : List[Any] = self.generator(resolved_prompt)
+        completion_data["text_inputs"] = completion_data.pop("prompt", None)
+        response : List[Any] = self.generator(**completion_data)
         outputs : List[Output] = []
         for count, result in enumerate(response):
             output = construct_regular_output(result, count, response_includes_details=False)

--- a/python/src/aiconfig/default_parsers/hugging_face_transformers/text_generation.py
+++ b/python/src/aiconfig/default_parsers/hugging_face_transformers/text_generation.py
@@ -1,0 +1,208 @@
+import copy
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from transformers import pipeline
+
+from aiconfig.util.params import resolve_prompt
+from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
+
+from aiconfig.schema import ExecuteResult, Output, Prompt, PromptMetadata
+
+# Circuluar Dependency Type Hints
+if TYPE_CHECKING:
+    from aiconfig.Config import AIConfigRuntime
+
+
+# Step 1: define Helpers
+def refine_chat_completion_params(model_settings: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Refines the completion params for the HF text generation api. Removes any unsupported params.
+    The supported keys were found by looking at the HF text generation api. `huggingface_hub.InferenceClient.text_generation()`
+    """
+
+    supported_keys = {
+        "details",
+        "stream",
+        "model",
+        "do_sample",
+        "max_new_tokens",
+        "best_of",
+        "repetition_penalty",
+        "return_full_text",
+        "seed",
+        "stop_sequences",
+        "temperature",
+        "top_k",
+        "top_p",
+        "truncate",
+        "typical_p",
+        "watermark",
+        "decoder_input_details",
+    }
+
+    completion_data = {}
+    for key in model_settings:
+        if key.lower() in supported_keys:
+            completion_data[key.lower()] = model_settings[key]
+
+    return completion_data
+
+
+def construct_regular_output(result: Dict[str, str], execution_count: int, response_includes_details: bool) -> Output:
+    """
+    Construct regular output per response result, without streaming enabled
+    """
+    metadata : Dict[str, str] = {}
+    data = result["generated_text"]
+    if response_includes_details and "details" in result:
+        metadata = {"details": result["details"]}
+
+    output = ExecuteResult(
+        **{
+            "output_type": "execute_result",
+            "data": data,
+            "execution_count": execution_count,
+            "metadata": metadata,
+        }
+    )
+    return output
+
+
+class HuggingFaceTextGenerationTransformer(ParameterizedModelParser):
+    """
+    A model parser for HuggingFace models of type text generation task using transformers.
+    """
+
+    MODEL = "gpt2" #TODO (rossdanlm): Do not use hardcoded model for text generation
+
+    def __init__(self, model_id: Optional[str] = None):
+        """
+        Args:
+            model_id (str): The model name of the model to use.
+
+        Returns:
+            HuggingFaceTextParser: The HuggingFaceTextParser object.
+
+        Usage:
+
+        1. Create a new model parser object with the model ID of the model to use.
+                parser = HuggingFaceTextParser("mistralai/Mistral-7B-Instruct-v0.1")
+        2. Add the model parser to the registry.
+                config.register_model_parser(parser)
+        """
+        super().__init__()
+        self.model_id = model_id
+        self.generator = pipeline('text-generation', model = self.MODEL)
+
+    def id(self) -> str:
+        """
+        Returns an identifier for the Model Parser
+        """
+        return self.model_id or "HuggingFaceTextGenerationTransformer"
+
+    async def serialize(
+        self,
+        prompt_name: str,
+        data: Any,
+        ai_config: "AIConfigRuntime",
+        parameters: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> Prompt:
+        """
+        Defines how a prompt and model inference settings get serialized in the .aiconfig.
+
+        Args:
+            prompt (str): The prompt to be serialized.
+            inference_settings (dict): Model-specific inference settings to be serialized.
+
+        Returns:
+            str: Serialized representation of the prompt and inference settings.
+        """
+        data = copy.deepcopy(data)
+
+        # assume data is completion params for HF text generation
+        prompt_input = data["prompt"]
+
+        # Prompt is handled, remove from data
+        data.pop("prompt", None)
+
+        model_metadata = ai_config.get_model_metadata(data, self.id())
+        prompt = Prompt(
+            name=prompt_name,
+            input=prompt_input,
+            metadata=PromptMetadata(
+                model=model_metadata, parameters=parameters, **kwargs
+            ),
+        )
+        return prompt
+
+    async def deserialize(
+        self,
+        prompt: Prompt,
+        aiconfig: "AIConfigRuntime",
+        _options,
+        params: Optional[Dict[str, Any]] = {},
+    ) -> Dict[str, Any]:
+        """
+        Defines how to parse a prompt in the .aiconfig for a particular model
+        and constructs the completion params for that model.
+
+        Args:
+            serialized_data (str): Serialized data from the .aiconfig.
+
+        Returns:
+            dict: Model-specific completion parameters.
+        """
+        resolved_prompt = resolve_prompt(prompt, params, aiconfig)
+
+        # Build Completion data
+        model_settings = self.get_model_settings(prompt, aiconfig)
+
+        completion_data = refine_chat_completion_params(model_settings)
+
+        completion_data["prompt"] = resolved_prompt
+
+        return completion_data
+
+    async def run_inference(
+        self, prompt: Prompt, aiconfig : "AIConfigRuntime", options, parameters: Dict[str, Any]
+    ) -> List[Output]:
+        """
+        Invoked to run a prompt in the .aiconfig. This method should perform
+        the actual model inference based on the provided prompt and inference settings.
+
+        Args:
+            prompt (str): The input prompt.
+            inference_settings (dict): Model-specific inference settings.
+
+        Returns:
+            InferenceResponse: The response from the model.
+        """
+        completion_data = await self.deserialize(prompt, aiconfig, options, parameters)
+
+        resolved_prompt : str = completion_data["prompt"]
+        response : List[Any] = self.generator(resolved_prompt)
+        outputs : List[Output] = []
+        for count, result in enumerate(response):
+            output = construct_regular_output(result, count, response_includes_details=False)
+            outputs.append(output)
+
+        prompt.outputs = outputs
+        return prompt.outputs
+
+    def get_output_text(
+        self,
+        prompt: Prompt,
+        aiconfig: "AIConfigRuntime",
+        output: Optional[Output] = None,
+    ) -> str:
+        if output is None:
+            output = aiconfig.get_latest_output(prompt)
+
+        if output is None:
+            return ""
+
+        if output.output_type == "execute_result":
+            if isinstance(output.data, str):
+                return output.data
+        else:
+            return ""


### PR DESCRIPTION
[hf parsers][3/n] Add streaming for text generation transformer

Streaming now enabled using the `TextIteratorStreamer` object: https://huggingface.co/docs/transformers/v4.35.2/en/internal/generation_utils#transformers.TextIteratorStreamer

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/348).
* #380
* #379
* #351
* #363
* __->__ #348
* #345
* #344