### PR TITLE
Add schema explicitly for JSON

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -412,7 +412,8 @@ class AIConfigRuntime(AIConfig):
                     indent=2,
                 )
             else:
-                # Save AIConfig as JSON to the file
+                # Save AIConfig as JSON to the file, with the schema specified
+                json_data["$schema"] = "https://json.schemastore.org/aiconfig-1.0"
                 json.dump(
                     json_data,
                     file,

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -254,6 +254,8 @@ export class AIConfigRuntime implements AIConfig {
       if (mode === "yaml") {
         aiConfigString = yaml.dump(aiConfigObj, { indent: 2 });
       } else {
+        // Add the $schema property to the JSON object before saving it. In the future this can respect the version specified in the AIConfig.
+        aiConfigObj["$schema"] = "https://json.schemastore.org/aiconfig-1.0";
         aiConfigString = JSON.stringify(aiConfigObj, null, 2);
       }
 


### PR DESCRIPTION
Add schema explicitly for JSON

Adding the $schema property to JSON with the schemastore schema. Currently our schema has just one version but in the future we should respect the schema that the config already has or introduce proper versioning.

Test Plan:
```
from aiconfig import AIConfigRuntime

# Load the aiconfig (without $schema).
config = AIConfigRuntime.load('travel.aiconfig.json')
config.save()

# Ensure $schema is specified and I can get IntelliSense in the json file now.
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/598).
* __->__ #598
* #589