### PR TITLE
Refactor update_model() API to be more user friendly and flexible

### DIFF
--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from aiconfig.util.config_utils import extract_override_settings
@@ -444,30 +445,159 @@ class AIConfig(BaseModel):
     # `update_model_parser_registry_with_config_runtime`` function
     # Tracked in https://github.com/lastmile-ai/aiconfig/issues/503
     def update_model(
-        self, model_metadata: Dict | ModelMetadata, prompt_name: Optional[str] = None
+        self, model_name: Optional[str] = None, settings: Optional[InferenceSettings] = None, prompt_name: Optional[str] = None
     ):
         """
-        Updates model settings in AIconfig-level metadata
+        Updates model name and/or settings at the prompt (if specified) or AIConfig level.
 
         Args:
-            model_metadata (dict): The model metadata to update.
-            prompt_name (str, optional): If specified, the model settings will only be applied to the prompt with the given prompt_name.
+            name (str): The model name to update. 
+                - If None: keep existing name for prompt; error for AIConfig.
+            settings (dict): The model settings to update. 
+                - If None: keep existing settings for prompt; keep existing
+                  for AIConfig (if model name exists) or create empty settings
+            prompt_name (Optional[str]): If specified, the model updatd will 
+                only be applied to the prompt with the given prompt_name.
+        
+        Examples: 
+            update_model("gpt3", None, "my_prompt")
+                --> updates "my_prompt" to use "gpt3" with existing settings
+            update_model("gpt3", None)
+                --> updates aiconfig model key "gpt3" to use existing 
+                    settings (empty if model was not previously defined)
+            update_model(None, {}, "my_prompt") 
+                --> updates "my_prompt" to use same model with empty settings
+            update_model(None, {}) 
+                --> errors because AiConfig needs a name to know which 
+                    model to update
+            update_model(None, None, "my_prompt") 
+                --> errors becasue no model name or settings provided
         """
-        if isinstance(model_metadata, dict):
-            if "name" not in model_metadata:
-                raise KeyError(
-                    "Cannot update model. Model metadata must contain a 'name' element. Optionally, it may contain a 'settings' element."
-                )
-            model_metadata = ModelMetadata(**model_metadata)
-        if prompt_name:
-            prompt = self.get_prompt(prompt_name)
-            if not prompt:
-                raise IndexError(
-                    f"Cannot update model {model_metadata.name} for prompt {prompt_name}. Prompt {prompt_name} does not exist in AIConfig."
-                )
-            prompt.metadata.model = model_metadata
+        if model_name is None and settings is None:
+            raise ValueError(
+                "Cannot update model. Either model name or model settings must be specified."
+            )
+        if model_name is None and prompt_name is None: #Only settings param is set
+            raise ValueError(
+                """
+Cannot update model. There are two things you are trying: \
+    1) Update the settings of a prompt \
+        Fix: You must pass in a `prompt_name` argument \
+    2) Update the settings at the AIConfig-level \
+        Fix: You must pass in a `name` for the model you wish \
+        to update. AIConfig-level can have multiple models, \
+        so without a model name, we don't know which model \
+        to set the settings for."
+"""
+            )
+        
+        if prompt_name is not None:
+            # We first update the model name, then update the model settings
+            if model_name is not None:
+                self._update_model_name_for_prompt(model_name, prompt_name)
+        
+            if settings is not None:
+                self._update_model_settings_for_prompt(settings, prompt_name)
         else:
-            self.metadata.models[model_metadata.name] = model_metadata.settings
+            if model_name is not None:
+                self._update_model_for_aiconfig(model_name, settings)
+    
+    def _update_model_name_for_prompt(self, model_name: str, prompt_name: str):
+        """
+        Updates model name at the prompt. To keep things simplified, at the 
+        prompt level we are only updating the model name, preserving existing 
+        settings if they exist, or setting the settings to empty dict. We 
+        will update the settings in a follow up 
+        `_update_model_settings_for_prompt()` call. The reason we do is
+        to delegate the `settings is None` check inside of `update_model()` 
+        instead of making this function more complicated.
+        
+        If model is not already specified for a prompt, we err on the side of
+        passing in the entire ModelMetadata into the prompt, even if there
+        are no settings, just becuase this makes it easier to manage for
+        future writes in case we want to add model settings later
+        (see `_update_model_settings`).
+
+        Args:
+            model_name (str): Model name to set
+            prompt_name (str): The name of the prompt we want to update
+        """
+        prompt = self.get_prompt(prompt_name)
+        if not prompt:
+            raise IndexError(
+                f"Cannot update model name of '{model_name}' for prompt '{prompt_name}'. Prompt {prompt_name} does not exist in AIConfig."
+            )
+        if prompt.metadata is None:
+            model_metadata = ModelMetadata(name=model_name, settings={})
+            prompt.metadata = PromptMetadata(model=model_metadata)
+        elif prompt.metadata.model is None or isinstance(prompt.metadata.model, str):
+            prompt.metadata.model = ModelMetadata(name=model_name, settings={})
+        else:
+            # prompt.metadata.model is a ModelMetadata object
+            model_settings : InferenceSettings = prompt.metadata.model.settings or {}
+            prompt.metadata.model = ModelMetadata(name=model_name, settings=model_settings)
+    
+    def _update_model_settings_for_prompt(self, settings: InferenceSettings, prompt_name: str):
+        """
+        Updates model name at the prompt level. We do not update at the
+        AIConfig level because an AIConfig can have multiple models, so
+        without the model name, we don't know which model to update.
+
+        Args:
+            settings (InferenceSettings): Model settings to set
+            prompt_name (str): The name of the prompt we want to update.
+        """
+        prompt = self.get_prompt(prompt_name)
+        if not prompt:
+            raise IndexError(
+                f"Cannot update model settings for prompt '{prompt_name}'. Prompt '{prompt_name}' does not exist in AIConfig."
+            )
+
+        metadata_error_message = f"""
+Cannot update model settings for prompt '{prompt_name}' because it does not \
+have a model name set for it. Please be sure that a model is set for this \
+prompt. You can do this be calling `update_model()` and passing a model name \
+as an argument.
+"""
+        if prompt.metadata is None or prompt.metadata.model is None:
+            raise ValueError(metadata_error_message)
+
+        if isinstance(prompt.metadata.model, str):
+            model_name = prompt.metadata.model
+            prompt.metadata.model = ModelMetadata(name=model_name, settings=settings)
+        else:
+            prompt.metadata.model.settings = settings
+
+    def _update_model_for_aiconfig(self, model_name: str, settings: Union[InferenceSettings, None], prompt_name: Optional[str] = None):
+        """
+        Updates model name at the AIConfig level.
+
+        Args:
+            model_name (str): Model name to set
+            settings (Optional[InferenceSettings]): Model settings to set
+                For AI-Config level settings we don't know the old model name 
+                so can't grab the older settings. If this is None, we will: 
+                    Case 1: Model name already exists at AIConfig level
+                        --> Preserve the existing settings
+                    Case 2: Model name is new at AIConfig level 
+                        --> Create an empty dict
+        """
+        warning_message = f"""
+No prompt name was given to update the model name to '{model_name}'. We are \
+assuming this is intentional and are therefore updating the \
+AIConfig-level settings. If this is a mistake, please rerun the \
+`update_model` function with a specified `prompt_name` argument.
+"""
+        warnings.warn(warning_message)
+        if self.metadata.models is None:
+            model_settings = settings or {}
+            self.metadata.models = {model_name: model_settings}
+        else:
+            # If the model name already exists and settings is None, 
+            # this is essentially a no-op since we are preserving 
+            # existing settings for that model name
+            model_settings = settings or self.metadata.models.get(model_name, {})
+            self.metadata.models[model_name] = model_settings
 
     def set_metadata(self, key: str, value: Any, prompt_name: Optional[str] = None):
         """

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -420,49 +420,107 @@ def test_get_prompt_nonexistent(ai_config_runtime: AIConfigRuntime):
         ai_config_runtime.get_prompt("GreetingPrompt")
 
 
-def test_update_model_ai_config(ai_config_runtime: AIConfigRuntime):
-    model_metadata = {"name": "testmodel", "settings": {"topP": 0.9}}
-    ai_config_runtime.update_model(model_metadata)
-    assert (
-        ai_config_runtime.metadata.models["testmodel"]
-        == ModelMetadata(**{"name": "testmodel", "settings": {"topP": 0.9}}).settings
-    )
+def test_update_model_for_ai_config(ai_config_runtime: AIConfigRuntime):
+    """Test updating model without a specific prompt."""
+    # New model name, new settings --> update
+    model_name = "testmodel"
+    settings = {"topP": 0.9}
+    ai_config_runtime.update_model(model_name, settings)
+    pytest.warns(match=f"No prompt name was given to update the model name to '{model_name}'.")
+    assert ai_config_runtime.metadata.models is not None
+    assert ai_config_runtime.metadata.models[model_name] == settings
+
+    # Existing model name, no settings --> no-op
+    ai_config_runtime.update_model(model_name)
+    pytest.warns(match=f"No prompt name was given to update the model name to '{model_name}'.")
+    assert ai_config_runtime.metadata.models is not None
+    assert ai_config_runtime.metadata.models[model_name] == settings
+
+    # Existing model name, new settings --> update
+    new_settings = {"topP": 0.75}
+    ai_config_runtime.update_model(model_name, new_settings)
+    pytest.warns(match=f"No prompt name was given to update the model name to '{model_name}'.")
+    assert ai_config_runtime.metadata.models is not None
+    assert ai_config_runtime.metadata.models[model_name] == new_settings
+
+    # New model name, no settings --> update
+    new_model_name = "testmodel_without_settings"
+    ai_config_runtime.update_model(new_model_name)
+    pytest.warns(match=f"No prompt name was given to update the model name to '{new_model_name}'.")
+    assert ai_config_runtime.metadata.models is not None
+    assert ai_config_runtime.metadata.models[new_model_name] == {}
 
 
-def test_update_model_specific_prompt(ai_config_runtime: AIConfigRuntime):
-    """Test updating model metadata for a specific prompt."""
-    model_metadata = {"name": "testmodel", "settings": {"topP": 0.9}}
+def test_update_model_for_prompt(ai_config_runtime: AIConfigRuntime):
+    """Test updating model for a specific prompt."""
+    #New model name, new settings, no prompt metadata --> update
     prompt1 = Prompt(
         name="GreetingPrompt",
-        input="Hello, how are you?",
-        metadata=PromptMetadata(model="fakemodel"),
+        input="Hello, how are you?"
     )
     ai_config_runtime.add_prompt(prompt1.name, prompt1)
-    ai_config_runtime.update_model(model_metadata, "GreetingPrompt")
-    assert ai_config_runtime.get_prompt(
-        "GreetingPrompt"
-    ).metadata.model == ModelMetadata(**model_metadata)
-
-
-def test_update_model_empty_metadata(ai_config_runtime: AIConfigRuntime):
-    """Test updating with an empty model_metadata dictionary."""
-    model_metadata = {}
-
-    with pytest.raises(
-        KeyError,
-        match=r"Cannot update model. Model metadata must contain a 'name' element. Optionally, it may contain a 'settings' element.",
-    ):
-        ai_config_runtime.update_model(model_metadata)
-
-
-def test_set_metadata_ai_config(ai_config_runtime: AIConfigRuntime):
-    """Test setting metadata at the AIConfig level."""
-    model_metadata = {"name": "testmodel", "settings": {"topP": 0.9}}
-    ai_config_runtime.update_model(model_metadata)
-    assert (
-        ai_config_runtime.get_metadata().models["testmodel"]
-        == ModelMetadata(**model_metadata).settings
+    model_name = "testmodel"
+    settings = {"topP": 0.9}
+    ai_config_runtime.update_model(model_name, settings, prompt1.name)
+    prompt = ai_config_runtime.get_prompt(prompt1.name)
+    assert prompt.metadata is not None
+    assert prompt.metadata.model == ModelMetadata(name=model_name, settings=settings)
+    
+    # New model name, no settings --> update name only
+    new_model_name = "testmodel_new_name"
+    ai_config_runtime.update_model(new_model_name, None, prompt1.name)
+    prompt = ai_config_runtime.get_prompt(prompt1.name)
+    assert prompt.metadata is not None
+    assert prompt.metadata.model == ModelMetadata(name=new_model_name, settings=settings)
+    
+    # Same model name, new settings --> update settings only
+    settings = {"topP": 0.9}
+    ai_config_runtime.update_model(new_model_name, settings, prompt1.name)
+    prompt = ai_config_runtime.get_prompt(prompt1.name)
+    assert prompt.metadata is not None
+    assert prompt.metadata.model == ModelMetadata(name=new_model_name, settings=settings)
+    
+    # New name, no settings, prompt with model name as string --> update
+    prompt2 = Prompt(
+        name="GreetingPromptModelAsStr",
+        input="Hello, how are you?",
+        metadata=PromptMetadata(model= "some_random_model"),
     )
+    ai_config_runtime.add_prompt(prompt2.name, prompt2)
+    new_name_again = "testmodel_new_name_model_as_str"
+    ai_config_runtime.update_model(new_name_again, None, prompt2.name)
+    prompt = ai_config_runtime.get_prompt(prompt2.name)
+    assert prompt.metadata is not None
+    assert prompt.metadata.model == ModelMetadata(name=new_name_again, settings={})
+
+    # New name, no settings, prompt with metadata but no model --> update
+    tags = ["my_fancy_tags"]
+    prompt3 = Prompt(
+        name="GreetingsNumber3",
+        input="Hello, how are you?",
+        metadata=PromptMetadata(tags= tags),
+    )
+    ai_config_runtime.add_prompt(prompt3.name, prompt3)
+    new_name_3 = "new_name_number_3"
+    ai_config_runtime.update_model(new_name_3, None, prompt3.name)
+    prompt = ai_config_runtime.get_prompt(prompt3.name)
+    assert prompt.metadata is not None
+    assert prompt.metadata.model == ModelMetadata(name=new_name_3, settings={})
+    assert prompt.metadata.tags == tags
+
+def test_update_model_with_invalid_arguments(ai_config_runtime: AIConfigRuntime):
+    """Test trying to update model with invalid arguments."""
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot update model. Either model name or model settings must be specified.",
+    ):
+        ai_config_runtime.update_model(model_name=None, settings=None)
+    
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot update model. There are two things you are trying:",
+    ):
+        ai_config_runtime.update_model(model_name=None, settings={"top": 0.9}, prompt_name=None)
 
 
 def test_set_and_delete_metadata_ai_config(ai_config_runtime: AIConfigRuntime):
@@ -547,9 +605,7 @@ def test_extract_override_settings(ai_config_runtime: AIConfigRuntime):
     assert override == {"topP": 0.9}
 
     # Test Case 3: Global Settings match settings, expect no override
-    ai_config_runtime.update_model(
-        ModelMetadata(name="testmodel", settings={"topP": 0.9})
-    )
+    ai_config_runtime.update_model(model_name="testmodel", settings={"topP": 0.9})
     override = extract_override_settings(
         ai_config_runtime, initial_settings, "testmodel"
     )


### PR DESCRIPTION
Refactor update_model() API to be more user friendly and flexible





See The last part of https://github.com/lastmile-ai/aiconfig/issues/503

This greatly makes the `update_model()` API way more flexible. Instead of needing to set the entire ModelSettings (which can be annoying because you have to first retrieve the settings from the prompt to even set the modelMetadata to pass into your argument), you can now do each part individually:

1. Set both the model name and model settings: `update_model(name="my_name", settings="my_settings")` --> pass in prompt_name arg to update at prompt-level, do not pass to update at AI-Config level
2. Set the model name only: `update_model(name="my_name")` --> pass in prompt_name arg to update at prompt-level, do not pass to update at AI-Config level
3. Set model settings only: `update_model(settings="my_settings", prompt_name="my_prompt")` --> must pass in prompt_name otherwise this will error since AI-Config can have multiple models so we don't know which model to update

Imo, this is much cleaner and makes working with everything a lot easier, preserving the existing settings/name for model metadata if it already exists!
