### PR TITLE
[editor] Fix argparsify command

### DIFF
--- a/python/src/aiconfig/scripts/aiconfig_cli.py
+++ b/python/src/aiconfig/scripts/aiconfig_cli.py
@@ -32,7 +32,7 @@ async def main(argv: list[str]) -> int:
 def run_subcommand(argv: list[str]) -> Result[str, str]:
     LOGGER.info("Running subcommand")
     subparser_record_types = {"edit": EditServerConfig}
-    main_parser = core_utils.argparsify(AIConfigCLIConfig, subparser_record_types=subparser_record_types)
+    main_parser = core_utils.argparsify(AIConfigCLIConfig, subparser_rs=subparser_record_types)
 
     res_cli_config = core_utils.parse_args(main_parser, argv[1:], AIConfigCLIConfig)
     res_cli_config.and_then(_process_cli_config)


### PR DESCRIPTION
[editor] Fix argparsify command

# [editor] Fix argparsify command

When running the cli command, I was getting an error that `argparsify` doesn't support `subparser_record_types` command. So, change it to supported `subparser_rs`

Can now run `aiconfig edit --aiconfig-path=cli/aiconfig-editor/travel.aiconfig.json --server-port=8080 --server-mode=debug_servers` successfully

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/584).
* #585
* __->__ #584