### PR TITLE
[editor] Union Settings Property

### DIFF
--- a/cli/aiconfig-editor/src/components/property_controls/UnionPropertyControl.tsx
+++ b/cli/aiconfig-editor/src/components/property_controls/UnionPropertyControl.tsx
@@ -1,0 +1,75 @@
+import {
+  PropertyRendererProps,
+  SetStateFn,
+} from "@/src/components/SettingsPropertyRenderer";
+import { Flex, SegmentedControl } from "@mantine/core";
+import { JSONObject } from "aiconfig";
+import { memo, useCallback, useMemo, useState } from "react";
+
+// TODO: Can we type prompt schema / all supported properties exhaustively?
+export type UnionProperty = {
+  type: "union";
+  types: JSONObject[];
+};
+
+type Props = {
+  property: UnionProperty;
+  propertyName: string;
+  initialValue?: any; // TODO: Handle initial value, selecting correct tab to show
+  isRequired?: boolean;
+  setValue: SetStateFn;
+  renderProperty: (props: PropertyRendererProps) => JSX.Element;
+};
+
+export default memo(function UnionPropertyControl(props: Props) {
+  const { property, renderProperty, setValue, ...renderPropertyProps } = props;
+
+  const segmentedTabs = useMemo(
+    () =>
+      property.types.map((_prop, i) => ({
+        label: "",
+        value: i.toString(),
+      })),
+    [property.types]
+  );
+
+  const [controlledData, setControlledData] = useState(new Map());
+  const [activeTab, setActiveTab] = useState("0");
+
+  const selectTab = useCallback(
+    (tab: string) => {
+      console.log("set value: ", controlledData.get(tab));
+      setValue(controlledData.get(tab));
+      setActiveTab(tab);
+    },
+    [controlledData, setValue]
+  );
+
+  const setPropertyValue: SetStateFn = useCallback(
+    (value: any) => {
+      const newValue =
+        typeof value === "function" ? value(controlledData) : value;
+      setControlledData((prev) => prev.set(activeTab, newValue));
+      setValue(newValue);
+    },
+    [activeTab, controlledData, setValue]
+  );
+
+  return (
+    <Flex direction="column">
+      <SegmentedControl
+        data={segmentedTabs}
+        value={activeTab}
+        onChange={selectTab}
+      />
+      <div style={{ marginLeft: "1em" }}>
+        {props.renderProperty({
+          ...renderPropertyProps,
+          property: property.types[parseInt(activeTab)],
+          setValue: setPropertyValue,
+          propertyName: "",
+        })}
+      </div>
+    </Flex>
+  );
+});

--- a/cli/aiconfig-editor/src/shared/prompt_schemas/OpenAIChatModelParserPromptSchema.ts
+++ b/cli/aiconfig-editor/src/shared/prompt_schemas/OpenAIChatModelParserPromptSchema.ts
@@ -66,6 +66,7 @@ export const OpenAIChatModelParserPromptSchema: PromptSchema = {
         type: "integer",
         maximum: 4096,
         minimum: 16,
+        default: 4096,
       },
       n: {
         type: "integer",


### PR DESCRIPTION
# [editor] Union Settings Property

Handle 'union' properties in the settings renderer to support properties that could be one of a union of types, rendering a `UnionPropertyControl` component whenever the property type is `union`. This required two main considerations:
1. Use a callback for setting the state/value instead of an effect; this ensures the value is set when they change instead of when the component mounts
2. Render a UnionPropertyControl with a render prop to render nested SettingsPropertyRenderers based on the property types (rendering SettingsPropertyRenderer directly in UnionPropertyControl could cause a cycle)

## Testing:
- Set both values and ensure the correct value is set in the config:

https://github.com/lastmile-ai/aiconfig/assets/5060851/05202282-f6f9-4dae-834c-be47be6aed43


