### PR TITLE
[py] 1/n PaLM Model parser match config spec

### DIFF
--- a/python/src/aiconfig/default_parsers/palm.py
+++ b/python/src/aiconfig/default_parsers/palm.py
@@ -410,6 +410,18 @@ def refine_completion_params(model_settings):
         "context",
     }
 
+    # python and node have different apis. Standardizing across both sdks, so we can use the same .aiconfig for both sdks
+    # Left is node, right is python.
+    key_converter_map = {
+        "topK": "top_k",
+        "topP": "top_p",
+    }
+
+    for key in model_settings:
+        if key in key_converter_map:
+            model_settings[key_converter_map[key]] = model_settings[key]
+            del model_settings[key]
+
     completion_data = {}
     for key in model_settings:
         if key.lower() in supported_keys:


### PR DESCRIPTION
[py] 1/n PaLM Model parser match config spec




## What

Added in a map to node api naming of completion param attributes.

## Why

PaLM API has different api across python and typescript. for example, the top k attribute

Node:
- `topK`

Python:
- `top_k`

This is also seen when exporting a workbook as aiconfig

It made sense to standardize them. the sdk will be able to take in `topK` and convert it to `top_k`. Both will work for py. Same for topP, top_P
