### PR TITLE
[ez] Check for nullable system prompt

### DIFF
--- a/cookbooks/Getting-Started/travel.aiconfig.json
+++ b/cookbooks/Getting-Started/travel.aiconfig.json
@@ -6,6 +6,7 @@
     "models": {
       "gpt-3.5-turbo": {
         "model": "gpt-3.5-turbo",
+        "system_prompt": null,
         "top_p": 1,
         "temperature": 1
       },

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -165,7 +165,7 @@ class OpenAIInference(ParameterizedModelParser):
             completion_params["messages"] = []
 
             # Add System Prompt
-            if "system_prompt" in model_settings:
+            if model_settings.get("system_prompt", None) is not None:
                 system_prompt = model_settings["system_prompt"]
                 if isinstance(system_prompt, dict):
                     # If system prompt is an object, then it should have content and role attributes


### PR DESCRIPTION
[ez] Check for nullable system prompt


We should really have automated tests more in our cookbooks to catch these issues, weird

This is NOT a thorough solution, just quickly unblocking. Filed an issue to investigate deeper and make sure we have better null-checks: https://github.com/lastmile-ai/aiconfig/issues/543
