### PR TITLE
Fixed typo for last-mile utils dependency

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,4 +14,4 @@ nest_asyncio
 prompt_toolkit
 mock
 pytest-asyncio
-lastmile_utils>=0.0.6
+lastmile-utils>=0.0.6


### PR DESCRIPTION
Fixed typo for last-mile utils dependency


TSIA, see the install command from https://pypi.org/project/lastmile-utils/

Before
```
rossdancraig@MacBook-Pro python % pip list | grep lastmile_utils
```

After
```
rossdancraig@MacBook-Pro python %  pip3 list | grep lastmile
lastmile-utils                               0.0.6
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/418).
* #419
* __->__ #418