### PR TITLE
[py] pin openai dependency to < 1.5

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,7 @@ pytest
 pydantic>=2.1
 pybars3
 google-generativeai
-openai>=1.0.0
+openai >= 1.0.0, < 1.5
 python-dotenv
 huggingface_hub
 result


### PR DESCRIPTION
[py] pin openai to a range of versions

## What

pin openai dependency to 1.0.0 < x < 1.5

## Why

OpenAI updated the api to 1.5. https://github.com/openai/openai-python/releases/tag/v1.5.0

Looks like the new version updates the Chat Completion type with a new field `logprobs`
