### PR TITLE
[hf parser] Pass in model name to text generator

### DIFF
--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -177,7 +177,7 @@ class AIConfig(BaseModel):
             raise Exception(f"Model '{model_name}' does not exist.")
         del self.metadata.models[model_name]
 
-    def get_model_name(self, prompt: Union[str, Prompt]):
+    def get_model_name(self, prompt: Union[str, Prompt]) -> str:
         """
         Extracts the model ID from the prompt.
 


### PR DESCRIPTION
[hf parser] Pass in model name to text generator


I forgot to do this before, which would default to None model (I forget which model they used). This explains why the mistral detokenizer wasn't working properly even though ChaptGPT was.

For now just storing these different generators in memory through a dict where the key is model name. No matter what model, they all follow the same text generation API so it's ok
