### PR TITLE
[editor] Move aiconfig state to reducer

### DIFF
--- a/cli/aiconfig-editor/package.json
+++ b/cli/aiconfig-editor/package.json
@@ -24,7 +24,7 @@
     "@mantine/spotlight": "^6.0.7",
     "@mantine/tiptap": "^6.0.7",
     "@tabler/icons-react": "^2.44.0",
-    "aiconfig": "^1.0.1",
+    "aiconfig": "^1.1.0",
     "next": "14.0.2",
     "node-fetch": "^3.3.2",
     "react": "^18",

--- a/cli/aiconfig-editor/pages/api/aiconfig/save.ts
+++ b/cli/aiconfig-editor/pages/api/aiconfig/save.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { promises as fs } from "fs";
 import { ErrorResponse } from "@/src/shared/serverTypes";
+import { AIConfig, AIConfigRuntime } from "aiconfig";
 
 type Data = {
   status: string;
@@ -8,7 +8,7 @@ type Data = {
 
 type RequestBody = {
   path: string;
-  aiconfig: any;
+  aiconfig: AIConfig;
 };
 
 export default async function handler(
@@ -29,9 +29,9 @@ export default async function handler(
     return res.status(500).json({ error: "No aiconfig data provided" });
   }
 
-  // TODO: There's no save without creating aiconfig object, and no clean way of only updating specific portions
-  // So ignore all of this & just save the json from the editor
-  await fs.writeFile(body.path, JSON.stringify(body.aiconfig, null, 2));
+  // Construct the config and ensure proper serialization for saving
+  const config = await AIConfigRuntime.loadJSON(body.aiconfig);
+  config.save(body.path, { serializeOutputs: true });
 
   res.status(200).json({ status: "ok" });
 }

--- a/cli/aiconfig-editor/src/components/EditorContainer.tsx
+++ b/cli/aiconfig-editor/src/components/EditorContainer.tsx
@@ -1,5 +1,5 @@
 import PromptContainer from "@/src/components/prompt/PromptContainer";
-import { Container, Text, Group, Button } from "@mantine/core";
+import { Container, Text, Group, Button, createStyles } from "@mantine/core";
 import { showNotification } from "@mantine/notifications";
 import { AIConfig, PromptInput } from "aiconfig";
 import router from "next/router";
@@ -10,6 +10,15 @@ type Props = {
   onBackNavigation: () => void;
   onSave: (aiconfig: AIConfig) => Promise<void>;
 };
+
+const useStyles = createStyles((theme) => ({
+  promptsContainer: {
+    [theme.fn.smallerThan("sm")]: {
+      padding: "0 0 200px 0",
+    },
+    paddingBottom: 400,
+  },
+}));
 
 export default function EditorContainer({
   aiconfig: initialAIConfig,
@@ -47,6 +56,8 @@ export default function EditorContainer({
     [aiconfig]
   );
 
+  const { classes } = useStyles();
+
   // TODO: Implement editor context for callbacks, readonly state, etc.
 
   return (
@@ -64,7 +75,7 @@ export default function EditorContainer({
           </Button>
         </Group>
       </Container>
-      <Container maw="80rem">
+      <Container maw="80rem" className={classes.promptsContainer}>
         {aiconfig.prompts.map((prompt: any, i: number) => {
           return (
             <PromptContainer

--- a/cli/aiconfig-editor/src/components/aiconfigReducer.ts
+++ b/cli/aiconfig-editor/src/components/aiconfigReducer.ts
@@ -1,0 +1,44 @@
+import { AIConfig, Prompt, PromptInput } from "aiconfig";
+
+type AIConfigReducerAction = UpdatePromptInputAction;
+
+export type UpdatePromptInputAction = {
+  type: "UPDATE_PROMPT_INPUT";
+  index: number;
+  input: PromptInput;
+};
+
+function reduceReplacePrompt(
+  state: AIConfig,
+  index: number,
+  replacerFn: (prompt: Prompt) => Prompt
+) {
+  return {
+    ...state,
+    prompts: state.prompts.map((prompt, i) =>
+      i === index ? replacerFn(prompt) : prompt
+    ),
+  };
+}
+
+function reduceReplaceInput(
+  state: AIConfig,
+  index: number,
+  replacerFn: (input: PromptInput) => PromptInput
+) {
+  return reduceReplacePrompt(state, index, (prompt) => ({
+    ...prompt,
+    input: replacerFn(prompt.input),
+  }));
+}
+
+export default function aiconfigReducer(
+  state: AIConfig,
+  action: AIConfigReducerAction
+) {
+  switch (action.type) {
+    case "UPDATE_PROMPT_INPUT": {
+      return reduceReplaceInput(state, action.index, () => action.input);
+    }
+  }
+}

--- a/cli/aiconfig-editor/src/components/prompt/model_settings/ModelSettingsRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/model_settings/ModelSettingsRenderer.tsx
@@ -1,13 +1,13 @@
 import ModelSettingsConfigRenderer from "@/src/components/prompt/model_settings/ModelSettingsConfigRenderer";
 import ModelSettingsSchemaRenderer from "@/src/components/prompt/model_settings/ModelSettingsSchemaRenderer";
-import { ModelSettingsSchema } from "@/src/utils/promptUtils";
+import { GenericPropertiesSchema } from "@/src/utils/promptUtils";
 import { Flex, Text } from "@mantine/core";
 import { Prompt } from "aiconfig";
 import { memo } from "react";
 
 type Props = {
   prompt: Prompt;
-  schema?: ModelSettingsSchema;
+  schema?: GenericPropertiesSchema;
 };
 
 // Don't default to config-level model settings since that could be confusing

--- a/cli/aiconfig-editor/src/components/prompt/model_settings/ModelSettingsSchemaRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/model_settings/ModelSettingsSchemaRenderer.tsx
@@ -1,12 +1,12 @@
 import SettingsPropertyRenderer from "@/src/components/SettingsPropertyRenderer";
 import { useSchemaState } from "@/src/hooks/useSchemaState";
-import { ModelSettingsSchema } from "@/src/utils/promptUtils";
+import { GenericPropertiesSchema } from "@/src/utils/promptUtils";
 import { Flex } from "@mantine/core";
 import { JSONObject } from "aiconfig/dist/common";
 import { memo } from "react";
 
 type Props = {
-  schema: ModelSettingsSchema;
+  schema: GenericPropertiesSchema;
   settings?: JSONObject;
 };
 

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/attachments/Attachment.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/attachments/Attachment.tsx
@@ -1,0 +1,18 @@
+import { memo } from "react";
+import type { Attachment as InputAttachment } from "aiconfig";
+import { Image } from "@mantine/core";
+
+type Props = {
+  attachment: InputAttachment;
+};
+
+export default memo(function Attachment({ attachment }: Props) {
+  const mimetype = (attachment.mime_type ?? "text/plain").split("/", 1)[0]; // MIME type without subtype
+  switch (mimetype) {
+    case "image":
+      // TODO: Figure out base64 encoding
+      return <Image alt="Attachment image" src={attachment.data as string} />;
+    default: // "text"
+      return <span>{attachment.data as string}</span>;
+  }
+});

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/attachments/AttachmentContainer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/attachments/AttachmentContainer.tsx
@@ -1,0 +1,52 @@
+import { memo } from "react";
+import type { Attachment as InputAttachment } from "aiconfig";
+import { PromptInputObjectAttachmentsSchema } from "@/src/utils/promptUtils";
+import Attachment from "@/src/components/prompt/prompt_input/attachments/Attachment";
+import { ActionIcon, Container, Flex, Tooltip } from "@mantine/core";
+import { IconEdit, IconTrash } from "@tabler/icons-react";
+import AttachmentMetadata from "@/src/components/prompt/prompt_input/attachments/AttachmentMetadata";
+
+type Props = {
+  schema: PromptInputObjectAttachmentsSchema;
+  attachment: InputAttachment;
+  onUpdateMetadata?: (metadata: { [k: string]: any }) => void;
+  onRemoveAttachment?: () => void;
+  onEditAttachment?: () => void;
+};
+
+export default memo(function AttachmentContainer({
+  schema,
+  attachment,
+  onUpdateMetadata,
+  onRemoveAttachment,
+  onEditAttachment,
+}: Props) {
+  return (
+    <Container display="flex">
+      <Flex direction="column">
+        {onEditAttachment && (
+          <ActionIcon onClick={onEditAttachment}>
+            <Tooltip label="Edit attachment">
+              <IconEdit size={16} />
+            </Tooltip>
+          </ActionIcon>
+        )}
+        {onRemoveAttachment && (
+          <ActionIcon onClick={onRemoveAttachment}>
+            <Tooltip label="Remove attachment">
+              <IconTrash size={16} color="red" />
+            </Tooltip>
+          </ActionIcon>
+        )}
+      </Flex>
+      <Attachment attachment={attachment} />
+      {schema.items.properties?.metadata && (
+        <AttachmentMetadata
+          schema={schema.items.properties.metadata}
+          attachment={attachment}
+          onUpdateMetadata={onUpdateMetadata}
+        />
+      )}
+    </Container>
+  );
+});

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/attachments/AttachmentMetadata.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/attachments/AttachmentMetadata.tsx
@@ -1,0 +1,24 @@
+import { memo } from "react";
+import type { Attachment as InputAttachment } from "aiconfig";
+import {
+  GenericPropertiesSchema,
+  PromptInputObjectAttachmentsSchema,
+} from "@/src/utils/promptUtils";
+import { useSchemaState } from "@/src/hooks/useSchemaState";
+
+type Props = {
+  schema: GenericPropertiesSchema;
+  attachment: InputAttachment;
+  onUpdateMetadata?: (metadata: { [k: string]: any }) => void;
+};
+
+export default memo(function AttachmentMetadata({
+  schema,
+  attachment,
+  onUpdateMetadata,
+}: Props) {
+  const metadataState = useSchemaState(schema, attachment.metadata);
+  // TODO: Implement similar to ModelSettingsSchemaRenderer. Can probably generalize to one component
+  // which properly updates the right aiconfig properties based on callback function
+  return null;
+});

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/attachments/AttachmentUploader.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/attachments/AttachmentUploader.tsx
@@ -1,0 +1,135 @@
+import { memo, useState } from "react";
+import type { Attachment, Attachment as InputAttachment } from "aiconfig";
+import { PromptInputObjectAttachmentsSchema } from "@/src/utils/promptUtils";
+import { Dropzone, FileRejection } from "@mantine/dropzone";
+import {
+  UploadState,
+  getDropzoneUploadErrorMessage,
+} from "@/src/utils/dropzoneHelpers";
+import { ActionIcon, Container, Text, Title, Tooltip } from "@mantine/core";
+import { IconX } from "@tabler/icons-react";
+
+type Props = {
+  schema: PromptInputObjectAttachmentsSchema;
+  onUploadAttachments: (attachments: InputAttachment[]) => void;
+  onCancel?: () => void;
+};
+
+async function uploadFile(file: File) {
+  // TODO: Implement
+  return {
+    url: "https://s3.amazonaws.com/files.uploads.lastmileai.com/uploads/cldxsqbel0000qs8owp8mkd0z/2023_12_1_21_23_24/942/Screenshot 2023-11-28 at 11.11.25 AM.png",
+  };
+}
+
+function getSupportedFileTypes(schema: PromptInputObjectAttachmentsSchema) {
+  return schema.items.mime_types;
+}
+
+export default memo(function AttachmentUploader({
+  schema,
+  onUploadAttachments,
+  onCancel,
+}: // TODO: Handle max files, taking into account existing attachments
+Props) {
+  const [fileList, setFileList] = useState<File[]>([]);
+  const [uploadState, setUploadState] = useState<UploadState>("idle");
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const onDropzoneClick = async (files: File[]) => {
+    if (uploadState === "dropzone_error") {
+      // button should be disabled anyway, but just in case
+      return;
+    }
+    let uploads: { url: string; mimeType: string }[] = [];
+
+    try {
+      if (files.length > 0) {
+        setUploadState("uploading");
+        uploads = await Promise.all(
+          files.map(async (file: File) => {
+            const upload = await uploadFile(file);
+            return {
+              url: upload.url,
+              mimeType: file.type,
+            };
+          })
+        );
+      }
+
+      const uploadedFileUrl = uploads[0]?.url;
+      if (!uploadedFileUrl) {
+        throw new Error("Error uploading file");
+      }
+      setUploadState("success");
+
+      const attachments: Attachment[] = uploads.map((upload) => {
+        return {
+          data: upload.url,
+          mimeType: upload.mimeType,
+        };
+      });
+
+      onUploadAttachments(attachments);
+    } catch (error) {
+      setUploadState("upload_error");
+      const errorMessage = (error as any)?.message ?? "Error uploading file";
+      setUploadError(errorMessage);
+    }
+  };
+
+  const maxFileSize = schema.items.max_size;
+
+  return (
+    <div>
+      {(uploadState === "upload_error" || uploadState === "dropzone_error") &&
+        uploadError && (
+          <Text size="xs" color="red">
+            {uploadError}
+          </Text>
+        )}
+      <Container display="flex">
+        {onCancel && (
+          <ActionIcon onClick={onCancel}>
+            <Tooltip label="Cancel">
+              <IconX size={16} />
+            </Tooltip>
+          </ActionIcon>
+        )}
+        <Dropzone
+          multiple={true}
+          onDrop={(files: File[]) => {
+            setUploadState("idle");
+            setFileList(files);
+            onDropzoneClick(files);
+          }}
+          onReject={(fileRejections: FileRejection[]) => {
+            setUploadState("dropzone_error");
+            const fileName = fileRejections?.[0]?.file?.name;
+            const error = fileRejections?.[0]?.errors?.[0];
+            setUploadError(getDropzoneUploadErrorMessage(error, fileName));
+          }}
+          // TODO: Get these from schema,
+          // maxSize={MAX_IMAGE_FILE_SIZE}
+          // accept={}
+        >
+          {fileList.length > 0 ? (
+            `${fileList.length} File(s) to Upload`
+          ) : (
+            <div>
+              <Title order={4}>Upload File</Title>
+              <Text fz="sm" c="dimmed">
+                Supported files: {getSupportedFileTypes(schema)}
+              </Text>
+              {maxFileSize && (
+                <Text fz="sm" c="dimmed">
+                  Max file size: {maxFileSize}MB
+                </Text>
+              )}
+            </div>
+          )}
+        </Dropzone>
+      </Container>
+    </div>
+  );
+});

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/schema_renderer/PromptInputAttachmentsSchemaRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/schema_renderer/PromptInputAttachmentsSchemaRenderer.tsx
@@ -1,14 +1,123 @@
 import { PromptInputObjectAttachmentsSchema } from "@/src/utils/promptUtils";
-import { JSONValue } from "aiconfig/dist/common";
-import { memo } from "react";
+import type { Attachment as InputAttachment } from "aiconfig";
+import { memo, useState } from "react";
+import AttachmentContainer from "@/src/components/prompt/prompt_input/attachments/AttachmentContainer";
+import AttachmentUploader from "@/src/components/prompt/prompt_input/attachments/AttachmentUploader";
+import { Container } from "@mantine/core";
 
 type Props = {
   schema: PromptInputObjectAttachmentsSchema;
-  onChangeAttachments: (value: JSONValue) => void;
+  onChangeAttachments: (value: InputAttachment[]) => void;
+  attachments?: InputAttachment[];
 };
 
-export default memo(function PromptInputAttachmentsSchemaRenderer(
-  props: Props
-) {
-  return "ATTACHMENTS SCHEMA RENDERER";
+function EditableAttachmentRenderer({
+  schema,
+  attachment,
+  onUpdateAttachment,
+  onAddAttachments,
+  onRemoveAttachment,
+}: {
+  schema: PromptInputObjectAttachmentsSchema;
+  attachment?: InputAttachment;
+  onUpdateAttachment: (attachment: InputAttachment) => void;
+  onAddAttachments: (value: InputAttachment[]) => void;
+  onRemoveAttachment?: () => void;
+}) {
+  const [showUploader, setShowUploader] = useState(attachment?.data == null);
+
+  return (
+    <Container m="xs">
+      {attachment && !showUploader ? (
+        <AttachmentContainer
+          attachment={attachment}
+          schema={schema}
+          onUpdateMetadata={(metadata: { [k: string]: any }) =>
+            onUpdateAttachment({ ...attachment, metadata })
+          }
+          onRemoveAttachment={onRemoveAttachment}
+          onEditAttachment={() => setShowUploader(true)}
+        />
+      ) : (
+        <AttachmentUploader
+          schema={schema}
+          onUploadAttachments={(attachments: InputAttachment[]) => {
+            onAddAttachments(attachments);
+            setShowUploader(false);
+          }}
+          // Can only cancel if there is already an attachment to toggle back to
+          onCancel={!attachment ? undefined : () => setShowUploader(false)}
+        />
+      )}
+    </Container>
+  );
+}
+
+export default memo(function PromptInputAttachmentsSchemaRenderer({
+  schema,
+  onChangeAttachments,
+  attachments = [],
+}: Props) {
+  const onUpdateAttachment = (attachment: InputAttachment, index: number) => {
+    const newAttachments = [...attachments];
+    newAttachments[index] = attachment;
+    onChangeAttachments(newAttachments);
+  };
+
+  const onAddAttachments = (
+    addedAttachments: InputAttachment[],
+    index: number
+  ) => {
+    const updatedAttachments = attachments.reduce((acc, attachment, i) => {
+      if (i === index) {
+        // Replace the attachment at the given index with the new attachments
+        return [...acc, ...addedAttachments];
+      }
+      return [...acc, attachment];
+    }, [] as InputAttachment[]);
+    onChangeAttachments(updatedAttachments);
+  };
+
+  const onRemoveAttachment = (index: number) => {
+    const newAttachments = [
+      ...attachments.slice(0, index),
+      ...attachments.slice(index + 1),
+    ];
+    onChangeAttachments(newAttachments);
+  };
+
+  const numAttachments = attachments.length;
+
+  return (
+    <>
+      {attachments.map((attachment, i) => (
+        <EditableAttachmentRenderer
+          key={`${JSON.stringify(attachment.data)}-${i}`}
+          attachment={attachment}
+          schema={schema}
+          onUpdateAttachment={(attachment) => onUpdateAttachment(attachment, i)}
+          onAddAttachments={(addedAttachments) =>
+            onAddAttachments(addedAttachments, i)
+          }
+          onRemoveAttachment={() => onRemoveAttachment(i)}
+        />
+      ))}
+
+      {/* If the schema supports more attachments, add another attachment input below existing attachments. This
+       * will allow the user to add more attachments without 'clearing' existing ones.
+       */}
+      {schema.max_items == null ||
+        (numAttachments < schema.max_items && (
+          <EditableAttachmentRenderer
+            schema={schema}
+            onUpdateAttachment={(attachment) =>
+              onUpdateAttachment(attachment, numAttachments + 1)
+            }
+            onAddAttachments={(addedAttachments) =>
+              onAddAttachments(addedAttachments, numAttachments + 1)
+            }
+          />
+        ))}
+    </>
+  );
 });

--- a/cli/aiconfig-editor/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
@@ -5,7 +5,7 @@ import {
 import DataRenderer from "@/src/components/prompt/prompt_input/schema_renderer/PromptInputDataSchemaRenderer";
 import AttachmentsRenderer from "@/src/components/prompt/prompt_input/schema_renderer/PromptInputAttachmentsSchemaRenderer";
 import { Flex, Textarea } from "@mantine/core";
-import { PromptInput } from "aiconfig";
+import { Attachment, PromptInput } from "aiconfig";
 import { memo } from "react";
 
 type Props = {
@@ -36,7 +36,7 @@ function SchemaRenderer({ input, schema, onChangeInput }: SchemaRendererProps) {
     onChangeInput({ ...input, data: value });
   };
 
-  const onChangeAttachments = (value: any) => {
+  const onChangeAttachments = (value: Attachment[]) => {
     onChangeInput({ ...input, attachments: value });
   };
 
@@ -51,6 +51,7 @@ function SchemaRenderer({ input, schema, onChangeInput }: SchemaRendererProps) {
         <AttachmentsRenderer
           schema={attachmentsSchema}
           onChangeAttachments={onChangeAttachments}
+          attachments={attachments}
         />
       )}
       {/* <JSONRenderer properties={restProperties} data={restData}/> */}

--- a/cli/aiconfig-editor/src/components/prompt/prompt_metadata/PromptMetadataRenderer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/prompt_metadata/PromptMetadataRenderer.tsx
@@ -1,10 +1,10 @@
-import { PromptMetadataSchema } from "@/src/utils/promptUtils";
+import { GenericPropertiesSchema } from "@/src/utils/promptUtils";
 import { Prompt } from "aiconfig";
 import { memo } from "react";
 
 type Props = {
   prompt: Prompt;
-  schema?: PromptMetadataSchema;
+  schema?: GenericPropertiesSchema;
 };
 
 function ModelMetadataConfigRenderer({ prompt }: Props) {

--- a/cli/aiconfig-editor/src/hooks/useSchemaState.ts
+++ b/cli/aiconfig-editor/src/hooks/useSchemaState.ts
@@ -1,14 +1,11 @@
-import {
-  ModelSettingsSchema,
-  PromptMetadataSchema,
-} from "@/src/utils/promptUtils";
+import { GenericPropertiesSchema } from "@/src/utils/promptUtils";
 import { useCallback, useRef, useState } from "react";
 
-// Local state to maintain all the possible properties from a schema, as well as 'dirty' state to track
+// Local state to maintain all the possible generic properties from a schema, as well as 'dirty' state to track
 // which properties have been changed. This is used to determine which properties to propagate to the config.
-// Otherwise, the config would be bloated with unnecessary settings just by loading it in the editor.
+// Otherwise, the config would be bloated with unnecessary properties just by loading it in the editor.
 export function useSchemaState(
-  schema: ModelSettingsSchema | PromptMetadataSchema,
+  schema: GenericPropertiesSchema,
   initialData?: Record<string, unknown>
 ) {
   const [schemaState, setSchemaState] = useState<

--- a/cli/aiconfig-editor/src/utils/dropzoneHelpers.ts
+++ b/cli/aiconfig-editor/src/utils/dropzoneHelpers.ts
@@ -1,0 +1,23 @@
+export type UploadState =
+  | "idle"
+  | "dropzone_error"
+  | "uploading"
+  | "upload_error"
+  | "success";
+
+export function getDropzoneUploadErrorMessage(
+  error?: {
+    code?: string;
+    message?: string;
+  },
+  fileName?: string
+) {
+  let errorMessage = `Failed to upload file${fileName ? ` ${fileName}` : ""}`;
+  if (error?.code === "file-too-large") {
+    errorMessage += ": File too large. Please upload a smaller file"; // TODO: Can we specify file size limits for attachments?
+  } else if (error?.message) {
+    errorMessage += `: ${error.message}`;
+  }
+
+  return errorMessage;
+}

--- a/cli/aiconfig-editor/src/utils/promptUtils.ts
+++ b/cli/aiconfig-editor/src/utils/promptUtils.ts
@@ -63,14 +63,18 @@ export type PromptInputObjectDataSchema = {
 
 export type PromptInputObjectAttachmentsSchema = {
   type: "array";
+  min_items?: number;
+  max_items?: number;
   items: {
     type: "attachment";
     required: string[];
     mime_types: string[];
+    max_size?: number;
     properties: {
       data: {
         type: string;
       };
+      metadata?: GenericPropertiesSchema;
     };
   };
 };
@@ -84,20 +88,20 @@ export type PromptInputObjectSchema = {
   required?: string[] | undefined;
 };
 
-export type ModelSettingsSchema = {
-  properties: Record<string, { [key: string]: any }>;
-  required?: string[];
-};
-
-export type PromptMetadataSchema = {
-  properties: Record<string, { [key: string]: any }>;
-  required?: string[];
+export type GenericPropertiesSchema = {
+  properties: Record<
+    string,
+    {
+      [key: string]: any;
+    }
+  >;
+  required?: string[] | undefined;
 };
 
 export type PromptSchema = {
   input: PromptInputSchema;
-  model_settings?: ModelSettingsSchema;
-  prompt_metadata?: PromptMetadataSchema;
+  model_settings?: GenericPropertiesSchema;
+  prompt_metadata?: GenericPropertiesSchema;
 };
 
 export function getPromptSchema(

--- a/cli/aiconfig-editor/yarn.lock
+++ b/cli/aiconfig-editor/yarn.lock
@@ -57,12 +57,26 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
+"@colors/colors@1.6.0", "@colors/colors@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.6.0.tgz#ec6cd237440700bc23ca23087f513c75508958b0"
+  integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
+
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.3.tgz#7f7e97ee9a725dffc7808d93668cc984e1dc477a"
+  integrity sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
 
 "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"
@@ -244,6 +258,11 @@
     long "^5.0.0"
     protobufjs "^7.2.4"
     yargs "^17.7.2"
+
+"@huggingface/inference@^2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@huggingface/inference/-/inference-2.6.4.tgz#a17d73e6e6558670a607752c44ac5868286ceb09"
+  integrity sha512-Xna7arltBSBoKaH3diGi3sYvkExgJMd/pF4T6vl2YbmDccbr1G/X5EPZ2048p+YgrJYG1jTYFCtY6Dr3HvJaow==
 
 "@humanwhocodes/config-array@^0.11.13":
   version "0.11.13"
@@ -766,6 +785,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
+"@types/triple-beam@^1.3.2":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
+  integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
+
 "@typescript-eslint/parser@^5.4.2 || ^6.0.0":
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.10.0.tgz#578af79ae7273193b0b6b61a742a2bc8e02f875a"
@@ -859,12 +883,13 @@ agentkeepalive@^4.2.1:
   dependencies:
     humanize-ms "^1.2.1"
 
-aiconfig@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/aiconfig/-/aiconfig-1.0.1.tgz#435c7f4aeedd16da0b4134bbe0d914a963665279"
-  integrity sha512-umL54u8IDUgTGy5cxf+ydeh9ynHU3NRW5EH1swVPs2RUmb1cMVaKxEdeD9BtmCJ9Qi2jOmQkjCcdezFV18ZypA==
+aiconfig@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/aiconfig/-/aiconfig-1.1.0.tgz#18772e1256512122d79b24153db3ed695fd1075b"
+  integrity sha512-di0F5qc/dSpQglpKgVZQXlmv1mbQw3X6uJ23GRra9rbj2WbcspXetCENC7fQNoPnuuwHztbW1vQGc/hEO6kwnQ==
   dependencies:
     "@google-ai/generativelanguage" "^1.1.0"
+    "@huggingface/inference" "^2.6.4"
     axios "^1.5.1"
     google-auth-library "^9.1.0"
     gpt-3-encoder "^1.1.4"
@@ -873,6 +898,7 @@ aiconfig@^1.0.1:
     openai "^4.11.1"
     typescript-json-schema "^0.60.0"
     uuid "^9.0.1"
+    winston "^3.11.0"
 
 ajv@^6.12.4:
   version "6.12.6"
@@ -1010,6 +1036,11 @@ ast-types-flow@^0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.8.tgz#0a85e1c92695769ac13a428bb653e7538bea27d6"
   integrity sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==
+
+async@^3.2.3:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
+  integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
 
 asynciterator.prototype@^1.0.0:
   version "1.0.0"
@@ -1170,7 +1201,7 @@ clsx@1.1.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -1189,10 +1220,34 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 combined-stream@^1.0.6, combined-stream@^1.0.8:
   version "1.0.8"
@@ -1411,6 +1466,11 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 encoding@^0.1.11:
   version "0.1.13"
@@ -1805,6 +1865,11 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fecha@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
+  integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
+
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
@@ -1860,6 +1925,11 @@ flatted@^3.2.9:
   version "3.2.9"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 follow-redirects@^1.15.0:
   version "1.15.3"
@@ -2315,6 +2385,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-async-function@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-async-function/-/is-async-function-2.0.0.tgz#8e4418efd3e5d3a6ebb0164c05ef5afb69aa9646"
@@ -2604,6 +2679,11 @@ klona@^2.0.5:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.6.tgz#85bffbf819c03b2f53270412420a4555ef882e22"
   integrity sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 language-subtag-registry@^0.3.20:
   version "0.3.22"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz#2e1500861b2e457eba7e7ae86877cbd08fa1fd1d"
@@ -2650,6 +2730,18 @@ lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+logform@^2.3.2, logform@^2.4.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.6.0.tgz#8c82a983f05d6eaeb2d75e3decae7a768b2bf9b5"
+  integrity sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==
+  dependencies:
+    "@colors/colors" "1.6.0"
+    "@types/triple-beam" "^1.3.2"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^2.3.1"
+    triple-beam "^1.3.0"
 
 long@^5.0.0:
   version "5.2.3"
@@ -2879,6 +2971,13 @@ once@^1.3.0, once@^1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
 
 openai@^4.11.1:
   version "4.17.4"
@@ -3127,7 +3226,7 @@ react@^18:
   dependencies:
     loose-envify "^1.1.0"
 
-readable-stream@^3.1.1:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -3248,7 +3347,7 @@ safe-regex-test@^1.0.0:
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
 
-safe-stable-stringify@^2.2.0:
+safe-stable-stringify@^2.2.0, safe-stable-stringify@^2.3.1:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
   integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
@@ -3317,6 +3416,13 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -3336,6 +3442,11 @@ source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
 
 stream-events@^1.0.5:
   version "1.0.5"
@@ -3500,6 +3611,11 @@ teeny-request@^9.0.0:
     stream-events "^1.0.5"
     uuid "^9.0.0"
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -3521,6 +3637,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+triple-beam@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.4.1.tgz#6fde70271dc6e5d73ca0c3b24e2d92afb7441984"
+  integrity sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==
 
 ts-api-utils@^1.0.1:
   version "1.0.3"
@@ -3809,6 +3930,32 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+winston-transport@^4.5.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.6.0.tgz#f1c1a665ad1b366df72199e27892721832a19e1b"
+  integrity sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==
+  dependencies:
+    logform "^2.3.2"
+    readable-stream "^3.6.0"
+    triple-beam "^1.3.0"
+
+winston@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.11.0.tgz#2d50b0a695a2758bb1c95279f0a88e858163ed91"
+  integrity sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==
+  dependencies:
+    "@colors/colors" "^1.6.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.4.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.5.0"
 
 wordwrap@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
[editor] Move aiconfig state to reducer

# Move aiconfig state to reducer

Implement an aiconfigReducer for managing the client-side AIConfig state, with UPDATE_PROMPT_INPUT as the first action. Note that we won't be propagating dispatch through to nested components for 2 main reasons:
1. Actions should be dispatched from the "root" EditorContainer so that they can also propagate event data to the server-side config. The root will be the interface between client and server
2. We will want to support custom user-provided PromptContainers and PromptInputRenderers but want to make it hard for such components to accidentally modify state unrelated to their prompt. As a result, we should leverage props for passing callbacks to these components instead of allowing them to dispatch arbitrary actions

Based on the above, the common flow for defining and handling events will be:
1. Define callback for event in EditorContainer, which dispatches the relevant action to update client-side state, sends async request to server, then updates client-side state with response data (as applicable)
2. Pass this callback down as a prop to the relevant Prompt (keyed on prompt index)


## Testing:
Updated the text for the first prompt and saved the config, reloading to ensure the changes were persisted

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/514).
* #515
* __->__ #514
* #511
* #510