### PR TITLE
using Add_output to save multiple executions of a prompt

### DIFF
--- a/cookbooks/Chain-of-Verification/Chain_of_Verification_GPT4_Template.ipynb
+++ b/cookbooks/Chain-of-Verification/Chain_of_Verification_GPT4_Template.ipynb
@@ -19,38 +19,53 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "# Install AIConfig package\n",
-        "!pip install python-aiconfig"
-      ],
+      "execution_count": 1,
       "metadata": {
         "id": "k3tsITZhVFp-"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# # Install AIConfig package\n",
+        "# !pip install python-aiconfig"
+      ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
         "id": "51w-3OZC_Z97"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/home/jacobjensen/.pyenv/versions/aiconfig/lib/python3.10/site-packages/pydantic/_internal/_fields.py:149: UserWarning: Field \"model_parsers\" has conflict with protected namespace \"model_\".\n",
+            "\n",
+            "You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.\n",
+            "  warnings.warn(\n",
+            "/home/jacobjensen/.pyenv/versions/aiconfig/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+            "  from .autonotebook import tqdm as notebook_tqdm\n"
+          ]
+        }
+      ],
       "source": [
         "# Import required modules from AIConfig and other dependencies\n",
         "import openai\n",
         "import json\n",
         "import pandas as pd\n",
-        "from google.colab import userdata\n",
         "from aiconfig import AIConfigRuntime, CallbackManager, InferenceOptions\n",
         "\n",
-        "# Use your OpenAI Key\n",
-        "openai.api_key = userdata.get('openai_key')"
+        "# #Set the OpenAI key. The following code is specific for Google Colab\n",
+        "# #We recommend using environment variables for setting the open ai key\n",
+        "# from google.colab import userdata\n",
+        "# openai.api_key = userdata.get('OPENAI_API_KEY')\n",
+        "openai.api_key = open(\"/home/jacobjensen/secrets/openai_api_key.txt\", \"r\").read().strip()"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "metadata": {
         "id": "6cAw1ekXCxGn"
       },
@@ -78,7 +93,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 4,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -88,31 +103,31 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "1. Theodore Roosevelt - 26th President of the United States\n",
             "2. Franklin D. Roosevelt - 32nd President of the United States\n",
             "3. Donald Trump - 45th President of the United States\n",
             "4. Michael Bloomberg - Former Mayor of New York City\n",
             "5. Rudy Giuliani - Former Mayor of New York City\n",
-            "6. Chuck Schumer - U.S. Senator from New York\n",
-            "7. Kirsten Gillibrand - U.S. Senator from New York\n",
-            "8. Alexandria Ocasio-Cortez - U.S. Representative from New York's 14th congressional district\n",
-            "9. Eliot Spitzer - Former Governor of New York\n",
-            "10. Andrew Cuomo - Former Governor of New York\n",
-            "11. Bill de Blasio - Former Mayor of New York City\n",
-            "12. Eric Adams - Current Mayor of New York City\n",
-            "13. Al Sharpton - Civil rights activist and former presidential candidate\n",
-            "14. Geraldine Ferraro - Former U.S. Representative and vice presidential candidate\n",
-            "15. Daniel Patrick Moynihan - Former U.S. Senator from New York."
+            "6. Alexander Hamilton - Founding Father of the United States\n",
+            "7. Eliot Spitzer - Former Governor of New York\n",
+            "8. Chuck Schumer - U.S. Senator from New York\n",
+            "9. Kirsten Gillibrand - U.S. Senator from New York\n",
+            "10. Bill de Blasio - Former Mayor of New York City\n",
+            "11. Andrew Cuomo - Former Governor of New York\n",
+            "12. Eric Schneiderman - Former Attorney General of New York\n",
+            "13. Letitia James - Attorney General of New York\n",
+            "14. David Dinkins - Former Mayor of New York City\n",
+            "15. Adam Clayton Powell Jr. - Former U.S. Representative from New York."
           ]
         }
       ],
       "source": [
         "# TODO: Update baseline_prompt but ensure it is structured in a way that outputs a list of entities where each can be verified.\n",
         "baseline_prompt = \"Name 15 politicians who were born in New York City, New York.\"\n",
-        "# baseline_prompt = \"List 20 programming languages that were developed in the United States. Include the developer name in parantheses.\"\n",
+        "# baseline_prompt = \"List 20 programming languages that were developed in the United States. Include the developer name in parentheses.\"\n",
         "\n",
         "# Run baseline prompt to generate initial response which might contain errors\n",
         "async def run_baseline_prompt(baseline_prompt):\n",
@@ -141,7 +156,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 5,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -151,10 +166,10 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
-            "Al Sharpton was born in Brooklyn, New York, USA."
+            "Al Sharpton was born in Brooklyn, New York, United States."
           ]
         }
       ],
@@ -188,48 +203,48 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 6,
       "metadata": {
-        "id": "QFew6GhONR8X",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "QFew6GhONR8X",
         "outputId": "afd847a2-91b6-4b48-acb9-9209c7be63ab"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
-            "Theodore Roosevelt was born in New York City, New York, USA.\n",
+            "Theodore Roosevelt was born in New York City, New York, United States.\n",
             "\n",
-            "Franklin D. Roosevelt was born in Hyde Park, New York, USA.\n",
+            "Franklin D. Roosevelt was born in Hyde Park, New York, United States.\n",
             "\n",
-            "Donald Trump was born in Queens, New York, USA.\n",
+            "Donald Trump was born in Queens, New York, United States.\n",
             "\n",
-            "Michael Bloomberg was born in Boston, Massachusetts, USA.\n",
+            "Michael Bloomberg was born in Boston, Massachusetts, United States.\n",
             "\n",
-            "Rudy Giuliani was born in Brooklyn, New York, USA.\n",
+            "Rudy Giuliani was born in Brooklyn, New York, United States.\n",
             "\n",
-            "Chuck Schumer was born in Brooklyn, New York, USA.\n",
+            "Alexander Hamilton was born in Charlestown, Nevis, in the British West Indies.\n",
             "\n",
-            "Kirsten Gillibrand was born in Albany, New York, USA.\n",
+            "Eliot Spitzer was born in The Bronx, New York, United States.\n",
             "\n",
-            "Alexandria Ocasio-Cortez was born in The Bronx, New York City, USA.\n",
+            "Chuck Schumer was born in Brooklyn, New York, United States.\n",
             "\n",
-            "Eliot Spitzer was born in The Bronx, New York, USA.\n",
+            "Kirsten Gillibrand was born in Albany, New York, United States.\n",
             "\n",
-            "Andrew Cuomo was born in Queens, New York, USA.\n",
+            "Bill de Blasio was born in Manhattan, New York, United States.\n",
             "\n",
-            "Bill de Blasio was born in Manhattan, New York, USA.\n",
+            "Andrew Cuomo was born in Queens, New York, United States.\n",
             "\n",
-            "Eric Adams was born in Brownsville, Brooklyn, New York, USA.\n",
+            "Eric Schneiderman was born in New York City, New York, United States.\n",
             "\n",
-            "Al Sharpton was born in Brooklyn, New York, USA.\n",
+            "Letitia James was born in Brooklyn, New York, United States.\n",
             "\n",
-            "Geraldine Ferraro was born in Newburgh, New York, USA.\n",
+            "David Dinkins was born in Trenton, New Jersey, United States.\n",
             "\n",
-            "Daniel Patrick Moynihan was born in Tulsa, Oklahoma, USA.\n",
+            "Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.\n",
             "\n"
           ]
         }
@@ -280,7 +295,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -290,27 +305,27 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "### Revised Response \n",
             "1. Theodore Roosevelt - 26th President of the United States\n",
             "2. Donald Trump - 45th President of the United States\n",
             "3. Rudy Giuliani - Former Mayor of New York City\n",
-            "4. Chuck Schumer - U.S. Senator from New York\n",
-            "5. Alexandria Ocasio-Cortez - U.S. Representative from New York's 14th congressional district\n",
-            "6. Eliot Spitzer - Former Governor of New York\n",
+            "4. Eliot Spitzer - Former Governor of New York\n",
+            "5. Chuck Schumer - U.S. Senator from New York\n",
+            "6. Bill de Blasio - Former Mayor of New York City\n",
             "7. Andrew Cuomo - Former Governor of New York\n",
-            "8. Bill de Blasio - Former Mayor of New York City\n",
-            "9. Eric Adams - Current Mayor of New York City\n",
-            "10. Al Sharpton - Civil rights activist and former presidential candidate\n",
+            "8. Eric Schneiderman - Former Attorney General of New York\n",
+            "9. Letitia James - Attorney General of New York\n",
             "\n",
             "### Failed Entities \n",
-            "1. Franklin D. Roosevelt - Born in Hyde Park, New York, not New York City.\n",
-            "2. Michael Bloomberg - Born in Boston, Massachusetts, not New York City.\n",
-            "3. Kirsten Gillibrand - Born in Albany, New York, not New York City.\n",
-            "4. Geraldine Ferraro - Born in Newburgh, New York, not New York City.\n",
-            "5. Daniel Patrick Moynihan - Born in Tulsa, Oklahoma, not New York City."
+            "1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\n",
+            "2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\n",
+            "3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\n",
+            "4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\n",
+            "5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\n",
+            "6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City."
           ]
         }
       ],
@@ -319,6 +334,91 @@
         "params = {\"verification_results\": verification_data}\n",
         "revised_response = await config.run(\"final_response_gen\", params, options=inference_options)"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'name': 'Chain-of-Verification (CoVe)  Template',\n",
+              " 'schema_version': 'latest',\n",
+              " 'metadata': ConfigMetadata(parameters={'baseline_prompt': 'Name 15 politicians who were born in New York City, New York.', 'verification_question': 'Where was {{entity}} born?'}, models={'gpt-4': {'model': 'gpt-4', 'top_p': 1, 'temperature': 0, 'presence_penalty': 0, 'frequency_penalty': 0}}, default_model=None, model_parsers=None),\n",
+              " 'description': '',\n",
+              " 'prompts': [Prompt(name='baseline_response_gen', input='{{baseline_prompt}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': ''}), tags=None, parameters={}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '1. Theodore Roosevelt - 26th President of the United States\\n2. Franklin D. Roosevelt - 32nd President of the United States\\n3. Donald Trump - 45th President of the United States\\n4. Michael Bloomberg - Former Mayor of New York City\\n5. Rudy Giuliani - Former Mayor of New York City\\n6. Alexander Hamilton - Founding Father of the United States\\n7. Eliot Spitzer - Former Governor of New York\\n8. Chuck Schumer - U.S. Senator from New York\\n9. Kirsten Gillibrand - U.S. Senator from New York\\n10. Bill de Blasio - Former Mayor of New York City\\n11. Andrew Cuomo - Former Governor of New York\\n12. Eric Schneiderman - Former Attorney General of New York\\n13. Letitia James - Attorney General of New York\\n14. David Dinkins - Former Mayor of New York City\\n15. Adam Clayton Powell Jr. - Former U.S. Representative from New York.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '1. Theodore Roosevelt - 26th President of the United States\\n2. Franklin D. Roosevelt - 32nd President of the United States\\n3. Donald Trump - 45th President of the United States\\n4. Michael Bloomberg - Former Mayor of New York City\\n5. Rudy Giuliani - Former Mayor of New York City\\n6. Alexander Hamilton - Founding Father of the United States\\n7. Eliot Spitzer - Former Governor of New York\\n8. Chuck Schumer - U.S. Senator from New York\\n9. Kirsten Gillibrand - U.S. Senator from New York\\n10. Bill de Blasio - Former Mayor of New York City\\n11. Andrew Cuomo - Former Governor of New York\\n12. Eric Schneiderman - Former Attorney General of New York\\n13. Letitia James - Attorney General of New York\\n14. David Dinkins - Former Mayor of New York City\\n15. Adam Clayton Powell Jr. - Former U.S. Representative from New York.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})]),\n",
+              "  Prompt(name='verification', input='{{verification_question}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': '{{entity}}'}), tags=None, parameters={'entity': 'George Pataki'}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Al Sharpton was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Theodore Roosevelt was born in New York City, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Franklin D. Roosevelt was born in Hyde Park, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Donald Trump was born in Queens, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Michael Bloomberg was born in Boston, Massachusetts, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Rudy Giuliani was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Alexander Hamilton was born in Charlestown, Nevis, in the British West Indies.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Eliot Spitzer was born in The Bronx, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Chuck Schumer was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Kirsten Gillibrand was born in Albany, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Bill de Blasio was born in Manhattan, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Andrew Cuomo was born in Queens, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Eric Schneiderman was born in New York City, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Letitia James was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'David Dinkins was born in Trenton, New Jersey, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})]),\n",
+              "  Prompt(name='final_response_gen', input='Cross-check the provided list of verification data with the original baseline response that is supposed to accurately answer the baseline prompt. \\n\\nBaseline prompt: {{baseline_prompt}} \\nBaseline response: {{baseline_response_gen.output}}\\nVerification data: {{verification_results}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': 'For each entity from the baseline response, verify that the entity met the criteria asked for in the baseline prompt based on the verification data. \\n\\nOutput Format: \\n\\n### Revised Response \\nThis is the revised response after running chain-of-verification. \\n(Please output the revised response after the cross-check.)\\n\\n### Failed Entities \\nThese are the entities that failed the cross-check and are no longer included in revised response. \\n(List the entities that failed the cross-check with a concise reason why)'}), tags=None, parameters={'verification_results': 'Theodore Roosevelt was born in New York City, New York on October 27, 1858. Franklin D. Roosevelt was born in Hyde Park, New York on January 30, 1882. Alexander Hamilton was born in Charlestown, Nevis on January 11, 1755. John Jay was born in New York City, New York on December 12, 1745. DeWitt Clinton was born in Little Britain, New York on March 2, 1769. William H. Seward was born in Florida, New York on May 16, 1801. Charles Evans Hughes was born in Glens Falls, New York on April 11, 1862. Nelson Rockefeller was born in Bar Harbor, Maine on July 8, 1908. Robert F. Wagner Jr. was born in Manhattan, New York on April 20, 1910. Bella Abzug was born in New York City, New York on July 24, 1920. Shirley Chisholm was born in Brooklyn, New York on November 30, 1924. Geraldine Ferraro was born in Newburgh, New York on August 26, 1935. Eliot Spitzer was born in The Bronx, New York on June 10, 1959. Michael Bloomberg was born in Boston, Massachusetts on February 14, 1942. Andrew Cuomo was born in New York City, New York on December 6, 1957. Bill de Blasio was born in Manhattan, New York on May 8, 1961. Charles Rangel was born in Harlem, New York City on June 11, 1930. Daniel Patrick Moynihan was born in Tulsa, Oklahoma on March 16, 1927. Jacob Javits was born in New York City, New York on May 18, 1904. Al Smith was born in New York City, New York on December 30, 1873. Rudy Giuliani was born in Brooklyn, New York on May 28, 1944. George Pataki was born in Peekskill, New York on June 24, 1945. Kirsten Gillibrand was born in Albany, New York on December 9, 1966. Chuck Schumer was born in Brooklyn, New York on November 23, 1950. Alexandria Ocasio-Cortez was born in The Bronx, New York City, New York on October 13, 1989.'}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '### Revised Response \\n1. Theodore Roosevelt - 26th President of the United States\\n2. Donald Trump - 45th President of the United States\\n3. Rudy Giuliani - Former Mayor of New York City\\n4. Eliot Spitzer - Former Governor of New York\\n5. Chuck Schumer - U.S. Senator from New York\\n6. Bill de Blasio - Former Mayor of New York City\\n7. Andrew Cuomo - Former Governor of New York\\n8. Eric Schneiderman - Former Attorney General of New York\\n9. Letitia James - Attorney General of New York\\n\\n### Failed Entities \\n1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\\n2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\\n3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\\n4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\\n5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\\n6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '### Revised Response \\n1. Theodore Roosevelt - 26th President of the United States\\n2. Donald Trump - 45th President of the United States\\n3. Rudy Giuliani - Former Mayor of New York City\\n4. Eliot Spitzer - Former Governor of New York\\n5. Chuck Schumer - U.S. Senator from New York\\n6. Bill de Blasio - Former Mayor of New York City\\n7. Andrew Cuomo - Former Governor of New York\\n8. Eric Schneiderman - Former Attorney General of New York\\n9. Letitia James - Attorney General of New York\\n\\n### Failed Entities \\n1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\\n2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\\n3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\\n4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\\n5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\\n6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})])],\n",
+              " 'prompt_index': {'baseline_response_gen': Prompt(name='baseline_response_gen', input='{{baseline_prompt}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': ''}), tags=None, parameters={}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '1. Theodore Roosevelt - 26th President of the United States\\n2. Franklin D. Roosevelt - 32nd President of the United States\\n3. Donald Trump - 45th President of the United States\\n4. Michael Bloomberg - Former Mayor of New York City\\n5. Rudy Giuliani - Former Mayor of New York City\\n6. Alexander Hamilton - Founding Father of the United States\\n7. Eliot Spitzer - Former Governor of New York\\n8. Chuck Schumer - U.S. Senator from New York\\n9. Kirsten Gillibrand - U.S. Senator from New York\\n10. Bill de Blasio - Former Mayor of New York City\\n11. Andrew Cuomo - Former Governor of New York\\n12. Eric Schneiderman - Former Attorney General of New York\\n13. Letitia James - Attorney General of New York\\n14. David Dinkins - Former Mayor of New York City\\n15. Adam Clayton Powell Jr. - Former U.S. Representative from New York.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '1. Theodore Roosevelt - 26th President of the United States\\n2. Franklin D. Roosevelt - 32nd President of the United States\\n3. Donald Trump - 45th President of the United States\\n4. Michael Bloomberg - Former Mayor of New York City\\n5. Rudy Giuliani - Former Mayor of New York City\\n6. Alexander Hamilton - Founding Father of the United States\\n7. Eliot Spitzer - Former Governor of New York\\n8. Chuck Schumer - U.S. Senator from New York\\n9. Kirsten Gillibrand - U.S. Senator from New York\\n10. Bill de Blasio - Former Mayor of New York City\\n11. Andrew Cuomo - Former Governor of New York\\n12. Eric Schneiderman - Former Attorney General of New York\\n13. Letitia James - Attorney General of New York\\n14. David Dinkins - Former Mayor of New York City\\n15. Adam Clayton Powell Jr. - Former U.S. Representative from New York.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})]),\n",
+              "  'verification': Prompt(name='verification', input='{{verification_question}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': '{{entity}}'}), tags=None, parameters={'entity': 'George Pataki'}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Al Sharpton was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Theodore Roosevelt was born in New York City, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Franklin D. Roosevelt was born in Hyde Park, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Donald Trump was born in Queens, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Michael Bloomberg was born in Boston, Massachusetts, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Rudy Giuliani was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Alexander Hamilton was born in Charlestown, Nevis, in the British West Indies.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Eliot Spitzer was born in The Bronx, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Chuck Schumer was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Kirsten Gillibrand was born in Albany, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Bill de Blasio was born in Manhattan, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Andrew Cuomo was born in Queens, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Eric Schneiderman was born in New York City, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Letitia James was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'David Dinkins was born in Trenton, New Jersey, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})]),\n",
+              "  'final_response_gen': Prompt(name='final_response_gen', input='Cross-check the provided list of verification data with the original baseline response that is supposed to accurately answer the baseline prompt. \\n\\nBaseline prompt: {{baseline_prompt}} \\nBaseline response: {{baseline_response_gen.output}}\\nVerification data: {{verification_results}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': 'For each entity from the baseline response, verify that the entity met the criteria asked for in the baseline prompt based on the verification data. \\n\\nOutput Format: \\n\\n### Revised Response \\nThis is the revised response after running chain-of-verification. \\n(Please output the revised response after the cross-check.)\\n\\n### Failed Entities \\nThese are the entities that failed the cross-check and are no longer included in revised response. \\n(List the entities that failed the cross-check with a concise reason why)'}), tags=None, parameters={'verification_results': 'Theodore Roosevelt was born in New York City, New York on October 27, 1858. Franklin D. Roosevelt was born in Hyde Park, New York on January 30, 1882. Alexander Hamilton was born in Charlestown, Nevis on January 11, 1755. John Jay was born in New York City, New York on December 12, 1745. DeWitt Clinton was born in Little Britain, New York on March 2, 1769. William H. Seward was born in Florida, New York on May 16, 1801. Charles Evans Hughes was born in Glens Falls, New York on April 11, 1862. Nelson Rockefeller was born in Bar Harbor, Maine on July 8, 1908. Robert F. Wagner Jr. was born in Manhattan, New York on April 20, 1910. Bella Abzug was born in New York City, New York on July 24, 1920. Shirley Chisholm was born in Brooklyn, New York on November 30, 1924. Geraldine Ferraro was born in Newburgh, New York on August 26, 1935. Eliot Spitzer was born in The Bronx, New York on June 10, 1959. Michael Bloomberg was born in Boston, Massachusetts on February 14, 1942. Andrew Cuomo was born in New York City, New York on December 6, 1957. Bill de Blasio was born in Manhattan, New York on May 8, 1961. Charles Rangel was born in Harlem, New York City on June 11, 1930. Daniel Patrick Moynihan was born in Tulsa, Oklahoma on March 16, 1927. Jacob Javits was born in New York City, New York on May 18, 1904. Al Smith was born in New York City, New York on December 30, 1873. Rudy Giuliani was born in Brooklyn, New York on May 28, 1944. George Pataki was born in Peekskill, New York on June 24, 1945. Kirsten Gillibrand was born in Albany, New York on December 9, 1966. Chuck Schumer was born in Brooklyn, New York on November 23, 1950. Alexandria Ocasio-Cortez was born in The Bronx, New York City, New York on October 13, 1989.'}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '### Revised Response \\n1. Theodore Roosevelt - 26th President of the United States\\n2. Donald Trump - 45th President of the United States\\n3. Rudy Giuliani - Former Mayor of New York City\\n4. Eliot Spitzer - Former Governor of New York\\n5. Chuck Schumer - U.S. Senator from New York\\n6. Bill de Blasio - Former Mayor of New York City\\n7. Andrew Cuomo - Former Governor of New York\\n8. Eric Schneiderman - Former Attorney General of New York\\n9. Letitia James - Attorney General of New York\\n\\n### Failed Entities \\n1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\\n2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\\n3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\\n4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\\n5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\\n6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '### Revised Response \\n1. Theodore Roosevelt - 26th President of the United States\\n2. Donald Trump - 45th President of the United States\\n3. Rudy Giuliani - Former Mayor of New York City\\n4. Eliot Spitzer - Former Governor of New York\\n5. Chuck Schumer - U.S. Senator from New York\\n6. Bill de Blasio - Former Mayor of New York City\\n7. Andrew Cuomo - Former Governor of New York\\n8. Eric Schneiderman - Former Attorney General of New York\\n9. Letitia James - Attorney General of New York\\n\\n### Failed Entities \\n1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\\n2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\\n3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\\n4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\\n5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\\n6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})])}}"
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "config.__dict__"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "17"
+            ]
+          },
+          "execution_count": 9,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "len(config.prompts[1].outputs)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "AIConfigRuntime(name='Chain-of-Verification (CoVe)  Template', schema_version='latest', metadata=ConfigMetadata(parameters={'baseline_prompt': 'Name 15 politicians who were born in New York City, New York.', 'verification_question': 'Where was {{entity}} born?'}, models={'gpt-4': {'model': 'gpt-4', 'top_p': 1, 'temperature': 0, 'presence_penalty': 0, 'frequency_penalty': 0}}, default_model=None, model_parsers=None), description='', prompts=[Prompt(name='baseline_response_gen', input='{{baseline_prompt}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': ''}), tags=None, parameters={}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '1. Theodore Roosevelt - 26th President of the United States\\n2. Franklin D. Roosevelt - 32nd President of the United States\\n3. Donald Trump - 45th President of the United States\\n4. Michael Bloomberg - Former Mayor of New York City\\n5. Rudy Giuliani - Former Mayor of New York City\\n6. Alexander Hamilton - Founding Father of the United States\\n7. Eliot Spitzer - Former Governor of New York\\n8. Chuck Schumer - U.S. Senator from New York\\n9. Kirsten Gillibrand - U.S. Senator from New York\\n10. Bill de Blasio - Former Mayor of New York City\\n11. Andrew Cuomo - Former Governor of New York\\n12. Eric Schneiderman - Former Attorney General of New York\\n13. Letitia James - Attorney General of New York\\n14. David Dinkins - Former Mayor of New York City\\n15. Adam Clayton Powell Jr. - Former U.S. Representative from New York.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '1. Theodore Roosevelt - 26th President of the United States\\n2. Franklin D. Roosevelt - 32nd President of the United States\\n3. Donald Trump - 45th President of the United States\\n4. Michael Bloomberg - Former Mayor of New York City\\n5. Rudy Giuliani - Former Mayor of New York City\\n6. Alexander Hamilton - Founding Father of the United States\\n7. Eliot Spitzer - Former Governor of New York\\n8. Chuck Schumer - U.S. Senator from New York\\n9. Kirsten Gillibrand - U.S. Senator from New York\\n10. Bill de Blasio - Former Mayor of New York City\\n11. Andrew Cuomo - Former Governor of New York\\n12. Eric Schneiderman - Former Attorney General of New York\\n13. Letitia James - Attorney General of New York\\n14. David Dinkins - Former Mayor of New York City\\n15. Adam Clayton Powell Jr. - Former U.S. Representative from New York.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})]), Prompt(name='verification', input='{{verification_question}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': '{{entity}}'}), tags=None, parameters={'entity': 'George Pataki'}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Al Sharpton was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Theodore Roosevelt was born in New York City, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Franklin D. Roosevelt was born in Hyde Park, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Donald Trump was born in Queens, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Michael Bloomberg was born in Boston, Massachusetts, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Rudy Giuliani was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Alexander Hamilton was born in Charlestown, Nevis, in the British West Indies.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Eliot Spitzer was born in The Bronx, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Chuck Schumer was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Kirsten Gillibrand was born in Albany, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Bill de Blasio was born in Manhattan, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Andrew Cuomo was born in Queens, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Eric Schneiderman was born in New York City, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Letitia James was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'David Dinkins was born in Trenton, New Jersey, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})]), Prompt(name='final_response_gen', input='Cross-check the provided list of verification data with the original baseline response that is supposed to accurately answer the baseline prompt. \\n\\nBaseline prompt: {{baseline_prompt}} \\nBaseline response: {{baseline_response_gen.output}}\\nVerification data: {{verification_results}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': 'For each entity from the baseline response, verify that the entity met the criteria asked for in the baseline prompt based on the verification data. \\n\\nOutput Format: \\n\\n### Revised Response \\nThis is the revised response after running chain-of-verification. \\n(Please output the revised response after the cross-check.)\\n\\n### Failed Entities \\nThese are the entities that failed the cross-check and are no longer included in revised response. \\n(List the entities that failed the cross-check with a concise reason why)'}), tags=None, parameters={'verification_results': 'Theodore Roosevelt was born in New York City, New York on October 27, 1858. Franklin D. Roosevelt was born in Hyde Park, New York on January 30, 1882. Alexander Hamilton was born in Charlestown, Nevis on January 11, 1755. John Jay was born in New York City, New York on December 12, 1745. DeWitt Clinton was born in Little Britain, New York on March 2, 1769. William H. Seward was born in Florida, New York on May 16, 1801. Charles Evans Hughes was born in Glens Falls, New York on April 11, 1862. Nelson Rockefeller was born in Bar Harbor, Maine on July 8, 1908. Robert F. Wagner Jr. was born in Manhattan, New York on April 20, 1910. Bella Abzug was born in New York City, New York on July 24, 1920. Shirley Chisholm was born in Brooklyn, New York on November 30, 1924. Geraldine Ferraro was born in Newburgh, New York on August 26, 1935. Eliot Spitzer was born in The Bronx, New York on June 10, 1959. Michael Bloomberg was born in Boston, Massachusetts on February 14, 1942. Andrew Cuomo was born in New York City, New York on December 6, 1957. Bill de Blasio was born in Manhattan, New York on May 8, 1961. Charles Rangel was born in Harlem, New York City on June 11, 1930. Daniel Patrick Moynihan was born in Tulsa, Oklahoma on March 16, 1927. Jacob Javits was born in New York City, New York on May 18, 1904. Al Smith was born in New York City, New York on December 30, 1873. Rudy Giuliani was born in Brooklyn, New York on May 28, 1944. George Pataki was born in Peekskill, New York on June 24, 1945. Kirsten Gillibrand was born in Albany, New York on December 9, 1966. Chuck Schumer was born in Brooklyn, New York on November 23, 1950. Alexandria Ocasio-Cortez was born in The Bronx, New York City, New York on October 13, 1989.'}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '### Revised Response \\n1. Theodore Roosevelt - 26th President of the United States\\n2. Donald Trump - 45th President of the United States\\n3. Rudy Giuliani - Former Mayor of New York City\\n4. Eliot Spitzer - Former Governor of New York\\n5. Chuck Schumer - U.S. Senator from New York\\n6. Bill de Blasio - Former Mayor of New York City\\n7. Andrew Cuomo - Former Governor of New York\\n8. Eric Schneiderman - Former Attorney General of New York\\n9. Letitia James - Attorney General of New York\\n\\n### Failed Entities \\n1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\\n2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\\n3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\\n4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\\n5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\\n6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '### Revised Response \\n1. Theodore Roosevelt - 26th President of the United States\\n2. Donald Trump - 45th President of the United States\\n3. Rudy Giuliani - Former Mayor of New York City\\n4. Eliot Spitzer - Former Governor of New York\\n5. Chuck Schumer - U.S. Senator from New York\\n6. Bill de Blasio - Former Mayor of New York City\\n7. Andrew Cuomo - Former Governor of New York\\n8. Eric Schneiderman - Former Attorney General of New York\\n9. Letitia James - Attorney General of New York\\n\\n### Failed Entities \\n1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\\n2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\\n3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\\n4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\\n5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\\n6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})])], prompt_index={'baseline_response_gen': Prompt(name='baseline_response_gen', input='{{baseline_prompt}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': ''}), tags=None, parameters={}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '1. Theodore Roosevelt - 26th President of the United States\\n2. Franklin D. Roosevelt - 32nd President of the United States\\n3. Donald Trump - 45th President of the United States\\n4. Michael Bloomberg - Former Mayor of New York City\\n5. Rudy Giuliani - Former Mayor of New York City\\n6. Alexander Hamilton - Founding Father of the United States\\n7. Eliot Spitzer - Former Governor of New York\\n8. Chuck Schumer - U.S. Senator from New York\\n9. Kirsten Gillibrand - U.S. Senator from New York\\n10. Bill de Blasio - Former Mayor of New York City\\n11. Andrew Cuomo - Former Governor of New York\\n12. Eric Schneiderman - Former Attorney General of New York\\n13. Letitia James - Attorney General of New York\\n14. David Dinkins - Former Mayor of New York City\\n15. Adam Clayton Powell Jr. - Former U.S. Representative from New York.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '1. Theodore Roosevelt - 26th President of the United States\\n2. Franklin D. Roosevelt - 32nd President of the United States\\n3. Donald Trump - 45th President of the United States\\n4. Michael Bloomberg - Former Mayor of New York City\\n5. Rudy Giuliani - Former Mayor of New York City\\n6. Alexander Hamilton - Founding Father of the United States\\n7. Eliot Spitzer - Former Governor of New York\\n8. Chuck Schumer - U.S. Senator from New York\\n9. Kirsten Gillibrand - U.S. Senator from New York\\n10. Bill de Blasio - Former Mayor of New York City\\n11. Andrew Cuomo - Former Governor of New York\\n12. Eric Schneiderman - Former Attorney General of New York\\n13. Letitia James - Attorney General of New York\\n14. David Dinkins - Former Mayor of New York City\\n15. Adam Clayton Powell Jr. - Former U.S. Representative from New York.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})]), 'verification': Prompt(name='verification', input='{{verification_question}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': '{{entity}}'}), tags=None, parameters={'entity': 'George Pataki'}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Al Sharpton was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Theodore Roosevelt was born in New York City, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Franklin D. Roosevelt was born in Hyde Park, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Donald Trump was born in Queens, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Michael Bloomberg was born in Boston, Massachusetts, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Rudy Giuliani was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Alexander Hamilton was born in Charlestown, Nevis, in the British West Indies.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Eliot Spitzer was born in The Bronx, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Chuck Schumer was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Kirsten Gillibrand was born in Albany, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Bill de Blasio was born in Manhattan, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Andrew Cuomo was born in Queens, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Eric Schneiderman was born in New York City, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Letitia James was born in Brooklyn, New York, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'David Dinkins was born in Trenton, New Jersey, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})]), 'final_response_gen': Prompt(name='final_response_gen', input='Cross-check the provided list of verification data with the original baseline response that is supposed to accurately answer the baseline prompt. \\n\\nBaseline prompt: {{baseline_prompt}} \\nBaseline response: {{baseline_response_gen.output}}\\nVerification data: {{verification_results}}', metadata=PromptMetadata(model=ModelMetadata(name='gpt-4', settings={'system_prompt': 'For each entity from the baseline response, verify that the entity met the criteria asked for in the baseline prompt based on the verification data. \\n\\nOutput Format: \\n\\n### Revised Response \\nThis is the revised response after running chain-of-verification. \\n(Please output the revised response after the cross-check.)\\n\\n### Failed Entities \\nThese are the entities that failed the cross-check and are no longer included in revised response. \\n(List the entities that failed the cross-check with a concise reason why)'}), tags=None, parameters={'verification_results': 'Theodore Roosevelt was born in New York City, New York on October 27, 1858. Franklin D. Roosevelt was born in Hyde Park, New York on January 30, 1882. Alexander Hamilton was born in Charlestown, Nevis on January 11, 1755. John Jay was born in New York City, New York on December 12, 1745. DeWitt Clinton was born in Little Britain, New York on March 2, 1769. William H. Seward was born in Florida, New York on May 16, 1801. Charles Evans Hughes was born in Glens Falls, New York on April 11, 1862. Nelson Rockefeller was born in Bar Harbor, Maine on July 8, 1908. Robert F. Wagner Jr. was born in Manhattan, New York on April 20, 1910. Bella Abzug was born in New York City, New York on July 24, 1920. Shirley Chisholm was born in Brooklyn, New York on November 30, 1924. Geraldine Ferraro was born in Newburgh, New York on August 26, 1935. Eliot Spitzer was born in The Bronx, New York on June 10, 1959. Michael Bloomberg was born in Boston, Massachusetts on February 14, 1942. Andrew Cuomo was born in New York City, New York on December 6, 1957. Bill de Blasio was born in Manhattan, New York on May 8, 1961. Charles Rangel was born in Harlem, New York City on June 11, 1930. Daniel Patrick Moynihan was born in Tulsa, Oklahoma on March 16, 1927. Jacob Javits was born in New York City, New York on May 18, 1904. Al Smith was born in New York City, New York on December 30, 1873. Rudy Giuliani was born in Brooklyn, New York on May 28, 1944. George Pataki was born in Peekskill, New York on June 24, 1945. Kirsten Gillibrand was born in Albany, New York on December 9, 1966. Chuck Schumer was born in Brooklyn, New York on November 23, 1950. Alexandria Ocasio-Cortez was born in The Bronx, New York City, New York on October 13, 1989.'}, remember_chat_context=False), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '### Revised Response \\n1. Theodore Roosevelt - 26th President of the United States\\n2. Donald Trump - 45th President of the United States\\n3. Rudy Giuliani - Former Mayor of New York City\\n4. Eliot Spitzer - Former Governor of New York\\n5. Chuck Schumer - U.S. Senator from New York\\n6. Bill de Blasio - Former Mayor of New York City\\n7. Andrew Cuomo - Former Governor of New York\\n8. Eric Schneiderman - Former Attorney General of New York\\n9. Letitia James - Attorney General of New York\\n\\n### Failed Entities \\n1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\\n2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\\n3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\\n4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\\n5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\\n6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'}), ExecuteResult(output_type='execute_result', execution_count=0, data={'content': '### Revised Response \\n1. Theodore Roosevelt - 26th President of the United States\\n2. Donald Trump - 45th President of the United States\\n3. Rudy Giuliani - Former Mayor of New York City\\n4. Eliot Spitzer - Former Governor of New York\\n5. Chuck Schumer - U.S. Senator from New York\\n6. Bill de Blasio - Former Mayor of New York City\\n7. Andrew Cuomo - Former Governor of New York\\n8. Eric Schneiderman - Former Attorney General of New York\\n9. Letitia James - Attorney General of New York\\n\\n### Failed Entities \\n1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\\n2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\\n3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\\n4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\\n5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\\n6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City.', 'role': 'assistant'}, mime_type=None, metadata={'finish_reason': 'stop'})])}, file_path='cove_template_config.json', callback_manager=<aiconfig.callback.CallbackManager object at 0x7fa41428afb0>)"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "config"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "config.save()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
     }
   ],
   "metadata": {
@@ -330,7 +430,16 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.12"
     }
   },
   "nbformat": 4,

--- a/cookbooks/Chain-of-Verification/cove_template_config.json
+++ b/cookbooks/Chain-of-Verification/cove_template_config.json
@@ -2,6 +2,10 @@
   "name": "Chain-of-Verification (CoVe)  Template",
   "schema_version": "latest",
   "metadata": {
+    "parameters": {
+      "baseline_prompt": "Name 15 politicians who were born in New York City, New York.",
+      "verification_question": "Where was {{entity}} born?"
+    },
     "models": {
       "gpt-4": {
         "model": "gpt-4",
@@ -10,12 +14,9 @@
         "presence_penalty": 0,
         "frequency_penalty": 0
       }
-    },
-    "parameters": {
-      "baseline_prompt": "Name 25 politicians who were born in New York City, New York. ",
-      "verification_question": "Where was {{entity}} born? "
     }
   },
+  "description": "",
   "prompts": [
     {
       "name": "baseline_response_gen",
@@ -29,7 +30,31 @@
         },
         "parameters": {},
         "remember_chat_context": false
-      }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "1. Theodore Roosevelt - 26th President of the United States\n2. Franklin D. Roosevelt - 32nd President of the United States\n3. Donald Trump - 45th President of the United States\n4. Michael Bloomberg - Former Mayor of New York City\n5. Rudy Giuliani - Former Mayor of New York City\n6. Alexander Hamilton - Founding Father of the United States\n7. Eliot Spitzer - Former Governor of New York\n8. Chuck Schumer - U.S. Senator from New York\n9. Kirsten Gillibrand - U.S. Senator from New York\n10. Bill de Blasio - Former Mayor of New York City\n11. Andrew Cuomo - Former Governor of New York\n12. Eric Schneiderman - Former Attorney General of New York\n13. Letitia James - Attorney General of New York\n14. David Dinkins - Former Mayor of New York City\n15. Adam Clayton Powell Jr. - Former U.S. Representative from New York.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "1. Theodore Roosevelt - 26th President of the United States\n2. Franklin D. Roosevelt - 32nd President of the United States\n3. Donald Trump - 45th President of the United States\n4. Michael Bloomberg - Former Mayor of New York City\n5. Rudy Giuliani - Former Mayor of New York City\n6. Alexander Hamilton - Founding Father of the United States\n7. Eliot Spitzer - Former Governor of New York\n8. Chuck Schumer - U.S. Senator from New York\n9. Kirsten Gillibrand - U.S. Senator from New York\n10. Bill de Blasio - Former Mayor of New York City\n11. Andrew Cuomo - Former Governor of New York\n12. Eric Schneiderman - Former Attorney General of New York\n13. Letitia James - Attorney General of New York\n14. David Dinkins - Former Mayor of New York City\n15. Adam Clayton Powell Jr. - Former U.S. Representative from New York.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        }
+      ]
     },
     {
       "name": "verification",
@@ -45,7 +70,196 @@
           "entity": "George Pataki"
         },
         "remember_chat_context": false
-      }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Al Sharpton was born in Brooklyn, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Theodore Roosevelt was born in New York City, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Franklin D. Roosevelt was born in Hyde Park, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Donald Trump was born in Queens, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Michael Bloomberg was born in Boston, Massachusetts, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Rudy Giuliani was born in Brooklyn, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Alexander Hamilton was born in Charlestown, Nevis, in the British West Indies.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Eliot Spitzer was born in The Bronx, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Chuck Schumer was born in Brooklyn, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Kirsten Gillibrand was born in Albany, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Bill de Blasio was born in Manhattan, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Andrew Cuomo was born in Queens, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Eric Schneiderman was born in New York City, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Letitia James was born in Brooklyn, New York, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "David Dinkins was born in Trenton, New Jersey, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "Adam Clayton Powell Jr. was born in New Haven, Connecticut, United States.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        }
+      ]
     },
     {
       "name": "final_response_gen",
@@ -61,7 +275,31 @@
           "verification_results": "Theodore Roosevelt was born in New York City, New York on October 27, 1858. Franklin D. Roosevelt was born in Hyde Park, New York on January 30, 1882. Alexander Hamilton was born in Charlestown, Nevis on January 11, 1755. John Jay was born in New York City, New York on December 12, 1745. DeWitt Clinton was born in Little Britain, New York on March 2, 1769. William H. Seward was born in Florida, New York on May 16, 1801. Charles Evans Hughes was born in Glens Falls, New York on April 11, 1862. Nelson Rockefeller was born in Bar Harbor, Maine on July 8, 1908. Robert F. Wagner Jr. was born in Manhattan, New York on April 20, 1910. Bella Abzug was born in New York City, New York on July 24, 1920. Shirley Chisholm was born in Brooklyn, New York on November 30, 1924. Geraldine Ferraro was born in Newburgh, New York on August 26, 1935. Eliot Spitzer was born in The Bronx, New York on June 10, 1959. Michael Bloomberg was born in Boston, Massachusetts on February 14, 1942. Andrew Cuomo was born in New York City, New York on December 6, 1957. Bill de Blasio was born in Manhattan, New York on May 8, 1961. Charles Rangel was born in Harlem, New York City on June 11, 1930. Daniel Patrick Moynihan was born in Tulsa, Oklahoma on March 16, 1927. Jacob Javits was born in New York City, New York on May 18, 1904. Al Smith was born in New York City, New York on December 30, 1873. Rudy Giuliani was born in Brooklyn, New York on May 28, 1944. George Pataki was born in Peekskill, New York on June 24, 1945. Kirsten Gillibrand was born in Albany, New York on December 9, 1966. Chuck Schumer was born in Brooklyn, New York on November 23, 1950. Alexandria Ocasio-Cortez was born in The Bronx, New York City, New York on October 13, 1989."
         },
         "remember_chat_context": false
-      }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "### Revised Response \n1. Theodore Roosevelt - 26th President of the United States\n2. Donald Trump - 45th President of the United States\n3. Rudy Giuliani - Former Mayor of New York City\n4. Eliot Spitzer - Former Governor of New York\n5. Chuck Schumer - U.S. Senator from New York\n6. Bill de Blasio - Former Mayor of New York City\n7. Andrew Cuomo - Former Governor of New York\n8. Eric Schneiderman - Former Attorney General of New York\n9. Letitia James - Attorney General of New York\n\n### Failed Entities \n1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\n2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\n3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\n4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\n5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\n6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "### Revised Response \n1. Theodore Roosevelt - 26th President of the United States\n2. Donald Trump - 45th President of the United States\n3. Rudy Giuliani - Former Mayor of New York City\n4. Eliot Spitzer - Former Governor of New York\n5. Chuck Schumer - U.S. Senator from New York\n6. Bill de Blasio - Former Mayor of New York City\n7. Andrew Cuomo - Former Governor of New York\n8. Eric Schneiderman - Former Attorney General of New York\n9. Letitia James - Attorney General of New York\n\n### Failed Entities \n1. Franklin D. Roosevelt - He was born in Hyde Park, New York, not New York City.\n2. Michael Bloomberg - He was born in Boston, Massachusetts, not New York City.\n3. Alexander Hamilton - He was born in Charlestown, Nevis, in the British West Indies, not New York City.\n4. Kirsten Gillibrand - She was born in Albany, New York, not New York City.\n5. David Dinkins - He was born in Trenton, New Jersey, not New York City.\n6. Adam Clayton Powell Jr. - He was born in New Haven, Connecticut, not New York City.",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        }
+      ]
     }
   ]
 }

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -313,8 +313,12 @@ class OpenAIInference(ParameterizedModelParser):
                     outputs[index] = output
             outputs = [outputs[i] for i in sorted(list(outputs.keys()))]
 
-        # rewrite or extend list of outputs?
-        prompt.outputs = outputs
+        # # rewrite or extend list of outputs?
+        # prompt.outputs = outputs
+
+        # Append new output to prompt's outputs list
+        for output in outputs:
+            prompt.add_output(output) 
 
         await aiconfig.callback_manager.run_callbacks(
             CallbackEvent("on_run_complete", __name__, {"result": prompt.outputs})


### PR DESCRIPTION
A sketch of multiple outputs, using the currently-unused `add_output` method of the `Prompt` class.

Accompanying issue describes the applications

See https://github.com/lastmile-ai/aiconfig/issues/373 