### PR TITLE
[AIC-py][eval] bundle of small easy fixes

### DIFF
--- a/python/src/aiconfig/eval/common.py
+++ b/python/src/aiconfig/eval/common.py
@@ -19,7 +19,7 @@ T_BaseModel = TypeVar("T_BaseModel", bound=BaseModel)
 SerializedJSON = NewType("SerializedJSON", str)
 
 
-@dataclass(eq=False)
+@dataclass(frozen=True)
 class CustomMetricValue(ABC):
     """
     Subclass this if you want your metric to return a type not included in MetricValue.
@@ -39,7 +39,7 @@ class CompletionTextToSerializedJSON(Protocol):
         pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class CustomMetricPydanticObject(CustomMetricValue, Generic[T_BaseModel]):
     data: T_BaseModel
 
@@ -98,8 +98,10 @@ class EvaluationMetricMetadata(cu.Record, Generic[T_Evaluable, T_MetricValue]):
         return f"EvaluationMetricMetadata({s_json})"
 
 
-@dataclass
+@dataclass(frozen=True)
 class SampleMetricValue(Generic[T_Evaluable, T_MetricValue]):
+    # `None` is used to signal that there was an error during calculation.
+    # In this case, error information is written to stderr (see lib.py:_evaluate_for_sample()).
     value: T_MetricValue | None
     metric_metadata: EvaluationMetricMetadata[T_Evaluable, T_MetricValue]
 

--- a/python/src/aiconfig/eval/metrics.py
+++ b/python/src/aiconfig/eval/metrics.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from abc import abstractmethod
+from dataclasses import dataclass
 from functools import partial, total_ordering
 from typing import Any, Callable, Generic, Protocol, Type
 
@@ -18,7 +19,6 @@ from aiconfig.eval.common import (
     TextRatingsData,
 )
 from aiconfig.eval.openai import OpenAIChatCompletionCreate, default_openai_chat_completion_create, make_fn_completion_text_to_serialized_json
-from attr import dataclass
 from nltk.sentiment.vader import SentimentIntensityAnalyzer as NLTKSentimentIntensityAnalyzer
 from result import Err, Ok, Result
 
@@ -56,7 +56,7 @@ async def _calculate_brevity(datum: str) -> int:
     return len(datum)
 
 
-@dataclass
+@dataclass(frozen=True)
 class TextSentimentScores(CustomMetricValue):
     mapping: dict[str, float]
     pos: float
@@ -67,7 +67,7 @@ class TextSentimentScores(CustomMetricValue):
 
 
 @total_ordering
-@dataclass(eq=False)
+@dataclass(frozen=True, eq=False)
 class TextOverallPositiveSentiment(CustomMetricValue):
     """Compare by total positive sentiment: positive - negative"""
 

--- a/python/src/aiconfig/eval/openai.py
+++ b/python/src/aiconfig/eval/openai.py
@@ -9,7 +9,7 @@ from aiconfig.eval import common
 from result import Err, Ok, Result
 
 
-@dataclass
+@dataclass(frozen=True)
 class OpenAIChatCompletionParams:
     # TODO: type better
     messages: list[openai_types.ChatCompletionMessageParam]

--- a/python/tests/mocks.py
+++ b/python/tests/mocks.py
@@ -1,0 +1,30 @@
+
+from typing import Any
+
+from aiconfig.Config import AIConfigRuntime
+from aiconfig.model_parser import InferenceOptions
+
+
+class MockAIConfigRuntime(AIConfigRuntime):
+    def __init__(self):
+        pass
+
+    async def run_and_get_output_text(
+        self,
+        prompt_name: str,
+        params: dict[Any, Any] | None = None,
+        options: InferenceOptions | None = None,
+        **kwargs,  # type: ignore
+    ) -> str:
+        """
+        This overrides the real method for mocking, but the output doesn't matter very much.
+        We're currently not really testing properties of the output.
+        We just have to return a string so the tests work.
+
+        Real method: https://github.com/lastmile-ai/aiconfig/blob/a4376d1f951e19776633d397a3cda7fa85506eef/python/src/aiconfig/Config.py#L277
+        """
+        params_ = params or {}
+        assert params_.keys() == {"the_query"}, 'For eval, AIConfig params must have just the key "the_query".'
+        the_query = params_["the_query"]
+        return f"output_for_{prompt_name}_the_query_{the_query}"
+

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -12,12 +12,12 @@ import openai.types.chat.chat_completion as openai_chat_completion_types
 import openai.types.chat.chat_completion_message_tool_call as openai_tool_call_types
 import pandas as pd
 import pytest
-from aiconfig.Config import AIConfigRuntime
 from aiconfig.eval import common
 from aiconfig.eval.api import TestSuiteWithInputsSettings, metrics, run_test_suite_outputs_only, run_test_suite_with_inputs
 from aiconfig.eval.lib import MetricList, TestSuiteWithInputsSpec, run_test_suite_helper
-from aiconfig.model_parser import InferenceOptions
 from result import Err, Ok, Result
+
+from . import mocks
 
 brevity = metrics.brevity
 substring_match = metrics.substring_match
@@ -56,30 +56,6 @@ def set_pd():
 
 def current_dir():
     return os.path.dirname(os.path.realpath(__file__))
-
-
-class MockAIConfigRuntime(AIConfigRuntime):
-    def __init__(self):
-        pass
-
-    async def run_and_get_output_text(
-        self,
-        prompt_name: str,
-        params: dict[Any, Any] | None = None,
-        options: InferenceOptions | None = None,
-        **kwargs,  # type: ignore
-    ) -> str:
-        """
-        This overrides the real method for mocking, but the output doesn't matter very much.
-        We're currently not really testing properties of the output.
-        We just have to return a string so the tests work.
-
-        Real method: https://github.com/lastmile-ai/aiconfig/blob/a4376d1f951e19776633d397a3cda7fa85506eef/python/src/aiconfig/Config.py#L277
-        """
-        params_ = params or {}
-        assert params_.keys() == {"the_query"}, 'For eval, AIConfig params must have just the key "the_query".'
-        the_query = params_["the_query"]
-        return f"output_for_{prompt_name}_the_query_{the_query}"
 
 
 @pytest.mark.asyncio
@@ -175,7 +151,7 @@ async def test_run_test_suite_with_inputs(data: st.DataObject):
         )
     )
 
-    mock_aiconfig = MockAIConfigRuntime()
+    mock_aiconfig = mocks.MockAIConfigRuntime()
 
     out = await run_test_suite_helper(
         TestSuiteWithInputsSpec(


### PR DESCRIPTION
[AIC-py][eval] bundle of small easy fixes

- freeze dataclasses
- wire up eval fn timeout further (there is a little more to go)
- move mock aiconfig runtime to separate file
-

see https://docs.google.com/document/d/15gx4vVmKVgI5bDHjSDd8xCQmTGcC8RrtLU0iCa32AIQ/edit
