### PR TITLE
Add Getting Started Tutorial video to cookbook readme

### DIFF
--- a/cookbooks/Getting-Started/README.md
+++ b/cookbooks/Getting-Started/README.md
@@ -10,6 +10,10 @@ Follow the tutorial to get started [here](https://aiconfig.lastmileai.dev/docs/g
 
 ## Resources
 
+Tutorial Video
+
+[![Watch the video](https://img.youtube.com/vi/X_Z-M2ZcpjA/default.jpg)](https://www.youtube.com/watch?v=X_Z-M2ZcpjA)
+
 Tutorial Implementation:
 
 - [Python - Google Colab notebook](https://colab.research.google.com/drive/1aZiEgiPiIDPmy7iD4xPcNw0BBcfC2e1S)


### PR DESCRIPTION
Add Getting Started Tutorial video to cookbook readme

Will also add it to docs and main readme as a follow-up

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/355).
* __->__ #355
* #354