### PR TITLE
Add README and LICENSE within the python extension dir

### DIFF
--- a/extensions/HuggingFaceTransformers/python/LICENSE
+++ b/extensions/HuggingFaceTransformers/python/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2023 LastMile AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/HuggingFaceTransformers/python/README.md
+++ b/extensions/HuggingFaceTransformers/python/README.md
@@ -1,0 +1,19 @@
+# Using HuggingFace transformers for model parsing with AIConfig
+
+We are prioritizing the Python library so that it can be used with the Gradio backend (which is written in Python) to support Hugging Face workspaces, which is why this is an extension and not part of the core library.
+
+The goal is for these transformers to be used to power the model parser backends.
+
+## Usage
+
+### Part 1: Update and test this extention
+
+If you are not testing locally (just using the published extension), ignore this and go to Part 2
+
+1. From the `aiconfig/HuggingFaceTransformers`, run this command: `pip install build && cd python && python -m build && pip install dist/*.whl`
+2. After you're done testing, be sure to delete the generated folder(s) in the `aiconfig/HuggingFaceTransformers` dir. It'll probalby look something like `python/dist` and `python/<package_name>.egg-info`
+
+### Part 2: Importing and using this extension
+
+1. Import whatever outputs pip gives from last command. For now it's `import text-generation` but this may change in the future
+2. In code, add all the relevant model parsers that you want to use from this extension to the registry: `ModelParserRegistry.register_model_parser(HuggingFaceTextGenerationTransformer())`. You can read the docstrings under `ModelParserRegistry` class for more info


### PR DESCRIPTION
Add README and LICENSE within the python extension dir

Also need this for publishing the extension

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/385).
* __->__ #385
* #384