### PR TITLE
[editor] Add Prompt Button UI Starting Point

### DIFF
--- a/cli/aiconfig-editor/src/components/EditorContainer.tsx
+++ b/cli/aiconfig-editor/src/components/EditorContainer.tsx
@@ -1,11 +1,19 @@
 import PromptContainer from "@/src/components/prompt/PromptContainer";
-import { Container, Text, Group, Button, createStyles } from "@mantine/core";
+import {
+  Container,
+  Text,
+  Group,
+  Button,
+  createStyles,
+  Stack,
+} from "@mantine/core";
 import { showNotification } from "@mantine/notifications";
 import { AIConfig, PromptInput } from "aiconfig";
 import router from "next/router";
 import { useCallback, useReducer, useState } from "react";
 import aiconfigReducer from "@/src/components/aiconfigReducer";
 import { ClientAIConfig, clientConfigToAIConfig } from "@/src/shared/types";
+import AddPromptButton from "@/src/components/prompt/AddPromptButton";
 
 type Props = {
   aiconfig: ClientAIConfig;
@@ -14,6 +22,27 @@ type Props = {
 };
 
 const useStyles = createStyles((theme) => ({
+  addPromptRow: {
+    borderRadius: "4px",
+    display: "inline-block",
+    bottom: -24,
+    left: -40,
+    "&:hover": {
+      backgroundColor:
+        theme.colorScheme === "light"
+          ? theme.colors.gray[1]
+          : "rgba(255, 255, 255, 0.1)",
+    },
+    [theme.fn.smallerThan("sm")]: {
+      marginLeft: "0",
+      display: "block",
+      position: "static",
+      bottom: -10,
+      left: 0,
+      height: 28,
+      margin: "10px 0",
+    },
+  },
   promptsContainer: {
     [theme.fn.smallerThan("sm")]: {
       padding: "0 0 200px 0",
@@ -94,14 +123,18 @@ export default function EditorContainer({
       <Container maw="80rem" className={classes.promptsContainer}>
         {aiconfigState.prompts.map((prompt: any, i: number) => {
           return (
-            <PromptContainer
-              index={i}
-              prompt={prompt}
-              key={prompt.name}
-              onChangePromptInput={onChangePromptInput}
-              onUpdateModelSettings={onUpdatePromptModelSettings}
-              defaultConfigModelName={aiconfigState.metadata.default_model}
-            />
+            <Stack key={prompt.name}>
+              <PromptContainer
+                index={i}
+                prompt={prompt}
+                onChangePromptInput={onChangePromptInput}
+                onUpdateModelSettings={onUpdatePromptModelSettings}
+                defaultConfigModelName={aiconfigState.metadata.default_model}
+              />
+              <div className={classes.addPromptRow}>
+                <AddPromptButton />
+              </div>
+            </Stack>
           );
         })}
       </Container>

--- a/cli/aiconfig-editor/src/components/prompt/AddPromptButton.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/AddPromptButton.tsx
@@ -1,0 +1,43 @@
+//import { fetcher } from "@/src/helpers/client/swrUtils";
+import {
+  ActionIcon,
+  Button,
+  createStyles,
+  Flex,
+  Menu,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { IconPlus, IconSearch, IconTextCaption } from "@tabler/icons-react";
+import { memo, useCallback, useContext, useState } from "react";
+//import useSWR from "swr";
+
+type Props = {};
+
+function ModelMenuItems({ models }: { models: string[] }) {
+  return models.map((model) => (
+    <Menu.Item key={model} icon={<IconTextCaption size="16" />}>
+      {model}
+    </Menu.Item>
+  ));
+}
+
+export default memo(function AddPromptButton(props: Props) {
+  const models = ["GPT-4V"];
+  return (
+    <Menu position="bottom-start">
+      <Menu.Target>
+        <ActionIcon>
+          <IconPlus size={20} />
+        </ActionIcon>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <TextInput icon={<IconSearch size="16" />} placeholder="Search" />
+        <ModelMenuItems models={models} />
+        <Menu.Divider />
+        <Menu.Item icon={<IconPlus size="16" />}>Add New Model</Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+});


### PR DESCRIPTION
# [editor] Add Prompt Button UI Starting Point

Starting point for the Add Prompt button below each prompt, following designs in https://www.figma.com/file/7YVa6KpEDgptj8DiAc5BaU/AiConfig-Editor?type=design&node-id=271-4785&mode=design&t=8jzhRGqLf5X60TiS-0


https://github.com/lastmile-ai/aiconfig/assets/5060851/30a8579a-dffe-482d-8205-b9fab5898ec5


Once this lands I'll port it over to the python editor code (still blocked there for now)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/590).
* #591
* __->__ #590