### PR TITLE
[editor] Execute Prompt Button UI Starting Point

### DIFF
--- a/cli/aiconfig-editor/src/components/EditorContainer.tsx
+++ b/cli/aiconfig-editor/src/components/EditorContainer.tsx
@@ -1,11 +1,19 @@
 import PromptContainer from "@/src/components/prompt/PromptContainer";
-import { Container, Text, Group, Button, createStyles } from "@mantine/core";
+import {
+  Container,
+  Text,
+  Group,
+  Button,
+  createStyles,
+  Stack,
+} from "@mantine/core";
 import { showNotification } from "@mantine/notifications";
 import { AIConfig, PromptInput } from "aiconfig";
 import router from "next/router";
 import { useCallback, useReducer, useState } from "react";
 import aiconfigReducer from "@/src/components/aiconfigReducer";
 import { ClientAIConfig, clientConfigToAIConfig } from "@/src/shared/types";
+import AddPromptButton from "@/src/components/prompt/AddPromptButton";
 
 type Props = {
   aiconfig: ClientAIConfig;
@@ -14,6 +22,27 @@ type Props = {
 };
 
 const useStyles = createStyles((theme) => ({
+  addPromptRow: {
+    borderRadius: "4px",
+    display: "inline-block",
+    bottom: -24,
+    left: -40,
+    "&:hover": {
+      backgroundColor:
+        theme.colorScheme === "light"
+          ? theme.colors.gray[1]
+          : "rgba(255, 255, 255, 0.1)",
+    },
+    [theme.fn.smallerThan("sm")]: {
+      marginLeft: "0",
+      display: "block",
+      position: "static",
+      bottom: -10,
+      left: 0,
+      height: 28,
+      margin: "10px 0",
+    },
+  },
   promptsContainer: {
     [theme.fn.smallerThan("sm")]: {
       padding: "0 0 200px 0",
@@ -94,14 +123,18 @@ export default function EditorContainer({
       <Container maw="80rem" className={classes.promptsContainer}>
         {aiconfigState.prompts.map((prompt: any, i: number) => {
           return (
-            <PromptContainer
-              index={i}
-              prompt={prompt}
-              key={prompt.name}
-              onChangePromptInput={onChangePromptInput}
-              onUpdateModelSettings={onUpdatePromptModelSettings}
-              defaultConfigModelName={aiconfigState.metadata.default_model}
-            />
+            <Stack key={prompt.name}>
+              <PromptContainer
+                index={i}
+                prompt={prompt}
+                onChangePromptInput={onChangePromptInput}
+                onUpdateModelSettings={onUpdatePromptModelSettings}
+                defaultConfigModelName={aiconfigState.metadata.default_model}
+              />
+              <div className={classes.addPromptRow}>
+                <AddPromptButton />
+              </div>
+            </Stack>
           );
         })}
       </Container>

--- a/cli/aiconfig-editor/src/components/prompt/AddPromptButton.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/AddPromptButton.tsx
@@ -1,0 +1,43 @@
+//import { fetcher } from "@/src/helpers/client/swrUtils";
+import {
+  ActionIcon,
+  Button,
+  createStyles,
+  Flex,
+  Menu,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { IconPlus, IconSearch, IconTextCaption } from "@tabler/icons-react";
+import { memo, useCallback, useContext, useState } from "react";
+//import useSWR from "swr";
+
+type Props = {};
+
+function ModelMenuItems({ models }: { models: string[] }) {
+  return models.map((model) => (
+    <Menu.Item key={model} icon={<IconTextCaption size="16" />}>
+      {model}
+    </Menu.Item>
+  ));
+}
+
+export default memo(function AddPromptButton(props: Props) {
+  const models = ["GPT-4V"];
+  return (
+    <Menu position="bottom-start">
+      <Menu.Target>
+        <ActionIcon>
+          <IconPlus size={20} />
+        </ActionIcon>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <TextInput icon={<IconSearch size="16" />} placeholder="Search" />
+        <ModelMenuItems models={models} />
+        <Menu.Divider />
+        <Menu.Item icon={<IconPlus size="16" />}>Add New Model</Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+});

--- a/cli/aiconfig-editor/src/components/prompt/ExecutePromptButton.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/ExecutePromptButton.tsx
@@ -1,0 +1,16 @@
+import { ClientPrompt } from "@/src/shared/types";
+import { Button } from "@mantine/core";
+import { IconPlayerPlayFilled } from "@tabler/icons-react";
+import { memo } from "react";
+
+type Props = {
+  prompt: ClientPrompt;
+};
+
+export default memo(function ExecutePromptButton({ prompt }: Props) {
+  return (
+    <Button onClick={() => {}} p="xs" size="xs">
+      <IconPlayerPlayFilled size="16" />
+    </Button>
+  );
+});

--- a/cli/aiconfig-editor/src/components/prompt/PromptActionBar.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/PromptActionBar.tsx
@@ -1,3 +1,4 @@
+import ExecutePromptButton from "@/src/components/prompt/ExecutePromptButton";
 import PromptParametersRenderer from "@/src/components/prompt/PromptParametersRenderer";
 import ModelSettingsRenderer from "@/src/components/prompt/model_settings/ModelSettingsRenderer";
 import PromptMetadataRenderer from "@/src/components/prompt/prompt_metadata/PromptMetadataRenderer";
@@ -34,31 +35,28 @@ export default memo(function PromptActionBar({
   const modelSettingsSchema = promptSchema?.model_settings;
   const promptMetadataSchema = promptSchema?.prompt_metadata;
 
-  return (
-    <Flex direction="column" justify="space-between">
-      {isExpanded ? (
-        <Container miw="400px">
-          <ActionIcon size="sm" onClick={() => setIsExpanded(false)}>
-            <IconClearAll />
-          </ActionIcon>
-          <ModelSettingsRenderer
-            settings={getModelSettings(prompt)}
-            schema={modelSettingsSchema}
-            onUpdateModelSettings={onUpdateModelSettings}
-          />
-          <PromptMetadataRenderer
-            prompt={prompt}
-            schema={promptMetadataSchema}
-          />
-          {checkParametersSupported(prompt) && (
-            <PromptParametersRenderer prompt={prompt} />
-          )}{" "}
-        </Container>
-      ) : (
-        <ActionIcon size="sm" onClick={() => setIsExpanded(true)}>
-          <IconClearAll />
-        </ActionIcon>
-      )}
+  return isExpanded ? (
+    <Container miw="400px">
+      <ActionIcon size="sm" onClick={() => setIsExpanded(false)}>
+        <IconClearAll />
+      </ActionIcon>
+      <ModelSettingsRenderer
+        settings={getModelSettings(prompt)}
+        schema={modelSettingsSchema}
+        onUpdateModelSettings={onUpdateModelSettings}
+      />
+      <PromptMetadataRenderer prompt={prompt} schema={promptMetadataSchema} />
+      {checkParametersSupported(prompt) && (
+        <PromptParametersRenderer prompt={prompt} />
+      )}{" "}
+      <ExecutePromptButton prompt={prompt} />
+    </Container>
+  ) : (
+    <Flex direction="column" justify="space-between" h="100%">
+      <ActionIcon size="sm" onClick={() => setIsExpanded(true)}>
+        <IconClearAll />
+      </ActionIcon>
+      <ExecutePromptButton prompt={prompt} />
     </Flex>
   );
 });

--- a/cli/aiconfig-editor/src/components/prompt/PromptContainer.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/PromptContainer.tsx
@@ -1,4 +1,5 @@
 import PromptActionBar from "@/src/components/prompt/PromptActionBar";
+import PromptOutputBar from "@/src/components/prompt/PromptOutputBar";
 import PromptInputRenderer from "@/src/components/prompt/prompt_input/PromptInputRenderer";
 import PromptOutputsRenderer from "@/src/components/prompt/prompt_outputs/PromptOutputsRenderer";
 import { ClientPrompt } from "@/src/shared/types";
@@ -67,6 +68,7 @@ export default memo(function PromptContainer({
             schema={inputSchema}
             onChangeInput={onChangeInput}
           />
+          <PromptOutputBar />
           {prompt.outputs && <PromptOutputsRenderer outputs={prompt.outputs} />}
         </Flex>
       </Card>

--- a/cli/aiconfig-editor/src/components/prompt/PromptOutputBar.tsx
+++ b/cli/aiconfig-editor/src/components/prompt/PromptOutputBar.tsx
@@ -1,0 +1,7 @@
+import { memo } from "react";
+
+type Props = {};
+
+export default memo(function PromptOutputBar(props: Props) {
+  return <div>Output</div>;
+});


### PR DESCRIPTION
# [editor] Execute Prompt Button UI Starting Point

Quick starting point for the execute prompt button UI following https://www.figma.com/file/7YVa6KpEDgptj8DiAc5BaU/AiConfig-Editor?type=design&node-id=144-5452&mode=design&t=8jzhRGqLf5X60TiS-0:
<img width="1310" alt="Screenshot 2023-12-22 at 2 32 07 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/cf160e05-a69a-4997-bc49-28d32e86cd28">

Once this lands, I'll port it over to the python editor client code


---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/591).
* __->__ #591
* #590