### PR TITLE
Prioritize python example code tab in docs

### DIFF
--- a/aiconfig-docs/core/tabConstants.js
+++ b/aiconfig-docs/core/tabConstants.js
@@ -29,8 +29,8 @@ const pythonPackageManagers = [
 const defaultPythonPackageManager = "pip";
 
 const aiConfigLanguages = [
-  { label: "TypeScript", value: "node" },
   { label: "Python", value: "python" },
+  { label: "TypeScript", value: "node" },
 ];
 const defaultAIConfigLanguage = "python";
 

--- a/aiconfig-docs/docs/getting-started.md
+++ b/aiconfig-docs/docs/getting-started.md
@@ -18,26 +18,6 @@ Please read [AIConfig Basics](/docs/basics) to understand the motivation behind 
 
 The [`aiconfig` file format](/docs/overview/ai-config-format) is best used with the AIConfig SDK. To install the SDK, use your favorite package manager:
 
-#### Node.js (TypeScript)
-
-<Tabs groupId="package-manager" queryString defaultValue={constants.defaultNodePackageManager} values={constants.nodePackageManagers}>
-<TabItem value="npm">
-
-```bash
-$ npm install aiconfig
-```
-
-</TabItem>
-<TabItem value="yarn">
-
-```bash
-$ yarn add aiconfig
-```
-
-</TabItem>
-
-</Tabs>
-
 #### Python
 
 <Tabs groupId="package-manager" queryString defaultValue={constants.defaultPythonPackageManager} values={constants.pythonPackageManagers}>
@@ -52,6 +32,26 @@ $ pip install --user python-aiconfig
 
 ```bash
 $ poetry add python-aiconfig
+```
+
+</TabItem>
+
+</Tabs>
+
+#### Node.js (TypeScript)
+
+<Tabs groupId="package-manager" queryString defaultValue={constants.defaultNodePackageManager} values={constants.nodePackageManagers}>
+<TabItem value="npm">
+
+```bash
+$ npm install aiconfig
+```
+
+</TabItem>
+<TabItem value="yarn">
+
+```bash
+$ yarn add aiconfig
 ```
 
 </TabItem>
@@ -134,6 +134,24 @@ Don't worry if you don't understand all parts of this yet, we'll go over it in s
 
 You don't need to worry about how to run inference for the model; it's all handled by AIConfig. The prompt runs with gpt-3.5-turbo since that is the `default_model` for this AIConfig.
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+import asyncio
+from aiconfig import AIConfigRuntime, InferenceOptions
+
+async def main():
+  # Load the aiconfig
+  config = AIConfigRuntime.load('travel.aiconfig.json')
+
+  # Run a single prompt
+  await config.run("get_activities")
+
+asyncio.run(main())
+```
+
+</TabItem>
+
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -152,23 +170,6 @@ async function travelWithGPT() {
 ```
 
 </TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-import asyncio
-from aiconfig import AIConfigRuntime, InferenceOptions
-
-async def main():
-  # Load the aiconfig
-  config = AIConfigRuntime.load('travel.aiconfig.json')
-
-  # Run a single prompt
-  await config.run("get_activities")
-
-asyncio.run(main())
-```
-
-</TabItem>
 </Tabs>
 
 ### 3. Enable streaming for your prompt.
@@ -176,6 +177,18 @@ asyncio.run(main())
 You can enable streaming for your prompt responses by passing in a streaming callback.
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+from aiconfig import AIConfigRuntime, InferenceOptions
+config = AIConfigRuntime.load('travel.aiconfig.json')
+
+# Run a single prompt (with streaming)
+inference_options = InferenceOptions(stream=True)
+await config.run("get_activities", options=inference_options)
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -199,18 +212,6 @@ async function travelWithGPT() {
   // Run a single prompt
   await aiConfig.run("get_activities", /*params*/ undefined, options);
 }
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-from aiconfig import AIConfigRuntime, InferenceOptions
-config = AIConfigRuntime.load('travel.aiconfig.json')
-
-# Run a single prompt (with streaming)
-inference_options = InferenceOptions(stream=True)
-await config.run("get_activities", options=inference_options)
 ```
 
 </TabItem>
@@ -252,6 +253,20 @@ Effectively, this is a prompt chain between `gen_itinerary` and `get_activities`
 Let's run this with AIConfig:
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+Replace `config.run` above with this:
+
+```python
+inference_options = InferenceOptions(stream=True)
+await config.run(
+    "gen_itinerary",
+    params={"order_by": "duration"},
+    options=inference_options,
+    run_with_dependencies=True)
+```
+
+</TabItem>
 <TabItem value="node">
 
 Replace the `aiconfig.run` call above with this:
@@ -268,20 +283,6 @@ await aiConfig.runWithDependencies(
 ```
 
 </TabItem>
-<TabItem value="python">
-
-Replace `config.run` above with this:
-
-```python
-inference_options = InferenceOptions(stream=True)
-await config.run(
-    "gen_itinerary",
-    params={"order_by": "duration"},
-    options=inference_options,
-    run_with_dependencies=True)
-```
-
-</TabItem>
 </Tabs>
 
 :::info
@@ -293,6 +294,14 @@ Notice how simple the syntax is to perform a fairly complex task - running 2 dif
 Let's save the AIConfig back to disk, and serialize the outputs from the latest inference run as well:
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python
+# Save the aiconfig to disk. and serialize outputs from the model run
+config.save('updated.aiconfig.json', include_outputs=True)
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript
@@ -301,14 +310,6 @@ aiConfig.save(
   "updated.aiconfig.json",
   /*saveOptions*/ { serializeOutputs: true }
 );
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python
-# Save the aiconfig to disk. and serialize outputs from the model run
-config.save('updated.aiconfig.json', include_outputs=True)
 ```
 
 </TabItem>

--- a/aiconfig-docs/docs/overview/create-an-aiconfig.md
+++ b/aiconfig-docs/docs/overview/create-an-aiconfig.md
@@ -22,6 +22,44 @@ There are 2 ways to create an `aiconfig` from scratch.
 You can use the `create` function to create an empty `aiconfig`. To create prompts in the config, you can use the `serialize` function, which takes in data in the form that a model expects (e.g. OpenAI completion params), and creates Prompt objects that can be saved in the `aiconfig`.
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+:::tip
+[Clone this notebook](https://github.com/lastmile-ai/aiconfig/blob/main/cookbooks/Create-AIConfig-Programmatically/create_aiconfig_programmatically.ipynb) to create an `aiconfig` programmatically.
+:::
+
+```python title="app.py"
+import asyncio
+from aiconfig import AIConfigRuntime
+
+async def main():
+    new_config = AIConfigRuntime.create("my_aiconfig", "This is my new AIConfig")
+
+    # OpenAI completion params
+    model = "gpt-4"
+    data = {
+        "model": model,
+        "messages": [
+        { "role": "user", "content": "Say this is a test" },
+        { "role": "assistant", "content": "This is a test." },
+        { "role": "user", "content": "What do you say?" }
+        ]
+    }
+
+    # Serialize the data into the aiconfig format.
+    prompts = await new_config.serialize(model, data, "prompts")
+
+    # Add the prompts to the aiconfig
+    for i, prompt in enumerate(prompts):
+        new_config.add_prompt(f"prompt_name_{i}", prompt)
+
+    # Save the aiconfig to disk
+    new_config.save('new.aiconfig.json', include_outputs=True)
+
+asyncio.run(main())
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -61,44 +99,6 @@ async function createAIConfig() {
   // Save the aiconfig to disk
   aiConfig.save("new.aiconfig.json", { serializeOutputs: true });
 }
-```
-
-</TabItem>
-<TabItem value="python">
-
-:::tip
-[Clone this notebook](https://github.com/lastmile-ai/aiconfig/blob/main/cookbooks/Create-AIConfig-Programmatically/create_aiconfig_programmatically.ipynb) to create an `aiconfig` programmatically.
-:::
-
-```python title="app.py"
-import asyncio
-from aiconfig import AIConfigRuntime
-
-async def main():
-    new_config = AIConfigRuntime.create("my_aiconfig", "This is my new AIConfig")
-
-    # OpenAI completion params
-    model = "gpt-4"
-    data = {
-        "model": model,
-        "messages": [
-        { "role": "user", "content": "Say this is a test" },
-        { "role": "assistant", "content": "This is a test." },
-        { "role": "user", "content": "What do you say?" }
-        ]
-    }
-
-    # Serialize the data into the aiconfig format.
-    prompts = await new_config.serialize(model, data, "prompts")
-
-    # Add the prompts to the aiconfig
-    for i, prompt in enumerate(prompts):
-        new_config.add_prompt(f"prompt_name_{i}", prompt)
-
-    # Save the aiconfig to disk
-    new_config.save('new.aiconfig.json', include_outputs=True)
-
-asyncio.run(main())
 ```
 
 </TabItem>

--- a/aiconfig-docs/docs/overview/define-prompt-chain.md
+++ b/aiconfig-docs/docs/overview/define-prompt-chain.md
@@ -71,6 +71,22 @@ For example, in the following `aiconfig`, `prompt1` and `prompt2` are considered
 In order to treat `prompt2` as an individual prompt, you can set `remember_chat_context` to `false` in the prompt's metadata:
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+from aiconfig import AIConfigRuntime
+
+config = AIConfigRuntime.load('transformers.aiconfig.json')
+
+config.set_metadata("remember_chat_context", False, "prompt2")
+
+# Runs just prompt2, without conversation history from prompt1
+await config.run("prompt2")
+
+config.save()
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -89,22 +105,6 @@ async function noConversationHistory() {
 
   aiConfig.save();
 }
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-from aiconfig import AIConfigRuntime
-
-config = AIConfigRuntime.load('transformers.aiconfig.json')
-
-config.set_metadata("remember_chat_context", False, "prompt2")
-
-# Runs just prompt2, without conversation history from prompt1
-await config.run("prompt2")
-
-config.save()
 ```
 
 </TabItem>
@@ -155,6 +155,22 @@ Effectively, this is a prompt chain between `gen_itinerary` and `get_activities`
 To run this with AIConfig:
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python
+from aiconfig import AIConfigRuntime
+
+config = AIConfigRuntime.load('travel.aiconfig.json')
+
+# This will first run get_activities with GPT-3.5,
+# and then use its output to run the gen_itinerary using GPT-4
+await config.run(
+    "gen_itinerary",
+    options=InferenceOptions(stream=True),
+    run_with_dependencies=True)
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript
@@ -170,22 +186,6 @@ async function runPromptChain() {
   // and then use its output to run the gen_itinerary using GPT-4
   await aiConfig.runWithDependencies("gen_itinerary");
 }
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python
-from aiconfig import AIConfigRuntime
-
-config = AIConfigRuntime.load('travel.aiconfig.json')
-
-# This will first run get_activities with GPT-3.5,
-# and then use its output to run the gen_itinerary using GPT-4
-await config.run(
-    "gen_itinerary",
-    options=InferenceOptions(stream=True),
-    run_with_dependencies=True)
 ```
 
 </TabItem>

--- a/aiconfig-docs/docs/overview/monitoring-aiconfig.md
+++ b/aiconfig-docs/docs/overview/monitoring-aiconfig.md
@@ -29,6 +29,16 @@ Anyone can register a callback, and filter for the events you care about. You ca
 Custom callbacks are functions that conform to the Callback type. They receive a CallbackEvent object containing event details, and return a Promise. Here's an example of a simple logging callback:
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+from aiconfig import AIConfigRuntime, CallbackEvent, CallbackManager
+
+async def my_custom_callback(event: CallbackEvent) -> None:
+  print(f"Event triggered: {event.name}", event)
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -37,16 +47,6 @@ import { Callback, CallbackEvent } from "aiconfig";
 const myCustomCallback: Callback = async (event: CallbackEvent) => {
   console.log(`Event triggered: ${event.name}`, event);
 };
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-from aiconfig import AIConfigRuntime, CallbackEvent, CallbackManager
-
-async def my_custom_callback(event: CallbackEvent) -> None:
-  print(f"Event triggered: {event.name}", event)
 ```
 
 </TabItem>
@@ -59,6 +59,22 @@ By default, a CallbackManager is set up which logs all events to to `aiconfig.lo
 :::
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+from aiconfig import AIConfigRuntime, CallbackEvent, CallbackManager
+config = AIConfigRuntime.load('aiconfig.json')
+
+async def my_custom_callback(event: CallbackEvent) -> None:
+  print(f"Event triggered: {event.name}", event)
+
+callback_manager = CallbackManager([my_custom_callback])
+config.set_callback_manager(callback_manager)
+
+await config.run("prompt_name")
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -80,22 +96,6 @@ const callbackManager = new CallbackManager([myCustomCallback]);
 config.setCallbackManager(callbackManager);
 
 await config.run("prompt_name");
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-from aiconfig import AIConfigRuntime, CallbackEvent, CallbackManager
-config = AIConfigRuntime.load('aiconfig.json')
-
-async def my_custom_callback(event: CallbackEvent) -> None:
-  print(f"Event triggered: {event.name}", event)
-
-callback_manager = CallbackManager([my_custom_callback])
-config.set_callback_manager(callback_manager)
-
-await config.run("prompt_name")
 ```
 
 </TabItem>
@@ -128,19 +128,19 @@ Similarly, ModelParsers should trigger their own events when serializing, deseri
 The CallbackManager uses a timeout mechanism to ensure callbacks do not hang indefinitely. If a callback does not complete within the specified timeout, it is aborted, and an error is logged. This timeout can be adjusted in the CallbackManager constructor and defaults to 5s if not specified.
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
-<TabItem value="node">
-
-```typescript
-const customTimeout = 10;
-const callbackManager = new CallbackManager(callbacks, customTimeout);
-```
-
-</TabItem>
 <TabItem value="python">
 
 ```python
 custom_timeout = 10; # 10 seconds
 callback_manager = CallbackManager([my_logging_callback], custom_timeout)
+```
+
+</TabItem>
+<TabItem value="node">
+
+```typescript
+const customTimeout = 10;
+const callbackManager = new CallbackManager(callbacks, customTimeout);
 ```
 
 </TabItem>

--- a/aiconfig-docs/docs/overview/parameters.md
+++ b/aiconfig-docs/docs/overview/parameters.md
@@ -68,6 +68,28 @@ Read more about the `aiconfig` metadata schema [here](docs/overview/ai-config-fo
 :::
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+from aiconfig import AIConfigRuntime
+
+# Load the aiconfig.
+config = AIConfigRuntime.load('sql.aiconfig.json')
+
+# Set a global parameter
+config.set_parameter("sql_language", "mysql")
+
+# Set a prompt-specific parameter
+config.set_parameter(
+    "output_data",
+    "user_name, user_email, trial. output granularity is the trial_id.",
+    "write_sql" #prompt_name
+)
+
+config.save()
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -95,6 +117,11 @@ config.save();
 ```
 
 </TabItem>
+</Tabs>
+
+### Specifying parameters in code
+
+<Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
 <TabItem value="python">
 
 ```python title="app.py"
@@ -103,25 +130,17 @@ from aiconfig import AIConfigRuntime
 # Load the aiconfig.
 config = AIConfigRuntime.load('sql.aiconfig.json')
 
-# Set a global parameter
-config.set_parameter("sql_language", "mysql")
+params = {
+    "sql_language": "mysql", # This will override the default value in the aiconfig
+    "output_data": "user_name, user_email, trial. output granularity is the trial_id.",
+    "table_relationships": "user table, trial table, trial_step table. a user can create many trials. each trial has many trial_steps."
+}
 
-# Set a prompt-specific parameter
-config.set_parameter(
-    "output_data",
-    "user_name, user_email, trial. output granularity is the trial_id.",
-    "write_sql" #prompt_name
-)
-
-config.save()
+# Run the prompt with parameters
+await config.run("write_sql", params)
 ```
 
 </TabItem>
-</Tabs>
-
-### Specifying parameters in code
-
-<Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -148,25 +167,6 @@ async function parameterizedPrompt() {
 ```
 
 </TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-from aiconfig import AIConfigRuntime
-
-# Load the aiconfig.
-config = AIConfigRuntime.load('sql.aiconfig.json')
-
-params = {
-    "sql_language": "mysql", # This will override the default value in the aiconfig
-    "output_data": "user_name, user_email, trial. output granularity is the trial_id.",
-    "table_relationships": "user table, trial table, trial_step table. a user can create many trials. each trial has many trial_steps."
-}
-
-# Run the prompt with parameters
-await config.run("write_sql", params)
-```
-
-</TabItem>
 </Tabs>
 
 ### Resolving the prompt
@@ -176,17 +176,17 @@ Use the `resolve` function to see how parameters are applied to a prompt templat
 In the example above, replace `config.run` with `config.resolve`:
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
-<TabItem value="node">
-
-```typescript
-await config.resolve("write_sql", params);
-```
-
-</TabItem>
 <TabItem value="python">
 
 ```python
 await config.resolve("write_sql", params)
+```
+
+</TabItem>
+<TabItem value="node">
+
+```typescript
+await config.resolve("write_sql", params);
 ```
 
 </TabItem>
@@ -251,6 +251,28 @@ In the example above, the `translate` prompt is a prompt chain because it depend
 To run this prompt chain properly, you'd need to pass in parameters for both prompts.
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+from aiconfig import AIConfigRuntime
+
+# Load the aiconfig.
+config = AIConfigRuntime.load('sql.aiconfig.json')
+
+params = {
+    # Parameters for `translate` prompt
+    "target_language": "postgresql",
+    # Parameters for `write_sql` prompt
+    "sql_language": "mysql",
+    "output_data": "user_name, user_email, trial. output granularity is the trial_id.",
+    "table_relationships": "user table, trial table, trial_step table. a user can create many trials. each trial has many trial_steps."
+}
+
+# Run the prompt chain
+await config.run("translate", params, run_with_dependencies=True)
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -277,28 +299,6 @@ async function parameterizedPrompt() {
   // Run the prompt chain
   await config.runWithDependencies("translate", params);
 }
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-from aiconfig import AIConfigRuntime
-
-# Load the aiconfig.
-config = AIConfigRuntime.load('sql.aiconfig.json')
-
-params = {
-    # Parameters for `translate` prompt
-    "target_language": "postgresql",
-    # Parameters for `write_sql` prompt
-    "sql_language": "mysql",
-    "output_data": "user_name, user_email, trial. output granularity is the trial_id.",
-    "table_relationships": "user table, trial table, trial_step table. a user can create many trials. each trial has many trial_steps."
-}
-
-# Run the prompt chain
-await config.run("translate", params, run_with_dependencies=True)
 ```
 
 </TabItem>

--- a/aiconfig-docs/docs/overview/run-aiconfig.md
+++ b/aiconfig-docs/docs/overview/run-aiconfig.md
@@ -19,6 +19,16 @@ Once you've [created an `aiconfig`](/docs/overview/create-an-aiconfig), defined 
 Running a prompt means invoking model inference for that prompt. The interface for running a prompt is the same no matter what underlying model is being invoked. This is one of the things that makes `aiconfig` powerful -- by removing model-specific logic from your application code, it streamlines your application and helps you iterate faster.
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+from aiconfig import AIConfigRuntime
+
+config = AIConfigRuntime.load('aiconfig.json')
+result = await config.run("prompt_name")
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -30,16 +40,6 @@ async function runPrompt() {
   const result = await config.run("prompt_name");
   return result;
 }
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-from aiconfig import AIConfigRuntime
-
-config = AIConfigRuntime.load('aiconfig.json')
-result = await config.run("prompt_name")
 ```
 
 </TabItem>
@@ -95,6 +95,19 @@ Consider the following example `aiconfig`. `gen_itinerary` is a prompt chain tha
 By default, calling `gen_itinerary` will use the cached output for `get_activities`.
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+from aiconfig import AIConfigRuntime, InferenceOptions
+config = AIConfigRuntime.load('travel.aiconfig.json')
+
+await config.run("get_activities")
+
+# Uses the cached output for `get_activities` to resolve the `gen_itinerary` prompt
+await config.run("gen_itinerary");
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -114,19 +127,6 @@ async function travelWithGPT() {
 ```
 
 </TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-from aiconfig import AIConfigRuntime, InferenceOptions
-config = AIConfigRuntime.load('travel.aiconfig.json')
-
-await config.run("get_activities")
-
-# Uses the cached output for `get_activities` to resolve the `gen_itinerary` prompt
-await config.run("gen_itinerary");
-```
-
-</TabItem>
 </Tabs>
 
 ### Re-running the entire chain
@@ -134,6 +134,17 @@ await config.run("gen_itinerary");
 Running with dependencies is useful to re-executing [prompt chains](/docs/overview/define-prompt-chain).
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+from aiconfig import AIConfigRuntime, InferenceOptions
+config = AIConfigRuntime.load('travel.aiconfig.json')
+
+# Re-runs `get_activities` first, and then uses the output to resolve the `gen_itinerary` prompt
+await config.run("gen_itinerary", run_with_dependencies=True);
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -151,17 +162,6 @@ async function travelWithGPT() {
 ```
 
 </TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-from aiconfig import AIConfigRuntime, InferenceOptions
-config = AIConfigRuntime.load('travel.aiconfig.json')
-
-# Re-runs `get_activities` first, and then uses the output to resolve the `gen_itinerary` prompt
-await config.run("gen_itinerary", run_with_dependencies=True);
-```
-
-</TabItem>
 </Tabs>
 
 ## Streaming outputs
@@ -171,6 +171,17 @@ The `run` API makes it easy to stream outputs in a consistent way across any mod
 You can pass in an `InferenceOptions` object, which allows you to specify a streaming callback:
 
 <Tabs groupId="aiconfig-language" queryString defaultValue={constants.defaultAIConfigLanguage} values={constants.aiConfigLanguages}>
+<TabItem value="python">
+
+```python title="app.py"
+from aiconfig import AIConfigRuntime, InferenceOptions
+config = AIConfigRuntime.load('travel.aiconfig.json')
+
+inference_options = InferenceOptions(stream=True) # Defines a console streaming callback
+await config.run("get_activities", options=inference_options)
+```
+
+</TabItem>
 <TabItem value="node">
 
 ```typescript title="app.ts"
@@ -194,17 +205,6 @@ async function streamOutputs() {
   // Run a single prompt
   await aiConfig.run("get_activities", /*params*/ undefined, options);
 }
-```
-
-</TabItem>
-<TabItem value="python">
-
-```python title="app.py"
-from aiconfig import AIConfigRuntime, InferenceOptions
-config = AIConfigRuntime.load('travel.aiconfig.json')
-
-inference_options = InferenceOptions(stream=True) # Defines a console streaming callback
-await config.run("get_activities", options=inference_options)
 ```
 
 </TabItem>


### PR DESCRIPTION
# Prioritize python example code tab in docs

Make sure all example code / tabs prioritizes showing python since that's the most common language for AIConfig usage. The order is actually determined by the order in the `aiConfigLanguages` array in tab constants, but this PR also updates the tabs defined in the md code to reflect the intended ordering.

## Testing:
- Went through each page and each tab toggle to ensure correctness
e.g.

https://github.com/lastmile-ai/aiconfig/assets/5060851/b852005d-2620-414e-a226-7a885cc95622


