### PR TITLE
[proof of concept][do not land] Python and Typescript explicit typing have separate interfaces, can't unify schema

### DIFF
--- a/.vscode/test.json
+++ b/.vscode/test.json
@@ -1,0 +1,556 @@
+{
+  "$defs": {
+    "BestOfSequence": {
+      "description": "Represents a best-of sequence generated during text generation.\n\nArgs:\n    generated_text (`str`):\n        The generated text.\n    finish_reason (`FinishReason`):\n        The reason for the generation to finish, represented by a `FinishReason` value.\n    generated_tokens (`int`):\n        The number of generated tokens in the sequence.\n    seed (`Optional[int]`):\n        The sampling seed if sampling was activated.\n    prefill (`List[InputToken]`):\n        The decoder input tokens. Empty if `decoder_input_details` is False. Defaults to an empty list.\n    tokens (`List[Token]`):\n        The generated tokens. Defaults to an empty list.",
+      "properties": {
+        "generated_text": {
+          "title": "Generated Text",
+          "type": "string"
+        },
+        "finish_reason": {
+          "$ref": "#/$defs/FinishReason"
+        },
+        "generated_tokens": {
+          "title": "Generated Tokens",
+          "type": "integer"
+        },
+        "seed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Seed"
+        },
+        "prefill": {
+          "items": {
+            "$ref": "#/$defs/InputToken"
+          },
+          "title": "Prefill",
+          "type": "array"
+        },
+        "tokens": {
+          "items": {
+            "$ref": "#/$defs/Token"
+          },
+          "title": "Tokens",
+          "type": "array"
+        }
+      },
+      "required": [
+        "generated_text",
+        "finish_reason",
+        "generated_tokens"
+      ],
+      "title": "BestOfSequence",
+      "type": "object"
+    },
+    "ChatCompletionMessage": {
+      "additionalProperties": true,
+      "properties": {
+        "content": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Content"
+        },
+        "role": {
+          "const": "assistant",
+          "title": "Role"
+        },
+        "function_call": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FunctionCall"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tool_calls": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ChatCompletionMessageToolCall"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Calls"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "title": "ChatCompletionMessage",
+      "type": "object"
+    },
+    "ChatCompletionMessageToolCall": {
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "function": {
+          "$ref": "#/$defs/Function"
+        },
+        "type": {
+          "const": "function",
+          "title": "Type"
+        }
+      },
+      "required": [
+        "id",
+        "function",
+        "type"
+      ],
+      "title": "ChatCompletionMessageToolCall",
+      "type": "object"
+    },
+    "CitationMetadataDict": {
+      "properties": {
+        "citation_sources": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/CitationSourceDict"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": "Citation Sources",
+          "type": "array"
+        }
+      },
+      "required": [
+        "citation_sources"
+      ],
+      "title": "CitationMetadataDict",
+      "type": "object"
+    },
+    "CitationSourceDict": {
+      "properties": {
+        "start_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Start Index"
+        },
+        "end_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "End Index"
+        },
+        "uri": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Uri"
+        },
+        "license": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "License"
+        }
+      },
+      "required": [
+        "start_index",
+        "end_index",
+        "uri",
+        "license"
+      ],
+      "title": "CitationSourceDict",
+      "type": "object"
+    },
+    "Details": {
+      "description": "Represents details of a text generation.\n\nArgs:\n    finish_reason (`FinishReason`):\n        The reason for the generation to finish, represented by a `FinishReason` value.\n    generated_tokens (`int`):\n        The number of generated tokens.\n    seed (`Optional[int]`):\n        The sampling seed if sampling was activated.\n    prefill (`List[InputToken]`, *optional*):\n        The decoder input tokens. Empty if `decoder_input_details` is False. Defaults to an empty list.\n    tokens (`List[Token]`):\n        The generated tokens. Defaults to an empty list.\n    best_of_sequences (`Optional[List[BestOfSequence]]`):\n        Additional sequences when using the `best_of` parameter.",
+      "properties": {
+        "finish_reason": {
+          "$ref": "#/$defs/FinishReason"
+        },
+        "generated_tokens": {
+          "title": "Generated Tokens",
+          "type": "integer"
+        },
+        "seed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Seed"
+        },
+        "prefill": {
+          "items": {
+            "$ref": "#/$defs/InputToken"
+          },
+          "title": "Prefill",
+          "type": "array"
+        },
+        "tokens": {
+          "items": {
+            "$ref": "#/$defs/Token"
+          },
+          "title": "Tokens",
+          "type": "array"
+        },
+        "best_of_sequences": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/BestOfSequence"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Best Of Sequences"
+        }
+      },
+      "required": [
+        "finish_reason",
+        "generated_tokens"
+      ],
+      "title": "Details",
+      "type": "object"
+    },
+    "FinishReason": {
+      "enum": [
+        "length",
+        "eos_token",
+        "stop_sequence"
+      ],
+      "title": "FinishReason",
+      "type": "string"
+    },
+    "Function": {
+      "additionalProperties": true,
+      "properties": {
+        "arguments": {
+          "title": "Arguments",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "arguments",
+        "name"
+      ],
+      "title": "Function",
+      "type": "object"
+    },
+    "FunctionCall": {
+      "additionalProperties": true,
+      "properties": {
+        "arguments": {
+          "title": "Arguments",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "arguments",
+        "name"
+      ],
+      "title": "FunctionCall",
+      "type": "object"
+    },
+    "GoogleChatCompletionOutput": {
+      "description": "A dict representation of a `glm.Message`.",
+      "properties": {
+        "author": {
+          "title": "Author",
+          "type": "string"
+        },
+        "content": {
+          "title": "Content",
+          "type": "string"
+        },
+        "citation_metadata": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitationMetadataDict"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "author",
+        "content",
+        "citation_metadata"
+      ],
+      "title": "GoogleChatCompletionOutput",
+      "type": "object"
+    },
+    "InputToken": {
+      "description": "Represents an input token.\n\nArgs:\n    id (`int`):\n        Token ID from the model tokenizer.\n    text (`str`):\n        Token text.\n    logprob (`float` or `None`):\n        Log probability of the token. Optional since the logprob of the first token cannot be computed.",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "logprob": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logprob"
+        }
+      },
+      "required": [
+        "id",
+        "text"
+      ],
+      "title": "InputToken",
+      "type": "object"
+    },
+    "StreamDetails": {
+      "description": "Represents details of a text generation stream.\n\nArgs:\n    finish_reason (`FinishReason`):\n        The reason for the generation to finish, represented by a `FinishReason` value.\n    generated_tokens (`int`):\n        The number of generated tokens.\n    seed (`Optional[int]`):\n        The sampling seed if sampling was activated.",
+      "properties": {
+        "finish_reason": {
+          "$ref": "#/$defs/FinishReason"
+        },
+        "generated_tokens": {
+          "title": "Generated Tokens",
+          "type": "integer"
+        },
+        "seed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Seed"
+        }
+      },
+      "required": [
+        "finish_reason",
+        "generated_tokens"
+      ],
+      "title": "StreamDetails",
+      "type": "object"
+    },
+    "TextGenerationResponse": {
+      "description": "Represents a response for text generation.\n\nOnly returned when `details=True`, otherwise a string is returned.\n\nArgs:\n    generated_text (`str`):\n        The generated text.\n    details (`Optional[Details]`):\n        Generation details. Returned only if `details=True` is sent to the server.",
+      "properties": {
+        "generated_text": {
+          "title": "Generated Text",
+          "type": "string"
+        },
+        "details": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Details"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "generated_text"
+      ],
+      "title": "TextGenerationResponse",
+      "type": "object"
+    },
+    "TextGenerationStreamResponse": {
+      "description": "Represents a response for streaming text generation.\n\nOnly returned when `details=True` and `stream=True`.\n\nArgs:\n    token (`Token`):\n        The generated token.\n    generated_text (`Optional[str]`, *optional*):\n        The complete generated text. Only available when the generation is finished.\n    details (`Optional[StreamDetails]`, *optional*):\n        Generation details. Only available when the generation is finished.",
+      "properties": {
+        "token": {
+          "$ref": "#/$defs/Token"
+        },
+        "generated_text": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Generated Text"
+        },
+        "details": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StreamDetails"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "token"
+      ],
+      "title": "TextGenerationStreamResponse",
+      "type": "object"
+    },
+    "Token": {
+      "description": "Represents a token.\n\nArgs:\n    id (`int`):\n        Token ID from the model tokenizer.\n    text (`str`):\n        Token text.\n    logprob (`float`):\n        Log probability of the token.\n    special (`bool`):\n        Indicates whether the token is a special token. It can be used to ignore\n        tokens when concatenating.",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "logprob": {
+          "title": "Logprob",
+          "type": "number"
+        },
+        "special": {
+          "title": "Special",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "text",
+        "logprob",
+        "special"
+      ],
+      "title": "Token",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "output_type": {
+      "const": "execute_result",
+      "title": "Output Type"
+    },
+    "execution_count": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Execution Count"
+    },
+    "data": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/GoogleChatCompletionOutput"
+        },
+        {
+          "$ref": "#/$defs/TextGenerationResponse"
+        },
+        {
+          "$ref": "#/$defs/TextGenerationStreamResponse"
+        },
+        {
+          "$ref": "#/$defs/ChatCompletionMessage"
+        },
+        {}
+      ],
+      "title": "Data"
+    },
+    "mime_type": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Mime Type"
+    },
+    "metadata": {
+      "title": "Metadata",
+      "type": "object"
+    }
+  },
+  "required": [
+    "output_type",
+    "data",
+    "metadata"
+  ],
+  "title": "ExecuteResult",
+  "type": "object"
+}

--- a/cookbooks/Getting-Started/getting_started.ipynb
+++ b/cookbooks/Getting-Started/getting_started.ipynb
@@ -12,13 +12,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "sq9uM4ENFStR"
       },
       "outputs": [],
       "source": [
-        "!pip install python-aiconfig\n",
+        "# !pip install python-aiconfig\n",
         "\n",
         "# Create .env file at aiconfig/.env containing the following line:\n",
         "# OPENAI_API_KEY=<your key here>\n",
@@ -43,13 +43,27 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 30,
+      "execution_count": 2,
       "metadata": {
         "id": "go9T1xivF4S2"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/Users/rossdancraig/.pyenv/versions/3.11.6/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+            "  from .autonotebook import tqdm as notebook_tqdm\n",
+            "/Users/rossdancraig/.pyenv/versions/3.11.6/lib/python3.11/site-packages/pydantic/_internal/_fields.py:128: UserWarning: Field \"model_parsers\" has conflict with protected namespace \"model_\".\n",
+            "\n",
+            "You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.\n",
+            "  warnings.warn(\n"
+          ]
+        }
+      ],
       "source": [
         "from aiconfig import AIConfigRuntime, InferenceOptions, CallbackManager\n",
+        "import json\n",
         "\n",
         "# Load the aiconfig.\n",
         "config = AIConfigRuntime.load('travel.aiconfig.json')\n",
@@ -70,7 +84,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 31,
+      "execution_count": 4,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -83,16 +97,12 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "1. Visit Central Park: Take a leisurely stroll, rent a bike, have a picnic or simply relax in the beautiful setting of Central Park.\n",
-            "2. Explore Times Square: Revel in the vibrant atmosphere, bright lights, and iconic billboards of Times Square, and catch a Broadway show if you can.\n",
-            "3. Walk the Brooklyn Bridge: Enjoy stunning views of the Manhattan skyline while walking across the famous Brooklyn Bridge.\n",
-            "4. Visit the Statue of Liberty: Take a ferry ride to Liberty Island and get up close to the iconic Statue of Liberty, a symbol of freedom and democracy.\n",
-            "5. Explore the Metropolitan Museum of Art: Discover one of the world's largest art museums, showcasing a vast collection of artwork spanning various periods and cultures.\n",
-            "6. Ride to the Top of the Empire State Building: Take in the breathtaking views of New York City's skyline from the observation decks of the iconic Empire State Building.\n",
-            "7. Experience the High Line: Walk along this elevated park built on an old railway track, offering unique views of the city and beautiful green spaces.\n",
-            "8. Discover the Museum of Modern Art (MoMA): Explore the vast collection of modern and contemporary art at this renowned museum, showcasing works by artists like Van Gogh, Warhol, and Picasso.\n",
-            "9. Enjoy the lively atmosphere of Chinatown: Explore the bustling streets of Chinatown, try some delicious Asian cuisine, and shop for unique souvenirs.\n",
-            "10. Take a ferry to Ellis Island: Visit the Ellis Island Immigration Museum to learn about the history of immigration in the United States and explore the grounds where millions of immigrants entered the country."
+            "1. Visit the Top of the Rock Observation Deck: Located at the top of the Rockefeller Center, this attraction offers stunning panoramic views of the New York City skyline. You can enjoy breathtaking views of famous landmarks like the Empire State Building, Central Park, and the Statue of Liberty.\n",
+            "\n",
+            "2. Experience the High Line: The High Line is an elevated park built on a historic freight rail line. It stretches for 1.45 miles along the west side of Manhattan, offering a unique green space with beautiful gardens, public art installations, and stunning views of the city. Walking along the High Line is a peaceful and enjoyable way to explore the city and escape the hustle and bustle of the streets below.\n",
+            "new line bitches\n",
+            "<class 'aiconfig.schema.ExecuteResult'>\n",
+            "output_type='execute_result' execution_count=0 data=ChatCompletionMessage(content='1. Visit the Top of the Rock Observation Deck: Located at the top of the Rockefeller Center, this attraction offers stunning panoramic views of the New York City skyline. You can enjoy breathtaking views of famous landmarks like the Empire State Building, Central Park, and the Statue of Liberty.\\n\\n2. Experience the High Line: The High Line is an elevated park built on a historic freight rail line. It stretches for 1.45 miles along the west side of Manhattan, offering a unique green space with beautiful gardens, public art installations, and stunning views of the city. Walking along the High Line is a peaceful and enjoyable way to explore the city and escape the hustle and bustle of the streets below.', role='assistant', function_call=None, tool_calls=None) mime_type=None metadata={'finish_reason': 'stop'}\n"
           ]
         }
       ],
@@ -100,7 +110,18 @@
         "# Run a single prompt (with streaming). inference_options = InferenceOptions(stream=True)\n",
         "\n",
         "inference_options = InferenceOptions(stream=True)\n",
-        "activities = await config.run(\"get_activities\", options=inference_options)\n"
+        "activities = await config.run(\"get_activities\", options=inference_options)\n",
+        "output = config.get_prompt(\"get_activities\").outputs[0]\n",
+        "print()\n",
+        "print(\"new line bitches\")\n",
+        "print(f\"{type(output)}\")\n",
+        "print(f\"{output}\")\n",
+        "\n",
+        "schema = output.model_json_schema()\n",
+        "schema_json = json.dumps(schema, indent=2)\n",
+        "with open(\"myschema.json\", \"w\") as f:\n",
+        "    f.write(schema_json)\n",
+        "# print(f\"{schema_json}\")\n"
       ]
     },
     {

--- a/cookbooks/Getting-Started/myschema.json
+++ b/cookbooks/Getting-Started/myschema.json
@@ -1,0 +1,556 @@
+{
+  "$defs": {
+    "BestOfSequence": {
+      "description": "Represents a best-of sequence generated during text generation.\n\nArgs:\n    generated_text (`str`):\n        The generated text.\n    finish_reason (`FinishReason`):\n        The reason for the generation to finish, represented by a `FinishReason` value.\n    generated_tokens (`int`):\n        The number of generated tokens in the sequence.\n    seed (`Optional[int]`):\n        The sampling seed if sampling was activated.\n    prefill (`List[InputToken]`):\n        The decoder input tokens. Empty if `decoder_input_details` is False. Defaults to an empty list.\n    tokens (`List[Token]`):\n        The generated tokens. Defaults to an empty list.",
+      "properties": {
+        "generated_text": {
+          "title": "Generated Text",
+          "type": "string"
+        },
+        "finish_reason": {
+          "$ref": "#/$defs/FinishReason"
+        },
+        "generated_tokens": {
+          "title": "Generated Tokens",
+          "type": "integer"
+        },
+        "seed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Seed"
+        },
+        "prefill": {
+          "items": {
+            "$ref": "#/$defs/InputToken"
+          },
+          "title": "Prefill",
+          "type": "array"
+        },
+        "tokens": {
+          "items": {
+            "$ref": "#/$defs/Token"
+          },
+          "title": "Tokens",
+          "type": "array"
+        }
+      },
+      "required": [
+        "generated_text",
+        "finish_reason",
+        "generated_tokens"
+      ],
+      "title": "BestOfSequence",
+      "type": "object"
+    },
+    "ChatCompletionMessage": {
+      "additionalProperties": true,
+      "properties": {
+        "content": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Content"
+        },
+        "role": {
+          "const": "assistant",
+          "title": "Role"
+        },
+        "function_call": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FunctionCall"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tool_calls": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ChatCompletionMessageToolCall"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool Calls"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "title": "ChatCompletionMessage",
+      "type": "object"
+    },
+    "ChatCompletionMessageToolCall": {
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "function": {
+          "$ref": "#/$defs/Function"
+        },
+        "type": {
+          "const": "function",
+          "title": "Type"
+        }
+      },
+      "required": [
+        "id",
+        "function",
+        "type"
+      ],
+      "title": "ChatCompletionMessageToolCall",
+      "type": "object"
+    },
+    "CitationMetadataDict": {
+      "properties": {
+        "citation_sources": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/CitationSourceDict"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "title": "Citation Sources",
+          "type": "array"
+        }
+      },
+      "required": [
+        "citation_sources"
+      ],
+      "title": "CitationMetadataDict",
+      "type": "object"
+    },
+    "CitationSourceDict": {
+      "properties": {
+        "start_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Start Index"
+        },
+        "end_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "End Index"
+        },
+        "uri": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Uri"
+        },
+        "license": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "License"
+        }
+      },
+      "required": [
+        "start_index",
+        "end_index",
+        "uri",
+        "license"
+      ],
+      "title": "CitationSourceDict",
+      "type": "object"
+    },
+    "Details": {
+      "description": "Represents details of a text generation.\n\nArgs:\n    finish_reason (`FinishReason`):\n        The reason for the generation to finish, represented by a `FinishReason` value.\n    generated_tokens (`int`):\n        The number of generated tokens.\n    seed (`Optional[int]`):\n        The sampling seed if sampling was activated.\n    prefill (`List[InputToken]`, *optional*):\n        The decoder input tokens. Empty if `decoder_input_details` is False. Defaults to an empty list.\n    tokens (`List[Token]`):\n        The generated tokens. Defaults to an empty list.\n    best_of_sequences (`Optional[List[BestOfSequence]]`):\n        Additional sequences when using the `best_of` parameter.",
+      "properties": {
+        "finish_reason": {
+          "$ref": "#/$defs/FinishReason"
+        },
+        "generated_tokens": {
+          "title": "Generated Tokens",
+          "type": "integer"
+        },
+        "seed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Seed"
+        },
+        "prefill": {
+          "items": {
+            "$ref": "#/$defs/InputToken"
+          },
+          "title": "Prefill",
+          "type": "array"
+        },
+        "tokens": {
+          "items": {
+            "$ref": "#/$defs/Token"
+          },
+          "title": "Tokens",
+          "type": "array"
+        },
+        "best_of_sequences": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/BestOfSequence"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Best Of Sequences"
+        }
+      },
+      "required": [
+        "finish_reason",
+        "generated_tokens"
+      ],
+      "title": "Details",
+      "type": "object"
+    },
+    "FinishReason": {
+      "enum": [
+        "length",
+        "eos_token",
+        "stop_sequence"
+      ],
+      "title": "FinishReason",
+      "type": "string"
+    },
+    "Function": {
+      "additionalProperties": true,
+      "properties": {
+        "arguments": {
+          "title": "Arguments",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "arguments",
+        "name"
+      ],
+      "title": "Function",
+      "type": "object"
+    },
+    "FunctionCall": {
+      "additionalProperties": true,
+      "properties": {
+        "arguments": {
+          "title": "Arguments",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "arguments",
+        "name"
+      ],
+      "title": "FunctionCall",
+      "type": "object"
+    },
+    "GoogleChatCompletionOutput": {
+      "description": "A dict representation of a `glm.Message`.",
+      "properties": {
+        "author": {
+          "title": "Author",
+          "type": "string"
+        },
+        "content": {
+          "title": "Content",
+          "type": "string"
+        },
+        "citation_metadata": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitationMetadataDict"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "author",
+        "content",
+        "citation_metadata"
+      ],
+      "title": "GoogleChatCompletionOutput",
+      "type": "object"
+    },
+    "InputToken": {
+      "description": "Represents an input token.\n\nArgs:\n    id (`int`):\n        Token ID from the model tokenizer.\n    text (`str`):\n        Token text.\n    logprob (`float` or `None`):\n        Log probability of the token. Optional since the logprob of the first token cannot be computed.",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "logprob": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logprob"
+        }
+      },
+      "required": [
+        "id",
+        "text"
+      ],
+      "title": "InputToken",
+      "type": "object"
+    },
+    "StreamDetails": {
+      "description": "Represents details of a text generation stream.\n\nArgs:\n    finish_reason (`FinishReason`):\n        The reason for the generation to finish, represented by a `FinishReason` value.\n    generated_tokens (`int`):\n        The number of generated tokens.\n    seed (`Optional[int]`):\n        The sampling seed if sampling was activated.",
+      "properties": {
+        "finish_reason": {
+          "$ref": "#/$defs/FinishReason"
+        },
+        "generated_tokens": {
+          "title": "Generated Tokens",
+          "type": "integer"
+        },
+        "seed": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Seed"
+        }
+      },
+      "required": [
+        "finish_reason",
+        "generated_tokens"
+      ],
+      "title": "StreamDetails",
+      "type": "object"
+    },
+    "TextGenerationResponse": {
+      "description": "Represents a response for text generation.\n\nOnly returned when `details=True`, otherwise a string is returned.\n\nArgs:\n    generated_text (`str`):\n        The generated text.\n    details (`Optional[Details]`):\n        Generation details. Returned only if `details=True` is sent to the server.",
+      "properties": {
+        "generated_text": {
+          "title": "Generated Text",
+          "type": "string"
+        },
+        "details": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Details"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "generated_text"
+      ],
+      "title": "TextGenerationResponse",
+      "type": "object"
+    },
+    "TextGenerationStreamResponse": {
+      "description": "Represents a response for streaming text generation.\n\nOnly returned when `details=True` and `stream=True`.\n\nArgs:\n    token (`Token`):\n        The generated token.\n    generated_text (`Optional[str]`, *optional*):\n        The complete generated text. Only available when the generation is finished.\n    details (`Optional[StreamDetails]`, *optional*):\n        Generation details. Only available when the generation is finished.",
+      "properties": {
+        "token": {
+          "$ref": "#/$defs/Token"
+        },
+        "generated_text": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Generated Text"
+        },
+        "details": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StreamDetails"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "token"
+      ],
+      "title": "TextGenerationStreamResponse",
+      "type": "object"
+    },
+    "Token": {
+      "description": "Represents a token.\n\nArgs:\n    id (`int`):\n        Token ID from the model tokenizer.\n    text (`str`):\n        Token text.\n    logprob (`float`):\n        Log probability of the token.\n    special (`bool`):\n        Indicates whether the token is a special token. It can be used to ignore\n        tokens when concatenating.",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "logprob": {
+          "title": "Logprob",
+          "type": "number"
+        },
+        "special": {
+          "title": "Special",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "text",
+        "logprob",
+        "special"
+      ],
+      "title": "Token",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "output_type": {
+      "const": "execute_result",
+      "title": "Output Type"
+    },
+    "execution_count": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Execution Count"
+    },
+    "data": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/GoogleChatCompletionOutput"
+        },
+        {
+          "$ref": "#/$defs/TextGenerationResponse"
+        },
+        {
+          "$ref": "#/$defs/TextGenerationStreamResponse"
+        },
+        {
+          "$ref": "#/$defs/ChatCompletionMessage"
+        },
+        {}
+      ],
+      "title": "Data"
+    },
+    "mime_type": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Mime Type"
+    },
+    "metadata": {
+      "title": "Metadata",
+      "type": "object"
+    }
+  },
+  "required": [
+    "output_type",
+    "data",
+    "metadata"
+  ],
+  "title": "ExecuteResult",
+  "type": "object"
+}

--- a/cookbooks/Getting-Started/travel.aiconfig.json
+++ b/cookbooks/Getting-Started/travel.aiconfig.json
@@ -20,7 +20,7 @@
   "prompts": [
     {
       "name": "get_activities",
-      "input": "Tell me 10 fun attractions to do in NYC."
+      "input": "Tell me 2 fun attractions to do in NYC."
     },
     {
       "name": "gen_itinerary",

--- a/cookbooks/OpenAI-ChatCompletion-AIConfigWrapper/openai_wrapper.ipynb
+++ b/cookbooks/OpenAI-ChatCompletion-AIConfigWrapper/openai_wrapper.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,19 +36,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.10/site-packages/pydantic/_internal/_fields.py:128: UserWarning: Field \"model_parsers\" has conflict with protected namespace \"model_\".\n",
+      "/opt/homebrew/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "/opt/homebrew/lib/python3.11/site-packages/pydantic/_internal/_fields.py:128: UserWarning: Field \"model_parsers\" has conflict with protected namespace \"model_\".\n",
       "\n",
       "You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.\n",
-      "  warnings.warn(\n",
-      "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
+      "  warnings.warn(\n"
      ]
     }
    ],
@@ -78,33 +78,37 @@
     "    }\n",
     "\n",
     "    response = openai.chat.completions.create(**completion_params) # Creates a config saved to default path `aiconfig.json`\n",
+    "    print(\"her what's up\")\n",
+    "    print(f\"{response=}\")\n",
     "    print(\"Chat Completion Response: \")\n",
     "    print(type(response))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO] 2023-12-01 14:03:43,767 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_start' file='aiconfig.Config' data={'gpt-3.5-turbo': 'gpt-3.5-turbo', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Tell me a joke about apples', 'role': 'user'}]}, 'prompt_name': 'prompt', 'params': None} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:43,768 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_start' file='aiconfig.default_parsers.openai' data={'prompt_name': 'prompt', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Tell me a joke about apples', 'role': 'user'}]}, 'parameters': {}, 'kwargs': {}} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:43,769 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_complete' file='aiconfig.default_parsers.openai' data={'result': [Prompt(name='prompt', input='Tell me a joke about apples', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:43,770 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_complete' file='aiconfig.Config' data={'result': [Prompt(name='prompt', input='Tell me a joke about apples', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1701457422515626000\n"
+      "[INFO] 2023-12-21 23:20:06,867 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_start' file='aiconfig.Config' data={'gpt-3.5-turbo': 'gpt-3.5-turbo', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Tell me a joke about apples', 'role': 'user'}]}, 'prompt_name': 'prompt', 'params': None} ts_ns=1703218614711964000\n",
+      "[INFO] 2023-12-21 23:20:06,869 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_start' file='aiconfig.default_parsers.openai' data={'prompt_name': 'prompt', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Tell me a joke about apples', 'role': 'user'}]}, 'parameters': {}, 'kwargs': {}} ts_ns=1703218614711964000\n",
+      "[INFO] 2023-12-21 23:20:06,870 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_complete' file='aiconfig.default_parsers.openai' data={'result': [Prompt(name='prompt', input='Tell me a joke about apples', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1703218614711964000\n",
+      "[INFO] 2023-12-21 23:20:06,871 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_complete' file='aiconfig.Config' data={'result': [Prompt(name='prompt', input='Tell me a joke about apples', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1703218614711964000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "her what's up\n",
+      "response=ChatCompletion(id='chatcmpl-8YRJ0qPOK9lNRMtayINvWGElc5zgP', choices=[Choice(finish_reason='stop', index=0, message=ChatCompletionMessage(content=\"Why did the apple go to the doctor?\\n\\nBecause it wasn't peeling well!\", role='assistant', function_call=None, tool_calls=None), logprobs=None)], created=1703218806, model='gpt-3.5-turbo-0613', object='chat.completion', system_fingerprint=None, usage=CompletionUsage(completion_tokens=17, prompt_tokens=13, total_tokens=30))\n",
       "Chat Completion Response: \n",
       "<class 'openai.types.chat.chat_completion.ChatCompletion'>\n"
      ]
@@ -117,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -157,58 +161,18 @@
       "          \"output_type\": \"execute_result\",\n",
       "          \"execution_count\": 0,\n",
       "          \"data\": {\n",
-      "            \"content\": \"Why did the apple go to therapy?\\n\\nBecause it had a bad peel-ing!\",\n",
+      "            \"content\": \"Why did the apple go to the doctor?\\n\\nBecause it wasn't peeling well!\",\n",
       "            \"role\": \"assistant\"\n",
       "          },\n",
       "          \"metadata\": {\n",
-      "            \"id\": \"chatcmpl-8R35bxxwnkQy4YronOeJWLLQ5fkKP\",\n",
-      "            \"created\": 1701457423,\n",
+      "            \"id\": \"chatcmpl-8YRJ0qPOK9lNRMtayINvWGElc5zgP\",\n",
+      "            \"created\": 1703218806,\n",
       "            \"model\": \"gpt-3.5-turbo-0613\",\n",
       "            \"object\": \"chat.completion\",\n",
       "            \"usage\": {\n",
-      "              \"completion_tokens\": 16,\n",
+      "              \"completion_tokens\": 17,\n",
       "              \"prompt_tokens\": 13,\n",
-      "              \"total_tokens\": 29\n",
-      "            },\n",
-      "            \"finish_reason\": \"stop\"\n",
-      "          }\n",
-      "        }\n",
-      "      ]\n",
-      "    },\n",
-      "    {\n",
-      "      \"name\": \"prompt_1\",\n",
-      "      \"input\": \"Tell a joke about apples in Shakespearian English.\",\n",
-      "      \"metadata\": {\n",
-      "        \"model\": {\n",
-      "          \"name\": \"gpt-3.5-turbo\",\n",
-      "          \"settings\": {\n",
-      "            \"model\": \"gpt-3.5-turbo\",\n",
-      "            \"top_p\": 1,\n",
-      "            \"max_tokens\": 3000,\n",
-      "            \"temperature\": 1,\n",
-      "            \"stream\": false\n",
-      "          }\n",
-      "        },\n",
-      "        \"parameters\": {},\n",
-      "        \"remember_chat_context\": true\n",
-      "      },\n",
-      "      \"outputs\": [\n",
-      "        {\n",
-      "          \"output_type\": \"execute_result\",\n",
-      "          \"execution_count\": 0,\n",
-      "          \"data\": {\n",
-      "            \"content\": \"Why did the apple become a noble knight in fair Verona? \\n\\nBecause it wished to 'tis the season, and transform from fruit to Rome-dreaming tree, but alas, it could only become a fallen pair, appealing to thee!\",\n",
-      "            \"role\": \"assistant\"\n",
-      "          },\n",
-      "          \"metadata\": {\n",
-      "            \"id\": \"chatcmpl-8R34kiMdly4hq5g1KrdVschroQWgV\",\n",
-      "            \"created\": 1701457370,\n",
-      "            \"model\": \"gpt-3.5-turbo-0613\",\n",
-      "            \"object\": \"chat.completion\",\n",
-      "            \"usage\": {\n",
-      "              \"completion_tokens\": 50,\n",
-      "              \"prompt_tokens\": 19,\n",
-      "              \"total_tokens\": 69\n",
+      "              \"total_tokens\": 30\n",
       "            },\n",
       "            \"finish_reason\": \"stop\"\n",
       "          }\n",
@@ -232,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -263,18 +227,18 @@
       "      \"output_type\": \"execute_result\",\n",
       "      \"execution_count\": 0,\n",
       "      \"data\": {\n",
-      "        \"content\": \"Why did the apple go to therapy?\\n\\nBecause it had a bad peel-ing!\",\n",
+      "        \"content\": \"Why did the apple go to the doctor?\\n\\nBecause it wasn't peeling well!\",\n",
       "        \"role\": \"assistant\"\n",
       "      },\n",
       "      \"metadata\": {\n",
-      "        \"id\": \"chatcmpl-8R35bxxwnkQy4YronOeJWLLQ5fkKP\",\n",
-      "        \"created\": 1701457423,\n",
+      "        \"id\": \"chatcmpl-8YRJ0qPOK9lNRMtayINvWGElc5zgP\",\n",
+      "        \"created\": 1703218806,\n",
       "        \"model\": \"gpt-3.5-turbo-0613\",\n",
       "        \"object\": \"chat.completion\",\n",
       "        \"usage\": {\n",
-      "          \"completion_tokens\": 16,\n",
+      "          \"completion_tokens\": 17,\n",
       "          \"prompt_tokens\": 13,\n",
-      "          \"total_tokens\": 29\n",
+      "          \"total_tokens\": 30\n",
       "        },\n",
       "        \"finish_reason\": \"stop\"\n",
       "      }\n",
@@ -302,27 +266,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO] 2023-12-01 14:03:44,950 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_start' file='aiconfig.Config' data={'gpt-3.5-turbo': 'gpt-3.5-turbo', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Tell a joke about apples in Shakespearian English.', 'role': 'user'}]}, 'prompt_name': 'prompt', 'params': None} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:44,953 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_start' file='aiconfig.default_parsers.openai' data={'prompt_name': 'prompt', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Tell a joke about apples in Shakespearian English.', 'role': 'user'}]}, 'parameters': {}, 'kwargs': {}} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:44,954 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_complete' file='aiconfig.default_parsers.openai' data={'result': [Prompt(name='prompt', input='Tell a joke about apples in Shakespearian English.', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:44,956 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_complete' file='aiconfig.Config' data={'result': [Prompt(name='prompt', input='Tell a joke about apples in Shakespearian English.', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1701457422515626000\n"
+      "[INFO] 2023-12-21 23:20:37,611 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_start' file='aiconfig.Config' data={'gpt-3.5-turbo': 'gpt-3.5-turbo', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Tell a joke about apples in Shakespearian English.', 'role': 'user'}]}, 'prompt_name': 'prompt', 'params': None} ts_ns=1703218614711964000\n",
+      "[INFO] 2023-12-21 23:20:37,614 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_start' file='aiconfig.default_parsers.openai' data={'prompt_name': 'prompt', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Tell a joke about apples in Shakespearian English.', 'role': 'user'}]}, 'parameters': {}, 'kwargs': {}} ts_ns=1703218614711964000\n",
+      "[INFO] 2023-12-21 23:20:37,615 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_complete' file='aiconfig.default_parsers.openai' data={'result': [Prompt(name='prompt', input='Tell a joke about apples in Shakespearian English.', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1703218614711964000\n",
+      "[INFO] 2023-12-21 23:20:37,616 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_complete' file='aiconfig.Config' data={'result': [Prompt(name='prompt', input='Tell a joke about apples in Shakespearian English.', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1703218614711964000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "her what's up\n",
+      "response=ChatCompletion(id='chatcmpl-8YRJU4XQpmqhNxb509bsJJWog8JEE', choices=[Choice(finish_reason='stop', index=0, message=ChatCompletionMessage(content='Why did the apple become a thespian?\\n\\nBecause it wanted to play a part in Macbeth, but it couldn\\'t resist saying, \"Is this a dagger I spy, or art thou just peeler?\"', role='assistant', function_call=None, tool_calls=None), logprobs=None)], created=1703218836, model='gpt-3.5-turbo-0613', object='chat.completion', system_fingerprint=None, usage=CompletionUsage(completion_tokens=43, prompt_tokens=19, total_tokens=62))\n",
       "Chat Completion Response: \n",
       "<class 'openai.types.chat.chat_completion.ChatCompletion'>\n"
      ]
@@ -335,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -366,18 +332,18 @@
       "      \"output_type\": \"execute_result\",\n",
       "      \"execution_count\": 0,\n",
       "      \"data\": {\n",
-      "        \"content\": \"Why did the apple go to therapy?\\n\\nBecause it had a bad peel-ing!\",\n",
+      "        \"content\": \"Why did the apple go to the doctor?\\n\\nBecause it wasn't peeling well!\",\n",
       "        \"role\": \"assistant\"\n",
       "      },\n",
       "      \"metadata\": {\n",
-      "        \"id\": \"chatcmpl-8R35bxxwnkQy4YronOeJWLLQ5fkKP\",\n",
-      "        \"created\": 1701457423,\n",
+      "        \"id\": \"chatcmpl-8YRJ0qPOK9lNRMtayINvWGElc5zgP\",\n",
+      "        \"created\": 1703218806,\n",
       "        \"model\": \"gpt-3.5-turbo-0613\",\n",
       "        \"object\": \"chat.completion\",\n",
       "        \"usage\": {\n",
-      "          \"completion_tokens\": 16,\n",
+      "          \"completion_tokens\": 17,\n",
       "          \"prompt_tokens\": 13,\n",
-      "          \"total_tokens\": 29\n",
+      "          \"total_tokens\": 30\n",
       "        },\n",
       "        \"finish_reason\": \"stop\"\n",
       "      }\n",
@@ -834,7 +800,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -870,21 +836,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO] 2023-12-01 14:03:57,426 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_start' file='aiconfig.Config' data={'gpt-3.5-turbo': 'gpt-3.5-turbo', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Are tomatoes fruits?', 'role': 'user'}]}, 'prompt_name': 'prompt', 'params': None} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:57,428 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_start' file='aiconfig.default_parsers.openai' data={'prompt_name': 'prompt', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Are tomatoes fruits?', 'role': 'user'}]}, 'parameters': {}, 'kwargs': {}} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:57,430 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_complete' file='aiconfig.default_parsers.openai' data={'result': [Prompt(name='prompt', input='Are tomatoes fruits?', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:57,432 callback.py:140: Callback called. event\n",
-      ": name='on_serialize_complete' file='aiconfig.Config' data={'result': [Prompt(name='prompt', input='Are tomatoes fruits?', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1701457422515626000\n"
+      "[INFO] 2023-12-22 00:06:07,549 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_start' file='aiconfig.Config' data={'gpt-3.5-turbo': 'gpt-3.5-turbo', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Are tomatoes fruits?', 'role': 'user'}]}, 'prompt_name': 'prompt', 'params': None} ts_ns=1703221540962554000\n",
+      "[INFO] 2023-12-22 00:06:07,553 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_start' file='aiconfig.default_parsers.openai' data={'prompt_name': 'prompt', 'data': {'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Are tomatoes fruits?', 'role': 'user'}]}, 'parameters': {}, 'kwargs': {}} ts_ns=1703221540962554000\n",
+      "[INFO] 2023-12-22 00:06:07,554 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_complete' file='aiconfig.default_parsers.openai' data={'result': [Prompt(name='prompt', input='Are tomatoes fruits?', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1703221540962554000\n",
+      "[INFO] 2023-12-22 00:06:07,555 callback.py:140: Callback called. event\n",
+      ": name='on_serialize_complete' file='aiconfig.Config' data={'result': [Prompt(name='prompt', input='Are tomatoes fruits?', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[])]} ts_ns=1703221540962554000\n"
      ]
     },
     {
@@ -902,25 +868,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO] 2023-12-01 14:03:57,440 callback.py:140: Callback called. event\n",
-      ": name='on_run_start' file='aiconfig.Config' data={'prompt_name': 'prompt_0', 'params': None, 'options': None, 'kwargs': {}} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:57,442 callback.py:140: Callback called. event\n",
-      ": name='on_run_start' file='aiconfig.default_parsers.openai' data={'prompt': Prompt(name='prompt_0', input='Are tomatoes fruits?', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Yes, tomatoes are classified as fruits. Although they are commonly used as a vegetable in cooking, botanically they are the fruit of the tomato plant.', 'role': 'assistant'}, mime_type=None, metadata={'id': 'chatcmpl-8R35ohinQTGI4uoWXn61NJIH4pYgO', 'created': 1701457436, 'model': 'gpt-3.5-turbo-0613', 'object': 'chat.completion', 'usage': {'completion_tokens': 31, 'prompt_tokens': 11, 'total_tokens': 42}, 'finish_reason': 'stop'})]), 'options': None, 'parameters': {}} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:57,443 callback.py:140: Callback called. event\n",
-      ": name='on_deserialize_start' file='aiconfig.default_parsers.openai' data={'prompt': Prompt(name='prompt_0', input='Are tomatoes fruits?', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Yes, tomatoes are classified as fruits. Although they are commonly used as a vegetable in cooking, botanically they are the fruit of the tomato plant.', 'role': 'assistant'}, mime_type=None, metadata={'id': 'chatcmpl-8R35ohinQTGI4uoWXn61NJIH4pYgO', 'created': 1701457436, 'model': 'gpt-3.5-turbo-0613', 'object': 'chat.completion', 'usage': {'completion_tokens': 31, 'prompt_tokens': 11, 'total_tokens': 42}, 'finish_reason': 'stop'})]), 'params': {}} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:57,446 callback.py:140: Callback called. event\n",
-      ": name='on_deserialize_complete' file='aiconfig.default_parsers.openai' data={'output': {'model': 'gpt-3.5-turbo', 'max_tokens': 3000, 'top_p': 1, 'temperature': 1, 'stream': False, 'messages': [{'content': 'Are tomatoes fruits?', 'role': 'user'}, {'content': 'Yes, tomatoes are classified as fruits. Although they are commonly used as a vegetable in cooking, botanically they are the fruit of the tomato plant.', 'role': 'assistant'}]}} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:58,852 callback.py:140: Callback called. event\n",
-      ": name='on_run_complete' file='aiconfig.default_parsers.openai' data={'result': [ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'To be more specific, tomatoes are technically classified as a berry. They develop from the ovary of a flower and contain seeds, which makes them a fruit. However, they are often treated and referred to as a vegetable due to their culinary usage.', 'role': 'assistant'}, mime_type=None, metadata={'id': 'chatcmpl-8R35p1LoxPLVjJFQWBHWjO962fz9q', 'created': 1701457437, 'model': 'gpt-3.5-turbo-0613', 'object': 'chat.completion', 'usage': {'completion_tokens': 50, 'prompt_tokens': 46, 'total_tokens': 96}, 'finish_reason': 'stop'})]} ts_ns=1701457422515626000\n",
-      "[INFO] 2023-12-01 14:03:58,854 callback.py:140: Callback called. event\n",
-      ": name='on_run_complete' file='aiconfig.Config' data={'result': [ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'To be more specific, tomatoes are technically classified as a berry. They develop from the ovary of a flower and contain seeds, which makes them a fruit. However, they are often treated and referred to as a vegetable due to their culinary usage.', 'role': 'assistant'}, mime_type=None, metadata={'id': 'chatcmpl-8R35p1LoxPLVjJFQWBHWjO962fz9q', 'created': 1701457437, 'model': 'gpt-3.5-turbo-0613', 'object': 'chat.completion', 'usage': {'completion_tokens': 50, 'prompt_tokens': 46, 'total_tokens': 96}, 'finish_reason': 'stop'})]} ts_ns=1701457422515626000\n"
+      "[INFO] 2023-12-22 00:06:18,175 callback.py:140: Callback called. event\n",
+      ": name='on_run_start' file='aiconfig.Config' data={'prompt_name': 'prompt_0', 'params': None, 'options': None, 'kwargs': {}} ts_ns=1703221540962554000\n",
+      "[INFO] 2023-12-22 00:06:18,177 callback.py:140: Callback called. event\n",
+      ": name='on_run_start' file='aiconfig.default_parsers.openai' data={'prompt': Prompt(name='prompt_0', input='Are tomatoes fruits?', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[]), 'options': None, 'parameters': {}} ts_ns=1703221540962554000\n",
+      "[INFO] 2023-12-22 00:06:18,178 callback.py:140: Callback called. event\n",
+      ": name='on_deserialize_start' file='aiconfig.default_parsers.openai' data={'prompt': Prompt(name='prompt_0', input='Are tomatoes fruits?', metadata=PromptMetadata(model=ModelMetadata(name='gpt-3.5-turbo', settings={'model': 'gpt-3.5-turbo', 'top_p': 1, 'max_tokens': 3000, 'temperature': 1, 'stream': False}), tags=None, parameters={}, remember_chat_context=True), outputs=[]), 'params': {}} ts_ns=1703221540962554000\n",
+      "[INFO] 2023-12-22 00:06:18,180 callback.py:140: Callback called. event\n",
+      ": name='on_deserialize_complete' file='aiconfig.default_parsers.openai' data={'output': {'temperature': 1, 'top_p': 1, 'stream': False, 'model': 'gpt-3.5-turbo', 'max_tokens': 3000, 'messages': [{'content': 'Are tomatoes fruits?', 'role': 'user'}]}} ts_ns=1703221540962554000\n",
+      "[INFO] 2023-12-22 00:06:19,423 callback.py:140: Callback called. event\n",
+      ": name='on_run_complete' file='aiconfig.default_parsers.openai' data={'result': [ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Yes, tomatoes are fruits. Although they are commonly referred to as vegetables, tomatoes are botanically classified as fruits because they develop from the ovary of a flowering plant and contain seeds.', 'role': 'assistant'}, mime_type=None, metadata={'id': 'chatcmpl-8YS1i6Nsf0kex8cb0tIQOr8yixtQO', 'created': 1703221578, 'model': 'gpt-3.5-turbo-0613', 'object': 'chat.completion', 'usage': {'completion_tokens': 38, 'prompt_tokens': 11, 'total_tokens': 49}, 'finish_reason': 'stop'})]} ts_ns=1703221540962554000\n",
+      "[INFO] 2023-12-22 00:06:19,424 callback.py:140: Callback called. event\n",
+      ": name='on_run_complete' file='aiconfig.Config' data={'result': [ExecuteResult(output_type='execute_result', execution_count=0, data={'content': 'Yes, tomatoes are fruits. Although they are commonly referred to as vegetables, tomatoes are botanically classified as fruits because they develop from the ovary of a flowering plant and contain seeds.', 'role': 'assistant'}, mime_type=None, metadata={'id': 'chatcmpl-8YS1i6Nsf0kex8cb0tIQOr8yixtQO', 'created': 1703221578, 'model': 'gpt-3.5-turbo-0613', 'object': 'chat.completion', 'usage': {'completion_tokens': 38, 'prompt_tokens': 11, 'total_tokens': 49}, 'finish_reason': 'stop'})]} ts_ns=1703221540962554000\n"
      ]
     },
     {
@@ -928,7 +894,9 @@
      "output_type": "stream",
      "text": [
       "Result:\n",
-      "To be more specific, tomatoes are technically classified as a berry. They develop from the ovary of a flower and contain seeds, which makes them a fruit. However, they are often treated and referred to as a vegetable due to their culinary usage.\n"
+      "Yes, tomatoes are fruits. Although they are commonly referred to as vegetables, tomatoes are botanically classified as fruits because they develop from the ovary of a flowering plant and contain seeds.\n",
+      "len(outputs)=1\n",
+      "output={'content': 'Yes, tomatoes are fruits. Although they are commonly referred to as vegetables, tomatoes are botanically classified as fruits because they develop from the ovary of a flowering plant and contain seeds.', 'role': 'assistant'}\n"
      ]
     }
    ],
@@ -936,7 +904,11 @@
     "await existing_aiconfig.run(\"prompt_0\")\n",
     "\n",
     "print(\"Result:\")\n",
-    "print(existing_aiconfig.get_output_text(\"prompt_0\"))"
+    "print(existing_aiconfig.get_output_text(\"prompt_0\"))\n",
+    "outputs = existing_aiconfig.get_prompt(\"prompt_0\").outputs\n",
+    "print(f\"{len(outputs)=}\")\n",
+    "output = outputs[0].data\n",
+    "print(f\"{output=}\")"
    ]
   }
  ],

--- a/python/make_json_schema.py
+++ b/python/make_json_schema.py
@@ -1,0 +1,3 @@
+import json
+
+json.dumps({})

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -349,10 +349,11 @@ class OpenAIInference(ParameterizedModelParser):
 
         if output.output_type == "execute_result":
             message = output.data
-            if message.get("content"):
-                return message.get("content")
-            elif message.get("function_call"):
-                return message.get("function_call")
+            print(f"{message=}")
+            if hasattr(message, "content"):
+                return message.content
+            elif hasattr(message, "function_call"):
+                return message.function_call
             else:
                 return ""
         else:

--- a/typescript/lib/parsers/openai.ts
+++ b/typescript/lib/parsers/openai.ts
@@ -568,13 +568,15 @@ export class OpenAIChatModelParser extends ParameterizedModelParser<Chat.ChatCom
       );
 
       let outputs = new Map<number, ExecuteResult>();
-      let messages: Map<number, Chat.ChatCompletionMessage> | null = null;
       for await (const chunk of responseStream) {
-        messages = multiChoiceMessageReducer(messages, chunk);
+        let messages: Map<number, Chat.ChatCompletionMessage> =
+          multiChoiceMessageReducer(null, chunk);
 
         for (let i = 0; i < chunk.choices.length; i++) {
           const choice = chunk.choices[i];
-          const message = messages.get(choice.index);
+          const message = messages.get(
+            choice.index
+          ) as Chat.ChatCompletionMessage;
 
           // Send the stream callback for each choice
           options?.callbacks?.streamCallback(

--- a/typescript/lib/parsers/palm.ts
+++ b/typescript/lib/parsers/palm.ts
@@ -24,7 +24,12 @@ export class PaLMTextParser extends ParameterizedModelParser {
     super();
   }
 
-  public serialize(promptName: string, data: JSONObject, aiConfig: AIConfigRuntime, params?: JSONObject | undefined): Prompt | Prompt[] {
+  public serialize(
+    promptName: string,
+    data: JSONObject,
+    aiConfig: AIConfigRuntime,
+    params?: JSONObject | undefined
+  ): Prompt | Prompt[] {
     const startEvent = {
       name: "on_serialize_start",
       file: __filename,
@@ -38,14 +43,18 @@ export class PaLMTextParser extends ParameterizedModelParser {
 
     // input type was found by looking at the impl of text generation api. When calling textGeneration, step into the defintion of the function and look at the type of the input parameter
     // ModelParser abstract method types data as JSONObject, but we know that the data is going to be of type protos.google.ai.generativelanguage.v1beta2.IGenerateTextRequest.
-    const input = data as protos.google.ai.generativelanguage.v1beta2.IGenerateTextRequest;
+    const input =
+      data as protos.google.ai.generativelanguage.v1beta2.IGenerateTextRequest;
 
     const prompt = input.prompt?.text as string;
     const modelName = input.model as string;
 
     let modelMetadata: ModelMetadata;
     // Once relevant attributes are parsed, we no longer need them. These attributes get moved to their respective fields and the rest of the attributes are passed to the model as settings (model metadata).
-    modelMetadata = aiConfig.getModelMetadata(_.omit(input, ["model", "prompt"]) as JSONObject, modelName);
+    modelMetadata = aiConfig.getModelMetadata(
+      _.omit(input, ["model", "prompt"]) as JSONObject,
+      modelName
+    );
 
     // Super simple since palm text generation is just one shot prompting.
     const prompts: Prompt[] = [
@@ -71,7 +80,11 @@ export class PaLMTextParser extends ParameterizedModelParser {
     return prompts;
   }
 
-  public deserialize(prompt: Prompt, aiConfig: AIConfigRuntime, params?: JSONObject | undefined): any {
+  public deserialize(
+    prompt: Prompt,
+    aiConfig: AIConfigRuntime,
+    params?: JSONObject | undefined
+  ): any {
     // TODO: @ankush-lastmile PaLM unable to set output type to Text Generation API request type, `protos.google.ai.generativelanguage.v1beta2.IGenerateTextRequest` looks like it conforms to JSONObject type but it doesn't. Returns any for now.
     const startEvent = {
       name: "on_deserialize_start",
@@ -87,10 +100,16 @@ export class PaLMTextParser extends ParameterizedModelParser {
 
     // Get Prompt Template (aka prompt string), paramaterize it, and set it in completionParams
     const promptTemplate = prompt.input as string;
-    const promptText = this.resolvePromptTemplate(promptTemplate, prompt, aiConfig, params);
+    const promptText = this.resolvePromptTemplate(
+      promptTemplate,
+      prompt,
+      aiConfig,
+      params
+    );
     completionParams.prompt = { text: promptText };
 
-    const refinedCompletionParams = refineTextGenerationParams(completionParams);
+    const refinedCompletionParams =
+      refineTextGenerationParams(completionParams);
 
     const endEvent = {
       name: "on_deserialize_end",
@@ -147,7 +166,11 @@ export class PaLMTextParser extends ParameterizedModelParser {
     return outputs;
   }
 
-  public getOutputText(aiConfig: AIConfigRuntime, output?: Output, prompt?: Prompt): string {
+  public getOutputText(
+    aiConfig: AIConfigRuntime,
+    output?: Output,
+    prompt?: Prompt
+  ): string {
     if (output == null && prompt != null) {
       output = aiConfig.getLatestOutput(prompt);
     }
@@ -168,21 +191,37 @@ export class PaLMTextParser extends ParameterizedModelParser {
  *  Refines the completion params for the PALM text generation api. Removes any unsupported params.
  *  The supported keys were found by looking at the PaLM text generation api. `INSERT TYPE HERE`
  */
-export function refineTextGenerationParams(params: JSONObject): protos.google.ai.generativelanguage.v1beta2.IGenerateTextRequest {
+export function refineTextGenerationParams(
+  params: JSONObject
+): protos.google.ai.generativelanguage.v1beta2.IGenerateTextRequest {
   return {
     model: params.model as string | null,
-    prompt: params.prompt as google.ai.generativelanguage.v1beta2.ITextPrompt | null,
-    temperature: params.temperature != null ? (params.temperature as number) : null,
-    candidateCount: params.candidateCount != null ? (params.candidateCount as number) : null,
-    maxOutputTokens: params.maxOutputTokens != null ? (params.maxOutputTokens as number) : null,
+    prompt:
+      params.prompt as google.ai.generativelanguage.v1beta2.ITextPrompt | null,
+    temperature:
+      params.temperature != null ? (params.temperature as number) : null,
+    candidateCount:
+      params.candidateCount != null ? (params.candidateCount as number) : null,
+    maxOutputTokens:
+      params.maxOutputTokens != null
+        ? (params.maxOutputTokens as number)
+        : null,
     topP: params.topP != null ? (params.topP as number) : null,
     topK: params.topK != null ? (params.topK as number) : null,
-    safetySettings: params.safetySettings !== undefined ? (params.safetySettings as google.ai.generativelanguage.v1beta2.ISafetySetting[]) : null,
-    stopSequences: params.stopSequences !== undefined ? (params.stopSequences as string[]) : null,
+    safetySettings:
+      params.safetySettings !== undefined
+        ? (params.safetySettings as google.ai.generativelanguage.v1beta2.ISafetySetting[])
+        : null,
+    stopSequences:
+      params.stopSequences !== undefined
+        ? (params.stopSequences as string[])
+        : null,
   };
 }
 
-function constructOutputs(response: protos.google.ai.generativelanguage.v1beta2.IGenerateTextResponse): ExecuteResult[] {
+function constructOutputs(
+  response: protos.google.ai.generativelanguage.v1beta2.IGenerateTextResponse
+): ExecuteResult[] {
   if (!response.candidates) {
     return [];
   }
@@ -191,11 +230,14 @@ function constructOutputs(response: protos.google.ai.generativelanguage.v1beta2.
 
   for (let i = 0; i < response.candidates.length; i++) {
     const candidate = response.candidates[i];
+    if (candidate.output === undefined) {
+      candidate.output = null;
+    }
     const output: ExecuteResult = {
       output_type: "execute_result",
       data: candidate.output,
       execution_count: i,
-      metadata: _.omit(candidate, ["output"])
+      metadata: _.omit(candidate, ["output"]),
     };
 
     outputs.push(output);

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -45,7 +45,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@google-ai/generativelanguage": "^1.1.0",
+    "@google-ai/generativelanguage": "1.1.0",
     "@huggingface/inference": "^2.6.4",
     "axios": "^1.5.1",
     "google-auth-library": "^9.1.0",

--- a/typescript/types.ts
+++ b/typescript/types.ts
@@ -1,4 +1,9 @@
 import { JSONObject, JSONValue } from "./common";
+import {
+  TextGenerationOutput,
+  TextGenerationStreamOutput,
+} from "@huggingface/inference";
+import { ChatCompletionMessage as OpenAIChatCompletionMessage } from "openai/resources/chat/completions";
 
 /**
  * AIConfig schema, latest version. For older versions, see AIConfigV*.
@@ -171,6 +176,27 @@ export type Prompt = {
 //#region Prompt Outputs
 
 /**
+ * Google does not make their types visible to other packages, so we need to
+ * maintain this manually. Do this to access the file and see for yourself:
+ * ```
+ * import { google } from "@google-ai/generativelanguage/build/protos/protos";
+ * google.ai.generativelanguage.v1beta2.ITextCompletion
+ * ```
+ */
+// Rossdan: Google Chat here
+import { google } from "@google-ai/generativelanguage/build/protos/protos";
+type myType = google.ai.generativelanguage.v1beta2.ITextCompletion;
+type GoogleChatCompletionOutput = string | null;
+type HuggingFaceTextGenerationOutput =
+  | TextGenerationOutput
+  | TextGenerationStreamOutput;
+type TextAndChatCompletionOutputs =
+  | GoogleChatCompletionOutput // Palm
+  | HuggingFaceTextGenerationOutput // HuggingFace
+  | OpenAIChatCompletionMessage; // OpenAI
+export type OutputData = string | TextAndChatCompletionOutputs;
+
+/**
  * Model inference result.
  */
 export type Output = ExecuteResult | Error;
@@ -192,7 +218,7 @@ export type ExecuteResult = {
   /**
    * The result of executing the prompt.
    */
-  data: JSONValue;
+  data: OutputData;
 
   /**
    * The MIME type of the result. If not specified, the MIME type will be assumed to be plain text.


### PR DESCRIPTION
[proof of concept][do not land] Python and Typescript explicit typing have separate interfaces, can't unify schema




Ok just do these steps
1. Open `schema.py` --> open `MessageDict`
2. Open `types.ts` --> open `ITextCompletion`
3. Observe that `MessageDict` (Python) and `ITextCompletion` (typescript) are separate interfaces

We cannot simply pass in the string forms of each in data, because we save the entire completion message (which is required for building a chat UI for determining things like roles, etc, not just pure text)
1. Open `default_parsers/palm.py` --> go to ` response = palm.chat(**completion_data)`
2. We use `get_output_text()`, but this is not passed anywhere into a JSON or AIConfig field, and it's only for text, not compatible with any other media types


## Old - ignore
Currently will break other non-string types, but will get this to to work later in diff stack. Because these are all "text base", I am not setting the mime-type to anything. cc @ryanholingsworth let me know if you need me to be explicit like setting the mime type to OpenAIChatCompletionMessage or something, because that's actually just a nested dict with things like "content" in there that you'll have to do some further parsing.

Next diff I will handle attachment formats like images, audio, etc
