### PR TITLE
[5/n] Scaffolding for Prompt Input via Schema

### DIFF
--- a/cli/aiconfig-editor/src/components/prompt/PromptContainer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/PromptContainer.tsx
@@ -1,5 +1,5 @@
 import PromptActionBar from "@/src/components/prompt/PromptActionBar";
-import PromptInput from "@/src/components/prompt/PromptInput";
+import PromptInputRenderer from "@/src/components/prompt/prompt_input/PromptInputRenderer";
 import { getPromptModelName, getPromptSchema } from "@/src/utils/promptUtils";
 import { Flex, Card, Text } from "@mantine/core";
 import { Prompt, PromptInput as AIConfigPromptInput } from "aiconfig";
@@ -25,6 +25,7 @@ export default memo(function PromptContainer({
   );
 
   const promptSchema = getPromptSchema(prompt, defaultConfigModelName);
+  const inputSchema = promptSchema?.input;
 
   return (
     <div style={{ marginTop: 16 }}>
@@ -35,7 +36,11 @@ export default memo(function PromptContainer({
               <Text weight="bold">{`{{${prompt.name}}}}`}</Text>
               <Text>{getPromptModelName(prompt, defaultConfigModelName)}</Text>
             </Flex>
-            <PromptInput input={prompt.input} onChangeInput={onChangeInput} />
+            <PromptInputRenderer
+              input={prompt.input}
+              schema={inputSchema}
+              onChangeInput={onChangeInput}
+            />
             {/* <PromptOutput /> */}
           </Flex>
           <PromptActionBar prompt={prompt} promptSchema={promptSchema} />

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/PromptInputConfigRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/PromptInputConfigRenderer.tsx
@@ -7,7 +7,10 @@ type Props = {
   onChangeInput: (value: PromptInput) => void;
 };
 
-export default memo(function PromptInput({ input, onChangeInput }: Props) {
+export default memo(function PromptInputConfigRenderer({
+  input,
+  onChangeInput,
+}: Props) {
   return (
     <Textarea
       value={input as string}

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/PromptInputRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/PromptInputRenderer.tsx
@@ -1,0 +1,27 @@
+import { PromptInput } from "aiconfig";
+import { memo } from "react";
+import { PromptInputSchema } from "@/src/utils/promptUtils";
+import PromptInputSchemaRenderer from "@/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer";
+import PromptInputConfigRenderer from "@/src/components/prompt/prompt_input/PromptInputConfigRenderer";
+
+type Props = {
+  input: PromptInput;
+  schema?: PromptInputSchema;
+  onChangeInput: (value: PromptInput) => void;
+};
+
+export default memo(function PromptInputRenderer({
+  input,
+  schema,
+  onChangeInput,
+}: Props) {
+  return schema ? (
+    <PromptInputSchemaRenderer
+      input={input}
+      schema={schema}
+      onChangeInput={onChangeInput}
+    />
+  ) : (
+    <PromptInputConfigRenderer input={input} onChangeInput={onChangeInput} />
+  );
+});

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/schema_renderer/PromptInputAttachmentsSchemaRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/schema_renderer/PromptInputAttachmentsSchemaRenderer.tsx
@@ -1,0 +1,14 @@
+import { PromptInputObjectAttachmentsSchema } from "@/src/utils/promptUtils";
+import { JSONValue } from "aiconfig/dist/common";
+import { memo } from "react";
+
+type Props = {
+  schema: PromptInputObjectAttachmentsSchema;
+  onChangeAttachments: (value: JSONValue) => void;
+};
+
+export default memo(function PromptInputAttachmentsSchemaRenderer(
+  props: Props
+) {
+  return "ATTACHMENTS SCHEMA RENDERER";
+});

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/schema_renderer/PromptInputDataSchemaRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/schema_renderer/PromptInputDataSchemaRenderer.tsx
@@ -1,0 +1,28 @@
+import { PromptInputObjectDataSchema } from "@/src/utils/promptUtils";
+import { Textarea } from "@mantine/core";
+import { JSONValue } from "aiconfig/dist/common";
+import { memo } from "react";
+
+type Props = {
+  schema: PromptInputObjectDataSchema;
+  data?: JSONValue;
+  onChangeData: (value: JSONValue) => void;
+};
+
+export default memo(function PromptInputDataSchemaRenderer({
+  schema,
+  data,
+  onChangeData,
+}: Props) {
+  switch (schema.type) {
+    case "string":
+      return (
+        <Textarea
+          value={data ? (data as string) : ""}
+          onChange={(e: any) => onChangeData(e.target.value)}
+        />
+      );
+    default:
+      return null; // TODO: Handle other input.data types
+  }
+});

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
@@ -1,0 +1,83 @@
+import {
+  PromptInputObjectSchema,
+  PromptInputSchema,
+} from "@/src/utils/promptUtils";
+import DataRenderer from "@/src/components/prompt/prompt_input/schema_renderer/PromptInputDataSchemaRenderer";
+import AttachmentsRenderer from "@/src/components/prompt/prompt_input/schema_renderer/PromptInputAttachmentsSchemaRenderer";
+import { Flex, Textarea } from "@mantine/core";
+import { PromptInput } from "aiconfig";
+import { memo } from "react";
+
+type Props = {
+  input: PromptInput;
+  schema: PromptInputSchema;
+  onChangeInput: (value: PromptInput) => void;
+};
+
+type SchemaRendererProps = Props & {
+  schema: PromptInputObjectSchema;
+};
+
+function SchemaRenderer({ input, schema, onChangeInput }: SchemaRendererProps) {
+  const {
+    data: dataSchema,
+    attachments: attachmentsSchema,
+    ..._restProperties
+  } = schema.properties;
+
+  if (typeof input === "string") {
+    return null;
+    // TODO: Add ErrorBoundary handling and throw error here
+  }
+
+  const { data, attachments, ..._restData } = input;
+
+  const onChangeData = (value: any) => {
+    onChangeInput({ ...input, data: value });
+  };
+
+  const onChangeAttachments = (value: any) => {
+    onChangeInput({ ...input, attachments: value });
+  };
+
+  return (
+    <Flex direction="column">
+      <DataRenderer
+        schema={dataSchema}
+        data={data}
+        onChangeData={onChangeData}
+      />
+      {attachmentsSchema && (
+        <AttachmentsRenderer
+          schema={attachmentsSchema}
+          onChangeAttachments={onChangeAttachments}
+        />
+      )}
+      {/* <JSONRenderer properties={restProperties} data={restData}/> */}
+    </Flex>
+  );
+}
+
+export default memo(function PromptInputSchemaRenderer(props: Props) {
+  if (props.schema.type === "string") {
+    // TODO: Add ErrorBoundary handling
+    // if (props.input && typeof props.input !== "string") {
+    //   throw new Error(
+    //     `Expected input to be a string, but got ${typeof props.input}`
+    //   );
+    // }
+    return (
+      <Textarea
+        value={props.input as string}
+        onChange={(e: any) => props.onChangeInput(e.target.value)}
+      />
+    );
+  } else {
+    return (
+      <SchemaRenderer
+        {...props}
+        schema={props.schema as PromptInputObjectSchema}
+      />
+    );
+  }
+});

--- a/cli/aiconfig-editor/src/components/prompt/prompt_metadata/PromptMetadataRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_metadata/PromptMetadataRenderer.tsx
@@ -15,7 +15,7 @@ function ModelMetadataSchemaRenderer({ prompt, schema }: Props) {
   return null; // TODO: Implement
 }
 
-export default memo(function ModelSettingsRenderer({ prompt, schema }: Props) {
+export default memo(function PromptMetadataRenderer({ prompt, schema }: Props) {
   return schema ? (
     <ModelMetadataSchemaRenderer prompt={prompt} schema={schema} />
   ) : (

--- a/cli/aiconfig-editor/src/shared/prompt_schemas/OpenAIChatVisionModelParserPromptSchema.ts
+++ b/cli/aiconfig-editor/src/shared/prompt_schemas/OpenAIChatVisionModelParserPromptSchema.ts
@@ -1,0 +1,28 @@
+import { OpenAIChatModelParserPromptSchema } from "@/src/shared/prompt_schemas/OpenAIChatModelParserPromptSchema";
+import { PromptSchema } from "@/src/utils/promptUtils";
+
+export const OpenAIChatVisionModelParserPromptSchema: PromptSchema = {
+  ...OpenAIChatModelParserPromptSchema,
+  input: {
+    type: "object",
+    required: ["data"],
+    properties: {
+      data: {
+        type: "string",
+      },
+      attachments: {
+        type: "array",
+        items: {
+          type: "attachment",
+          required: ["data"],
+          mime_types: ["image/png"],
+          properties: {
+            data: {
+              type: "string",
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/cli/aiconfig-editor/src/utils/promptUtils.ts
+++ b/cli/aiconfig-editor/src/utils/promptUtils.ts
@@ -1,5 +1,6 @@
 import { Prompt } from "aiconfig";
 import { OpenAIChatModelParserPromptSchema } from "../shared/prompt_schemas/OpenAIChatModelParserPromptSchema";
+import { OpenAIChatVisionModelParserPromptSchema } from "@/src/shared/prompt_schemas/OpenAIChatVisionModelParserPromptSchema";
 
 /**
  * Get the name of the model for the specified prompt. The name will either be specified in the prompt's
@@ -45,10 +46,42 @@ export function getPromptModelName(
 export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   "gpt-3.5-turbo": OpenAIChatModelParserPromptSchema,
   "gpt-4": OpenAIChatModelParserPromptSchema,
+  "gpt-4-vision-preview": OpenAIChatVisionModelParserPromptSchema,
 };
 
-export type PromptInputSchema = {
-  type: "string" | "object";
+export type PromptInputSchema =
+  | PromptInputStringSchema
+  | PromptInputObjectSchema;
+
+export type PromptInputStringSchema = {
+  type: "string";
+};
+
+export type PromptInputObjectDataSchema = {
+  type: string;
+};
+
+export type PromptInputObjectAttachmentsSchema = {
+  type: "array";
+  items: {
+    type: "attachment";
+    required: string[];
+    mime_types: string[];
+    properties: {
+      data: {
+        type: string;
+      };
+    };
+  };
+};
+
+export type PromptInputObjectSchema = {
+  type: "object";
+  properties: {
+    data: PromptInputObjectDataSchema;
+    attachments?: PromptInputObjectAttachmentsSchema;
+  } & Record<string, { [key: string]: any }>;
+  required?: string[] | undefined;
 };
 
 export type ModelSettingsSchema = {

--- a/cli/aiconfig-editor/travel.aiconfig.json
+++ b/cli/aiconfig-editor/travel.aiconfig.json
@@ -46,6 +46,27 @@
           "order_by": "geographic location"
         }
       }
+    },
+    {
+      "name": "image_prompt",
+      "input": {
+        "data": "What do these images show?",
+        "attachments": [
+          {
+            "data": "https://s3.amazonaws.com/files.uploads.lastmileai.com/uploads/cldxsqbel0000qs8owp8mkd0z/2023_12_1_21_23_24/942/Screenshot 2023-11-28 at 11.11.25 AM.png",
+            "mime_type": "image/png"
+          },
+          {
+            "data": "https://s3.amazonaws.com/files.uploads.lastmileai.com/uploads/cldxsqbel0000qs8owp8mkd0z/2023_12_1_21_23_24/8325/Screenshot 2023-11-28 at 1.51.52 PM.png",
+            "mime_type": "image/png"
+          }
+        ]
+      },
+      "metadata": {
+        "model": {
+          "name": "gpt-4-vision-preview"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
# Scaffolding for Prompt Input via Schema

Implement the basis for rendering prompt inputs -- each may be rendered directly from the config or from the Prompt schema associated with the model parser.

Using GPT4-V as an example, created a schema `OpenAIChatVisionModelParserPromptSchema` which outlines how attachments can be specified.

Once https://github.com/lastmile-ai/aiconfig/pull/360 we can implement the attachments rendering more completely.

Quick video showing updating input and input.data and saving properly persists it to the config on disk:

https://github.com/lastmile-ai/aiconfig/assets/5060851/8f7f8adf-741e-493d-9cbf-837b9afc533f

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/398).
* #482
* __->__ #398