### PR TITLE
Bump pypi package version to 1.1.6 to support Prompt Input Attachments

### DIFF
--- a/cookbooks/Function-Calling-OpenAI/python/Function_Calling_with_OpenAI.ipynb
+++ b/cookbooks/Function-Calling-OpenAI/python/Function_Calling_with_OpenAI.ipynb
@@ -22,8 +22,9 @@
         "# Install AIConfig package\n",
         "!pip install python-aiconfig\n",
         "\n",
-        "# Create ~/.env file with this line: export OPENAI_API_KEY=<your key here>\n",
-        "# You can get your key from https://platform.openai.com/api-keys \n",
+        "# Create .env file at cookbooks/Function-Calling-OpenAI/python/.env containing the \n",
+        "# following line: OPENAI_API_KEY=<your key here>\n",
+        "# You can get your key from https://platform.openai.com/api-keys\n",
         "import openai\n",
         "import dotenv\n",
         "import os\n",
@@ -128,7 +129,7 @@
       },
       "outputs": [],
       "source": [
-        "from aiconfig import AIConfigRuntime, InferenceOptions, CallbackManager\n",
+        "from aiconfig import AIConfigRuntime, InferenceOptions\n",
         "\n",
         "# Load the aiconfig.\n",
         "config = AIConfigRuntime.create(name=\"Book Finder\", description=\"Use OpenAI function calling to help recommend books\")"
@@ -331,7 +332,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "metadata": {
         "id": "4l-buJXglaLw"
       },

--- a/cookbooks/Getting-Started/getting_started.ipynb
+++ b/cookbooks/Getting-Started/getting_started.ipynb
@@ -1,6 +1,7 @@
 {
   "cells": [
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "kNmnUZnUFzt3"
@@ -19,7 +20,8 @@
       "source": [
         "!pip install python-aiconfig\n",
         "\n",
-        "# Create ~/.env file with this line: export OPENAI_API_KEY=<your key here>\n",
+        "# Create .env file at cookbooks/Function-Calling-OpenAI/python/.env containing the \n",
+        "# following line: OPENAI_API_KEY=<your key here>\n",
         "# You can get your key from https://platform.openai.com/api-keys \n",
         "import openai\n",
         "import dotenv\n",
@@ -29,6 +31,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "-FMlVH2bF4iN"
@@ -54,6 +57,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "zqCchve9GINL"
@@ -100,6 +104,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "5Fgj5w85Sbch"
@@ -211,6 +216,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "7DTy5qLpRxlx"
@@ -328,6 +334,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "q9deFcBK55yN"
@@ -349,6 +356,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "JLiElYyC6DB-"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "python-aiconfig"
-version = "1.1.5"
+version = "1.1.6"
 authors = [
   { name="Sarmad Qadri", email="sarmad@lastmileai.dev" },
 ]


### PR DESCRIPTION
Bump pypi package version to 1.1.6 to support Prompt Input Attachments

With the Attachments added to the config schema, bumping the package version to 1.1.6 prior to publishing to pypi.

Tested successfully on the Getting Started and Function Calling cookbooks (moved python function calling one to python dir)
