### PR TITLE
[ts] Pin OpenAI to 4.11.1

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -52,7 +52,7 @@
     "gpt-3-encoder": "^1.1.4",
     "handlebars": "^4.7.8",
     "lodash": "^4.17.21",
-    "openai": "^4.11.1",
+    "openai": "4.11.1",
     "typescript-json-schema": "^0.60.0",
     "uuid": "^9.0.1",
     "winston": "^3.11.0"


### PR DESCRIPTION
[ts] Pin OpenAI to 4.11.1


## What

Pin OpenAI Typescript dependency to 4.11.1.

## Why

Tested the Function Call Stream demo where OpenAI was set to openai@4.23.0

This failed due to a missing attribute `function_call` from type `ChatCompletionMessageParam`. Not entirely sure  if this breaks library atm.

Previously We've been working with `4.11.1`.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/524).
* #520
* __->__ #524