### PR TITLE
[hf parser] Fix bug where we're not properly appending outputs for multiple return sequences

### DIFF
--- a/extensions/HuggingFaceTransformers/python/src/aiconfig_extension_hugging_face_transformers/text_generation.py
+++ b/extensions/HuggingFaceTransformers/python/src/aiconfig_extension_hugging_face_transformers/text_generation.py
@@ -251,6 +251,7 @@ class HuggingFaceTextGenerationTransformer(ParameterizedModelParser):
             response : List[Any] = generator(**completion_data)
             for count, result in enumerate(response):
                 output = construct_regular_output(result, count)
+                outputs.append(output)
         else:
             if completion_data.get("num_return_sequences", 1) > 1:
                 raise ValueError("Sorry, TextIteratorStreamer does not support multiple return sequences, please set `num_return_sequences` to 1")
@@ -261,8 +262,8 @@ class HuggingFaceTextGenerationTransformer(ParameterizedModelParser):
             thread = threading.Thread(target=generator, kwargs=completion_data)
             thread.start()
             output = construct_stream_output(streamer, options)
-        if output is not None:
-            outputs.append(output)
+            if output is not None:
+                outputs.append(output)
 
         prompt.outputs = outputs
         return prompt.outputs

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -177,7 +177,7 @@ class AIConfig(BaseModel):
             raise Exception(f"Model '{model_name}' does not exist.")
         del self.metadata.models[model_name]
 
-    def get_model_name(self, prompt: Union[str, Prompt]):
+    def get_model_name(self, prompt: Union[str, Prompt]) -> str:
         """
         Extracts the model ID from the prompt.
 


### PR DESCRIPTION
[hf parser] Fix bug where we're not properly appending outputs for multiple return sequences

Minor bug fix I noticed that I messed up when adding streaming support in https://github.com/lastmile-ai/aiconfig/pull/380 (after I already supported multiple inputs in https://github.com/lastmile-ai/aiconfig/pull/345). The reason i missed this is that streaming only supports a single return sequence so didn't end up testing for multiple non-streaming. We should have automated tests. Added GH issue in


Tested by reabsing onto: https://github.com/lastmile-ai/aiconfig/pull/412

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/411).
* #414
* __->__ #411
* #410