### PR TITLE
[editor] Enable CORS for /api/* requests

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,4 +17,6 @@ pytest-asyncio
 lastmile-utils==0.0.13
 hypothesis==6.91.0
 nltk
+# Editor server
 flask[async]
+flask-cors

--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -19,6 +19,7 @@ from aiconfig.editor.server.server_utils import (
 )
 from aiconfig.model_parser import InferenceOptions
 from flask import Flask, request
+from flask_cors import CORS
 from result import Err, Ok, Result
 
 logging.getLogger("werkzeug").disabled = True
@@ -34,6 +35,7 @@ LOGGER.addHandler(log_handler)
 
 
 app = Flask(__name__, static_url_path="")
+CORS(app, resources={r"/api/*": {"origins": "*"}})
 
 
 def _validated_request_path(allow_create: bool = False) -> Result[ValidatedPath, str]:

--- a/python/src/aiconfig/scripts/aiconfig_cli.py
+++ b/python/src/aiconfig/scripts/aiconfig_cli.py
@@ -32,7 +32,7 @@ async def main(argv: list[str]) -> int:
 def run_subcommand(argv: list[str]) -> Result[str, str]:
     LOGGER.info("Running subcommand")
     subparser_record_types = {"edit": EditServerConfig}
-    main_parser = core_utils.argparsify(AIConfigCLIConfig, subparser_record_types=subparser_record_types)
+    main_parser = core_utils.argparsify(AIConfigCLIConfig, subparser_rs=subparser_record_types)
 
     res_cli_config = core_utils.parse_args(main_parser, argv[1:], AIConfigCLIConfig)
     res_cli_config.and_then(_process_cli_config)


### PR DESCRIPTION
[editor] Enable CORS for /api/* requests

# [editor] Enable CORS for /api/* requests

Sending a request to `localhost:8080/api/load` on the client is currently failing due to CORS (cross origin from localhost:3000). To fix, just enable all origins for the api requests for now, following https://flask-cors.readthedocs.io/en/latest/#using-json-with-cors. We can consider restricting the allowed origins as needed

Testing: Can now send a request from the client and get a response ('Done' right now) instead of CORS error
![Screenshot 2023-12-22 at 10 51 33 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/8d7f5fe3-681e-4438-9bed-469eddbc23e6)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/585).
* __->__ #585
* #584