### PR TITLE
2/n Gemini Serialize()

### DIFF
--- a/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py
+++ b/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py
@@ -1,5 +1,6 @@
 # Define a Model Parser for LLama-Guard
 from typing import TYPE_CHECKING, Dict, List, Optional, Any
+import copy
 
 import google.generativeai as genai
 import copy
@@ -15,6 +16,23 @@ from google.generativeai.types import content_types
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
     from google.generativeai.types import AsyncGenerateContentResponse
+
+
+DOCSTRING = """
+Model Parser for Gemini text to text models. Doesn't support image generation yet. 
+Function calling is not available on the public release Gemini api. Function Calling is also not supported in this model parser.
+See this link for more information on api versions: https://ai.google.dev/docs/api_versions
+
+@ankush-lastmile 
+TODO: This model Parser does not support multimodal
+TODO: This model Parser does not support function calling (not available)
+TODO: This model Parser does not support serializing all different types of the Gemini API (ie protos)
+TODO: This model Parser does not support chat history if the input of a prompt is NOT a template (aka a string)
+TODO: This model Parser does not support strongly structuring the input data containing the configmetadata for the Gemini API
+- The `GenerationConfig` must be specified explicitly underneat `settings as its own nested dict. see #532 Test Plan for more info https://github.com/lastmile-ai/aiconfig/pull/532
+- Docs ref: https://ai.google.dev/tutorials/python_quickstart#generation_configuration
+"""
+
 
 def construct_regular_outputs(response: "AsyncGenerateContentResponse") -> list[Output]:
     """
@@ -90,7 +108,23 @@ class GeminiModelParser(ParameterizedModelParser):
         **kwargs,
     ) -> List[Prompt]:
         """
-        Defines how a prompt and model inference settings get serialized in the .aiconfig.
+        Defines how a prompt or a multi turn prompt chain along with model inference settings get serialized into prompts for AIConfig.
+        If given a conversation history, this method should return a list of prompts.
+        Check out the docs for multi-turn conversations here: https://ai.google.dev/tutorials/python_quickstart#multi-turn_conversations
+
+        The data passed in is the completion params a user would use to call the Gemini API directly.
+        If the user wanted to call the Gemini API directly, they might do something like this:
+        
+        ```
+        model = genai.GenerativeModel('gemini-pro')
+        completion_params = {"contents": "Hello"}
+        
+        model.generate_content(**completion_params)
+        # Note: The above line is the same as doing this: 
+        model.generate_content(contents="Hello")
+        ```
+        * Important: The contents field is what contains the input data. In this case, prompt input would be the contents field.
+        
 
         Args:
             prompt (str): The prompt to be serialized.
@@ -98,6 +132,26 @@ class GeminiModelParser(ParameterizedModelParser):
 
         Returns:
             str: Serialized representation of the prompt and inference settings.
+
+        Sample Usage:
+            1. 
+                completion_params = {"contents": "Hello"}
+                serialized_prompts = await ai_config.serialize("prompt", completion_params, "gemini-pro")
+
+            2.  completion_params = {"contents": ["Hello", "Hi]}
+                serialized_prompts = await ai_config.serialize("prompt", completion_params, "gemini-pro")
+
+            3.  completion_params = {"contents": {"role": "user", "parts": "Hello"}}
+                serialized_prompts = await ai_config.serialize("prompt", completion_params, "gemini-pro")
+
+            4.  completion_params = {"contents": {
+                                            [
+                                                {"role": "user", "parts": "[Hello]"},
+                                                {"role": "model", "parts": ["Hi!]"},
+                                                {"role": "user", "parts": ["What's your favorite condiment?"]},
+                                            ]
+                                                }}
+                serialized_prompts = await ai_config.serialize("prompt", completion_params, "gemini-pro")
         """
 
         event = CallbackEvent(
@@ -112,14 +166,59 @@ class GeminiModelParser(ParameterizedModelParser):
         )
         await ai_config.callback_manager.run_callbacks(event)
 
-        raise Exception("Not Implemented")
+        # Don't operate on the original data object
+        data = copy.deepcopy(data)
+        contents = data.pop("contents", None)
+
+        model_name = self.model.model_name[len("models/"):]
+        model_metadata = ai_config.get_model_metadata(data, model_name)
+
+        prompts = []
+
+        contents_is_str = isinstance(contents, str)
+        contents_is_list_of_strings = all(isinstance(item, str) for item in contents) if isinstance(contents, list) else False
+        
+        # Role Dict looks like this:
+        #     {'role':'user',
+        #      'parts': ["Briefly explain how a computer works to a young child."]
+        #     }
+        contents_is_role_dict = isinstance(contents, dict) and "role" in contents and "parts"
+        # Multi Turn means that the contents is a list of dicts with alternating role and parts. See for more info: https://ai.google.dev/tutorials/python_quickstart#multi-turn_conversations
+        contents_is_multi_turn = isinstance(contents, list) and all(isinstance(item, dict) and "role" in item and "parts" in item for item in contents)
+
+        if contents is None:
+            raise ValueError("No contents found in data. Gemini api request requires a contents field")
+        if contents_is_str or contents_is_list_of_strings or contents_is_role_dict:
+            # Just one string. Assume it's a single-turn prompt
+            prompt = Prompt(**{"name": prompt_name, "input": {"contents": contents}, "metadata": {"model": model_metadata}})
+            prompts.append(prompt)
+        elif contents_is_multi_turn:
+            # Assume it's a multi-turn prompt. Each item in the list is a dict with role and parts
+            i = 0
+            while i < len(contents):
+                user_message = contents[i]
+                user_message_parts = user_message["parts"]
+                outputs = []
+                if i + 1 < len(contents):
+                    model_message = contents[i + 1]
+                    model_message_parts = model_message["parts"]
+                    # Gemini api currently only supports one candidate aka  one output. Model should only be retuning one part in response.
+                    # Should output data be this list of parts? or just the first one? TODO: figure out if Gemini outputs may contain more than one part.
+                    # see https://ai.google.dev/tutorials/python_quickstart#multi-turn_conversations:~:text=Note%3A%20For%20multi%2Dturn%20conversations%2C%20you%20need%20to%20send%20the%20whole%20conversation%20history%20with%20each%20request
+                    outputs = [ExecuteResult(**{"output_type": "execute_result", "data": model_message_parts[0], "metadata": {}})]
+                    i += 1
+                prompt = Prompt(**{"name": f'{prompt_name}_{len(prompts) + 1}', "input": user_message_parts, "metadata": {"model": model_metadata}, "outputs": outputs})
+                prompts.append(prompt)
+                i += 1
+        else:
+            raise ValueError("Unable to parse Data into prompts. Contents data is either invalid or contains unsupported objects like protobufs.")
 
         event = CallbackEvent("on_serialize_complete", __name__, {"result": prompts})
         await ai_config.callback_manager.run_callbacks(event)
 
-    async def deserialize(
-        self, prompt: Prompt, aiconfig: "AIConfigRuntime", params: Optional[Dict] = None
-    ) -> Dict:
+        return prompts
+
+    async def deserialize(self, prompt: Prompt, aiconfig: "AIConfigRuntime", params: Optional[Dict] = None) -> Dict:
         """
         Defines how to parse a prompt in the .aiconfig for a particular model
         and constructs the completion params for that model.


### PR DESCRIPTION
2/n Gemini Serialize()



## What

Implemented the serialize() method of the Gemini Model parser

The gemini api is a bit trickier than previous api's we've seen before. Using the OpenAI api as a comparison point, the Gemini api is a little bit more complex.

The request takes in a contents field, which can have various types. This is because the api supports
- one shot prompts
- one shot prompting but with multiple "parts"
- multi-turn conversation with multiple parts
- multi-modal one shot with multiple parts (out of scope of this diff)

Note: `part` refers to some form of data. Either a string, a proto, a blob, or mime typed data. Gemini api has done a good job in supporting a wide array of use cases.

For simplicity, I've limited the serialize() functionality to string objects or list/dict objects with strings. If the object contains something else, an error is thrown

Notes:
- Function Calling is not supported by the public release beta. This is only available in a beta not available to the general public. Incorporating this into serialize/deserialize() may require an extra step of parsing the input. Specifically, function calling takes in a param called `tools`.


## Why

Was not implemented previously, planned as a fast follow.

## Testplan

<img width="1487" alt="Serialize Test plan 1" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/ffe8a874-5138-43e3-ba05-d30342140caa">
<img width="1625" alt="serialize test plan 2" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/e7fbc0bd-e940-4e54-8727-648d186fc4e6">


## Issue

#463

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/531).
* #558
* #534
* __->__ #531
* #532