### PR TITLE
[py][ts] Clear outputs before running

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -261,6 +261,9 @@ class AIConfigRuntime(AIConfig):
         model_name = self.get_model_name(prompt_data)
         model_provider = AIConfigRuntime.get_model_parser(model_name)
 
+        # Clear previous run outputs if they exist
+        self.delete_output(prompt_name)
+
         response = await model_provider.run(
             prompt_data,
             self,

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -396,7 +396,9 @@ export class AIConfigRuntime implements AIConfig {
         `E1014: Unable to run prompt '${promptName}': ModelParser for model ${modelName} does not exist`
       );
     }
-
+    
+    // Clear previous run outputs if they exist
+    this.deleteOutput(promptName);
     const result = await modelParser.run(prompt, this, options, params);
 
     // Update the prompt's outputs


### PR DESCRIPTION
[py][ts] Clear outputs before running




## What

Remove the outputs of the prompt when run() is called

## Why

previous outputs stay cached. This introduces unintended side effects

## Testplan

Run a prompt twice, expect the same output without any changes. This is the result of the output no longer being cached on a new run

TS:
<img width="1604" alt="Screenshot 2023-12-14 at 3 06 17 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/f9ef9e77-aaa6-45ab-acc2-f1628165d21d">
Py:
Added print statements to verify outputs were getting removed
<img width="1605" alt="Screenshot 2023-12-14 at 3 07 47 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/6a671eb0-1aae-4ce2-9824-d34cacb42b96">
