### PR TITLE
[editor] Fix Save to Properly Serialize

### DIFF
--- a/cli/aiconfig-editor/pages/api/aiconfig/save.ts
+++ b/cli/aiconfig-editor/pages/api/aiconfig/save.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { promises as fs } from "fs";
 import { ErrorResponse } from "@/src/shared/serverTypes";
+import { AIConfig, AIConfigRuntime } from "aiconfig";
 
 type Data = {
   status: string;
@@ -8,7 +8,7 @@ type Data = {
 
 type RequestBody = {
   path: string;
-  aiconfig: any;
+  aiconfig: AIConfig;
 };
 
 export default async function handler(
@@ -29,9 +29,9 @@ export default async function handler(
     return res.status(500).json({ error: "No aiconfig data provided" });
   }
 
-  // TODO: There's no save without creating aiconfig object, and no clean way of only updating specific portions
-  // So ignore all of this & just save the json from the editor
-  await fs.writeFile(body.path, JSON.stringify(body.aiconfig, null, 2));
+  // Construct the config and ensure proper serialization for saving
+  const config = await AIConfigRuntime.loadJSON(body.aiconfig);
+  config.save(body.path, { serializeOutputs: true });
 
   res.status(200).json({ status: "ok" });
 }


### PR DESCRIPTION
[editor] Fix Save to Properly Serialize

# [editor] Fix Save to Properly Serialize

When opening a file in the editor we load the config into an AIConfigRuntime and send that to the client. On the client, we are modifying this serialized object and sending it to the server on save. Previously, save was just JSON serializing this to a string to save directly, which resulted in some fields (e.g. CallbackManager) being saved as well. Instead, this PR updates save to properly serialize to an AIConfig and leverages the config save method to ensure proper contents are saved to disk. As a bonus, this will also result in implicit validation of the config structure (when we add validation via the schema that will be explicit as well)

## Testing:
- Make a change in the editor & save, ensuring only that change is persisted (no more CallbackManager)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/510).
* #515
* #514
* #511
* __->__ #510