### PR TITLE
Version Bumps for first changelog

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "python-aiconfig"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
   { name="Sarmad Qadri", email="sarmad@lastmileai.dev" },
 ]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiconfig",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "Library to help manage AI prompts, models and parameters using the .aiconfig file format.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version Bumps


Python

- 1.1.3 -> 1.1.4

Node
- 1.0.6 -> 1.0.7
note: current release is 1.0.6. so this change is now 1.0.5 -> 1.0.6 -> 1.0.7

