### PR TITLE
new github action on merge for ReadMe Badge

### DIFF
--- a/.github/workflows/main_python.yml
+++ b/.github/workflows/main_python.yml
@@ -1,0 +1,26 @@
+name: Python Tests
+
+# Triggers the workflow on push on main. This is the same as pr_python.yml but does not run on every PR.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Build and Install Library into Package
+        run: |
+          pip install build && cd python && python -m build && pip install dist/*.whl
+      - name: Install Test dependencies
+        run: |
+          cd python && pip install -r requirements-dev.txt
+      - name: Run tests
+        run: |
+          cd python && pytest


### PR DESCRIPTION
new github action for merge


New GithubAction for Python Tests that runs after a pr is merged

## Why

This way we can link the tests_passing badge on readme to main rather than the latest PR
