### PR TITLE
[extensions] gemini bump extension package version; update dependencies before publish

### DIFF
--- a/cookbooks/Gemini/Gemini.ipynb
+++ b/cookbooks/Gemini/Gemini.ipynb
@@ -54,7 +54,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "wLS1XJvyosT7"
       },
@@ -66,7 +66,7 @@
         "dotenv.load_dotenv()\n",
         "\n",
         "# Retrieve and set your Google API Key - https://ai.google.dev/tutorials/setup \n",
-        "# os.environ[\"GOOGLE_API_KEY\"] = \"your key\""
+        "os.environ[\"GOOGLE_API_KEY\"] = \"AIzaSyDrTHb-R2MRJE_Haa5-gh7O5uOY2tQ41Oc\""
       ]
     },
     {
@@ -85,11 +85,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
         "id": "W_UGROg7jlmP"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/Users/ankush/anaconda3/envs/empty/lib/python3.12/site-packages/pydantic/_internal/_fields.py:128: UserWarning: Field \"model_parsers\" has conflict with protected namespace \"model_\".\n",
+            "\n",
+            "You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.\n",
+            "  warnings.warn(\n",
+            "/Users/ankush/anaconda3/envs/empty/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+            "  from .autonotebook import tqdm as notebook_tqdm\n"
+          ]
+        }
+      ],
       "source": [
         "from aiconfig import AIConfigRuntime\n",
         "import aiconfig_extension_gemini\n",
@@ -152,7 +165,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 5,
       "metadata": {
         "id": "YFBE95DUjBvU"
       },
@@ -163,25 +176,96 @@
         "aiconfig = AIConfigRuntime.load(\"gemini_demo.aiconfig.json\")\n",
         "\n",
         "aiconfig.callback_manager = CallbackManager([]) # Skip Logging, Google Colab forwards logs to stdout\n",
-        "inference_options = InferenceOptions(stream=True)"
+        "inference_options = InferenceOptions(stream=True, stream_callback= lambda x,y,z: print(x))"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 9,
       "metadata": {
         "id": "7-ci5weaIlnY"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "**1. French:** Canard (Pronounced as \"kah-nar\")\n",
+            "\n",
+            "**2. Spanish:** Pato (Pronounced as \"pah-toh\")\n",
+            "**3. German:** Ente (Pronounced as \"en-teh\")\n",
+            "\n",
+            "**4. Italian:** Anatra (Pronounced as \"ah-nah-tra\")\n",
+            "**5. Chinese (Mandarin):** 鸭子 (Pronounced as \"yaa-zi\")\n",
+            "**6. Japanese:** 鴨 (Pronounced as \"kamo\")\n",
+            "**7. Korean:** 오리\n",
+            " (Pronounced as \"oh-ree\")\n",
+            "**8. Russian:** Утка (Pronounced as \"oot-kah\")\n",
+            "**9. Hindi:** बत्तख (Pronounced as \"buttakh\")\n",
+            "**10. Arabic:** بطة (Pronounced as \"battah\")\n",
+            "Gemini output: **1. French:** Canard (Pronounced as \"kah-nar\")\n",
+            "**2. Spanish:** Pato (Pronounced as \"pah-toh\")\n",
+            "**3. German:** Ente (Pronounced as \"en-teh\")\n",
+            "**4. Italian:** Anatra (Pronounced as \"ah-nah-tra\")\n",
+            "**5. Chinese (Mandarin):** 鸭子 (Pronounced as \"yaa-zi\")\n",
+            "**6. Japanese:** 鴨 (Pronounced as \"kamo\")\n",
+            "**7. Korean:** 오리 (Pronounced as \"oh-ree\")\n",
+            "**8. Russian:** Утка (Pronounced as \"oot-kah\")\n",
+            "**9. Hindi:** बत्तख (Pronounced as \"buttakh\")\n",
+            "**10. Arabic:** بطة (Pronounced as \"battah\") \n",
+            "\n",
+            "To pronounce the Mandarin word for duck, 鸭子 (yaa-zi), follow\n",
+            " these steps:\n",
+            "\n",
+            "1. **Start with the first syllable, \"yaa.\"** This syllable is pronounced with a relatively high and flat tone. Your mouth should\n",
+            " be open slightly, and your tongue should be positioned behind your lower front teeth. The sound is similar to the \"a\" in \"father,\" but slightly shorter and more nasal.\n",
+            "\n",
+            "\n",
+            "2. **Move on to the second syllable, \"zi.\"** This syllable is pronounced with a falling-rising tone, which means\n",
+            " your voice starts high and then falls, before rising again at the end. Your mouth should be open slightly wider than for the first syllable, and your tongue should be positioned behind your upper front teeth. The sound is similar to the \"ee\" in \"feet,\" but shorter and more nasal.\n",
+            "\n",
+            "\n",
+            "3. **Combine the two syllables to say \"yaa-zi.\"** Be sure to pronounce each syllable clearly and distinctly, with the correct tone. The overall pronunciation should sound something like \"yaa-ZEE,\" with the emphasis on the second syllable.\n",
+            "\n",
+            "Here are a few tips for practicing the pronunciation:\n",
+            "\n",
+            "* Try saying the word\n",
+            " slowly at first, exaggerating the tones and sounds.\n",
+            "* Once you feel more comfortable, gradually increase the speed of your pronunciation.\n",
+            "* Practice saying the word in different contexts, such as in a sentence or conversation.\n",
+            "* Listen to native Mandarin speakers pronouncing the word to get a better sense of the correct pronunciation.\n",
+            "\n",
+            "With practice, you'll be able to pronounce the Mandarin word for duck, 鸭子 (yaa-zi), correctly and confidently.\n",
+            "Gemini output: To pronounce the Mandarin word for duck, 鸭子 (yaa-zi), follow these steps:\n",
+            "\n",
+            "1. **Start with the first syllable, \"yaa.\"** This syllable is pronounced with a relatively high and flat tone. Your mouth should be open slightly, and your tongue should be positioned behind your lower front teeth. The sound is similar to the \"a\" in \"father,\" but slightly shorter and more nasal.\n",
+            "\n",
+            "\n",
+            "2. **Move on to the second syllable, \"zi.\"** This syllable is pronounced with a falling-rising tone, which means your voice starts high and then falls, before rising again at the end. Your mouth should be open slightly wider than for the first syllable, and your tongue should be positioned behind your upper front teeth. The sound is similar to the \"ee\" in \"feet,\" but shorter and more nasal.\n",
+            "\n",
+            "\n",
+            "3. **Combine the two syllables to say \"yaa-zi.\"** Be sure to pronounce each syllable clearly and distinctly, with the correct tone. The overall pronunciation should sound something like \"yaa-ZEE,\" with the emphasis on the second syllable.\n",
+            "\n",
+            "Here are a few tips for practicing the pronunciation:\n",
+            "\n",
+            "* Try saying the word slowly at first, exaggerating the tones and sounds.\n",
+            "* Once you feel more comfortable, gradually increase the speed of your pronunciation.\n",
+            "* Practice saying the word in different contexts, such as in a sentence or conversation.\n",
+            "* Listen to native Mandarin speakers pronouncing the word to get a better sense of the correct pronunciation.\n",
+            "\n",
+            "With practice, you'll be able to pronounce the Mandarin word for duck, 鸭子 (yaa-zi), correctly and confidently.\n"
+          ]
+        }
+      ],
       "source": [
         "# Config.run() handles the complex things for you\n",
         "# Run multiple different prompts and pass in parameters to specify variables to pass into the prompt\n",
         "aiconfig.delete_output(\"multilinguality\")\n",
-        "await aiconfig.run(\"multilinguality\")\n",
+        "await aiconfig.run(\"multilinguality\", options = inference_options)\n",
         "output_text = aiconfig.get_output_text(\"multilinguality\")\n",
         "print(f'Gemini output: {output_text} \\n')\n",
         "\n",
-        "await aiconfig.run(\"pronounciation\", params={\"language\": \"Mandarin\"})\n",
+        "await aiconfig.run(\"pronounciation\", params={\"language\": \"Mandarin\"}, options = inference_options)\n",
         "output_text = aiconfig.get_output_text(\"pronounciation\")\n",
         "print(f'Gemini output: {output_text}')"
       ]
@@ -233,6 +317,44 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Hello! How can I help you today?\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "[ExecuteResult(output_type='execute_result', execution_count=0, data='Hello! How can I help you today?', mime_type=None, metadata={'safetyRatings': [{'category': 'HARM_CATEGORY_SEXUALLY_EXPLICIT', 'probability': 'NEGLIGIBLE'}, {'category': 'HARM_CATEGORY_HATE_SPEECH', 'probability': 'NEGLIGIBLE'}, {'category': 'HARM_CATEGORY_HARASSMENT', 'probability': 'NEGLIGIBLE'}, {'category': 'HARM_CATEGORY_DANGEROUS_CONTENT', 'probability': 'NEGLIGIBLE'}]})]"
+            ]
+          },
+          "execution_count": 18,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "prompts = await aiconfig.serialize(\"gemini-pro\", {\"contents\": \"hi!\"}, \"prompt\")\n",
+        "prompt = prompts[0]\n",
+        "\n",
+        "\n",
+        "await aiconfig.run(prompt.name, options = inference_options)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
     }
   ],
   "metadata": {
@@ -259,7 +381,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.6"
+      "version": "3.12.0"
     }
   },
   "nbformat": 4,

--- a/extensions/Gemini/python/pyproject.toml
+++ b/extensions/Gemini/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "aiconfig_extension_gemini"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
   { name="LastMile AI" },
   { name="Ankush Pala", email="ankush@lastmileai.dev" },

--- a/extensions/Gemini/python/requirements.txt
+++ b/extensions/Gemini/python/requirements.txt
@@ -3,7 +3,6 @@ google-generativeai==0.3.1
 
 #Other
 asyncio
-copy
 
 # AIConfig
 python-aiconfig

--- a/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py
+++ b/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py
@@ -1,5 +1,5 @@
 # Define a Model Parser for LLama-Guard
-from typing import TYPE_CHECKING, Dict, List, Optional, Any, override
+from typing import TYPE_CHECKING, Dict, List, Optional, Any
 import copy
 
 import google.generativeai as genai
@@ -400,8 +400,7 @@ class GeminiModelParser(ParameterizedModelParser):
                     )
 
         return messages   
-    
-    @override
+
     def get_prompt_template(self, prompt: Prompt, aiConfig: "AIConfigRuntime") -> str:
         """
         This method is overriden from the ParameterizedModelParser class. Its intended to be used only when collecting prompt references, nothing else.


### PR DESCRIPTION
[extensions] gemini bump extension package version; update dependencies before publish



## What

- bump pyproject toml
- Removed @override, this doesn't exist outside of python 3.12
- removed copy from requirements.txt, this is included in python; does not need to be pip installed.

## Why

To update public release with updated functionality to serialize and deserialize() for GEmini Model parser

## Testplan:

Run through the Gemini cookbook succesfully with local pip install

<img width="848" alt="Screenshot 2023-12-21 at 2 18 56 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/533b9fe7-8121-4438-acea-841f7c05097c">
