### PR TITLE
[py][model parser][hf] 2/n callbacks

### DIFF
--- a/python/src/aiconfig/default_parsers/hf.py
+++ b/python/src/aiconfig/default_parsers/hf.py
@@ -183,6 +183,19 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         Returns:
             str: Serialized representation of the prompt and inference settings.
         """
+        await ai_config.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_serialize_start",
+                __name__,
+                {
+                    "prompt_name": prompt_name,
+                    "data": data,
+                    "parameters": parameters,
+                    "kwargs": kwargs,
+                },
+            )
+        )
+
         data = copy.deepcopy(data)
 
         # assume data is completion params for HF text generation
@@ -190,6 +203,8 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
 
         # Prompt is handled, remove from data
         data.pop("prompt", None)
+
+        prompts = []
 
         model_metadata = ai_config.get_model_metadata(data, self.id())
         prompt = Prompt(
@@ -199,7 +214,12 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
                 model=model_metadata, parameters=parameters, **kwargs
             ),
         )
-        return [prompt]
+
+        prompts.append(prompt)
+        
+        await ai_config.callback_manager.run_callbacks(CallbackEvent("on_serialize_complete", __name__, {"result": prompts }))
+        
+        return prompts
 
     async def deserialize(
         self,
@@ -217,6 +237,8 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         Returns:
             dict: Model-specific completion parameters.
         """
+        await aiconfig.callback_manager.run_callbacks(CallbackEvent("on_deserialize_start", __name__, {"prompt": prompt, "params": params}))
+
         resolved_prompt = resolve_prompt(prompt, params, aiconfig)
 
         # Build Completion data
@@ -225,6 +247,8 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         completion_data = refine_chat_completion_params(model_settings)
 
         completion_data["prompt"] = resolved_prompt
+
+        await aiconfig.callback_manager.run_callbacks(CallbackEvent("on_deserialize_complete", __name__, {"output": completion_data}))
 
         return completion_data
 
@@ -242,7 +266,15 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         Returns:
             InferenceResponse: The response from the model.
         """
-        completion_data = await self.deserialize(prompt, aiconfig, options, parameters)
+        await aiconfig.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_run_start",
+                __name__,
+                {"prompt": prompt, "options": options, "parameters": parameters},
+            )
+        )
+
+        completion_data = await self.deserialize(prompt, aiconfig, parameters)
 
         # if stream enabled in runtime options and config, then stream. Otherwise don't stream.
         stream = True  # Default value
@@ -268,7 +300,10 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
             outputs.append(output)
 
         prompt.outputs = outputs
-        return prompt.outputs
+
+        await aiconfig.callback_manager.run_callbacks(CallbackEvent("on_run_complete", __name__, {"result": outputs}))
+
+        return outputs
 
     def get_output_text(
         self,

--- a/python/src/aiconfig/default_parsers/hf.py
+++ b/python/src/aiconfig/default_parsers/hf.py
@@ -12,7 +12,8 @@ from huggingface_hub.inference._text_generation import (
     TextGenerationStreamResponse,
 )
 
-from aiconfig.schema import ExecuteResult, Output, Prompt
+from aiconfig.schema import ExecuteResult, Output, Prompt, PromptMetadata
+from aiconfig import CallbackEvent
 
 from aiconfig.util.params import resolve_prompt
 
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 # Step 1: define Helpers
 
 
-def refine_chat_completion_params(model_settings):
+def refine_chat_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
     """
     Refines the completion params for the HF text generation api. Removes any unsupported params.
     The supported keys were found by looking at the HF text generation api. `huggingface_hub.InferenceClient.text_generation()`
@@ -106,11 +107,10 @@ def construct_stream_output(
     return output
 
 
-def construct_regular_output(response, response_includes_details: bool) -> Output:
+def construct_regular_output(response: TextGenerationResponse, response_includes_details: bool) -> Output:
     metadata = {}
     data = response
     if response_includes_details:
-        response: TextGenerationResponse  # Expect response to be of type TextGenerationResponse
         data = response.generated_text
         metadata = {"details": response.details}
 
@@ -170,9 +170,9 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         prompt_name: str,
         data: Any,
         ai_config: "AIConfigRuntime",
-        parameters: Optional[Dict] = None,
+        parameters: Optional[dict[Any, Any]] = None,
         **kwargs,
-    ) -> Prompt:
+    ) -> list[Prompt]:
         """
         Defines how a prompt and model inference settings get serialized in the .aiconfig.
 
@@ -205,9 +205,8 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         self,
         prompt: Prompt,
         aiconfig: "AIConfigRuntime",
-        options,
-        params: Optional[Dict] = {},
-    ) -> Dict:
+        params: Optional[dict[Any, Any]] = {},
+    ) -> dict[Any, Any]:
         """
         Defines how to parse a prompt in the .aiconfig for a particular model
         and constructs the completion params for that model.
@@ -230,7 +229,7 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         return completion_data
 
     async def run_inference(
-        self, prompt: Prompt, aiconfig, options, parameters
+        self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: dict[Any, Any]
     ) -> Output:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform


### PR DESCRIPTION
[py][model parser][hf] 2/n callbacks




## What

- Added callbacks to model parser.
- It doesn't look like there is any other issues with this specific model parser at the moment. More investigation required into logging/callbacks, parameterization as seen with mixtral issues.

## Why

This model Parser has not been updated for a while. Taking this upto par with the rest of the library

## Testplan

Ran through the getting started. Modified the config to use HuggingFace model parser and mixtral model

Note: Input prompt said generate 10 activities, got 15.

![Untitled drawing](https://github.com/lastmile-ai/aiconfig/assets/141073967/15492126-b43d-4692-8e2a-4f13a88774f2)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/588).
* #597
* __->__ #588
* #587