### PR TITLE
[github actions] Publish Workflow to pypi

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,26 @@
+name: Python Tests
+
+# Triggers the workflow on push on main. This is the same as pr_python.yml but does not run on every PR.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Build and Install Library into Package
+        run: |
+          pip install build && cd python && python -m build && pip install dist/*.whl
+      - name: Install Test dependencies
+        run: |
+          cd python && pip install -r requirements-dev.txt
+      - name: Run tests
+        run: |
+          cd python && pytest


### PR DESCRIPTION
[github actions] Publish Workflow to pypi

- Github Action to be invoked manually to publish package to pypi.
