### PR TITLE
Increase VSCode Formatter Line Length to 150

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,9 +25,9 @@
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.formatOnSave": true,
-    "editor.rulers": [88]
+    "editor.rulers": [150]
   },
-  "black-formatter.args": ["--line-length=88"],
+  "black-formatter.args": ["--line-length=150"],
   // example: "--disable=C0114,C0115,C0116"
   "pylint.args": []
 }


### PR DESCRIPTION
Increase VSCode Formatter Line Length to 150
