### PR TITLE
[py] Batch Execution fix inconsistent outputs

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -317,6 +317,9 @@ class AIConfigRuntime(AIConfig):
         model_name = self.get_model_name(prompt_data)
         model_provider = AIConfigRuntime.get_model_parser(model_name)
 
+        # Clear previous run outputs if they exist
+        self.delete_output(prompt_name)
+
         # Run the batch and store results
         batch_results_aiconfigruntimes = await model_provider.run_batch(
             prompt_data,

--- a/python/src/aiconfig/model_parser.py
+++ b/python/src/aiconfig/model_parser.py
@@ -110,6 +110,7 @@ class ModelParser(ABC):
         for params in parameters_list:
             # Create a deep copy of the aiconfig object to prevent mutations that could affect other iterations
             aiconfig_deep_copy = copy.deepcopy(aiconfig)
+            prompt = aiconfig_deep_copy.get_prompt(prompt.name)
             # Asynchronously schedule 'run()' for execution with a set of parameters.
             # This approach enables concurrent processing of multiple aiconfigs.
             task = asyncio.create_task(self.run(prompt, aiconfig_deep_copy, options, params, **kwargs))


### PR DESCRIPTION
[py] Batch Execution fix inconsistent outputs






## What

1. Resolved an inconsistency between the prompt object in the deep copy and the one used for execution. Ensures the correct Prompt object is used during Batch Execution.

2. Also added an extra step of clearing outputs inside run_batch, similarly to #490

## Why

-  Python SDK checks for the existence of Prompt objects within the AIConfigRuntime, evaluating more than just their names.
- In Batch Execution, a deep copy of AIConfigRuntime is created, which also duplicates the Prompt objects. This update addresses the issue where previously a stale prompt object might have been used.


## Testplan:

- rebased onto [this commit](https://github.com/lastmile-ai/aiconfig/pull/553/files) and tested with the python notebook provided by @2timesJay. The batch execution operated correctly as intended.

- Performance comparison between batch and sequential execution showed no significant difference in speed, minus variations in GPT outputs.

Successful Batch Execution:
<img width="1595" alt="Screenshot 2023-12-21 at 12 15 20 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/0ad060f5-8019-4c61-8923-984adfb749fd">

Comparison of sequential execution (see time):
<img width="1600" alt="Screenshot 2023-12-21 at 12 15 35 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/b01ce5cf-a72e-4f97-8789-690076b848d8">
