### PR TITLE
Unpin requests dependency and fix jason validator from load_from_workbook() API

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.30.0
+requests
 black
 flake8
 pylint

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -114,7 +114,7 @@ class AIConfigRuntime(AIConfig):
             Exception: If the request to the API is not successful.
         """
         if workbook_id:
-            API_ENDPOINT = "http://lastmileai.dev/api"
+            API_ENDPOINT = "https://lastmileai.dev/api"
 
             # Make sure to set the API key
             lastmileapi_token = os.environ.get("LASTMILE_API_TOKEN")
@@ -131,7 +131,7 @@ class AIConfigRuntime(AIConfig):
 
             data = resp.json()
 
-            aiconfigruntime = cls.model_validate_json(data)
+            aiconfigruntime = cls(**data)
             update_model_parser_registry_with_config_runtime(aiconfigruntime)
             return aiconfigruntime
 


### PR DESCRIPTION
Unpin requests dependency and fix jason validator from load_from_workbook() API

Unpin `requests` dependency and fix jason validator from `load_from_workbook()` API

This diff addresses two separate issues, but one was needed before I could debug the second.


1. Before you'd get an error if trying to do JSON model validator because struct is now a dict, so instead we are just using `**` directly into `cls` where it'll be validated in the init file for `AIConfigRuntime` obj since it's a BaseModel.


2. Also did some investigation into why `requests` was pinned to v 2.30.0. The only difference I could find between that and v2.31.0 is that in 2.31.0 it doesn't seem to support `https:` and would only support `http:`. However, I tried testing this with both versions, and it still seems to work, so idk what is going on

For now I'm feeling this is safe to unpin since we've tested both. If there's something I'm missing, please let me know!

I checked and there's no where else that this module is being used:
<img width="342" alt="Screenshot 2023-12-21 at 20 40 33" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/26cb9ca2-834e-4596-ae64-0963d5eeddad">


https works for both
| v2.30.0 | v2.31.0 |
|---|---|
| <img width="755" alt="Screenshot 2023-12-21 at 20 38 13" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/a7787cf0-5bad-429a-9138-d0bc98a17009"> | <img width="753" alt="Screenshot 2023-12-21 at 20 38 39" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/f3707537-14e9-4158-a56a-d44a20942c19"> |
