### PR TITLE
[AIC-py] optional: add prompt at index

### DIFF
--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -355,7 +355,7 @@ class AIConfig(BaseModel):
             raise IndexError("Prompt '{}' not found in config, available prompts are:\n {}".format(prompt_name, list(self.prompt_index.keys())))
         return self.prompt_index[prompt_name]
 
-    def add_prompt(self, prompt_name: str, prompt_data: Prompt):
+    def add_prompt(self, prompt_name: str, prompt_data: Prompt, index: int | None = None):
         """
         Adds a prompt to the .aiconfig.
 
@@ -370,7 +370,10 @@ class AIConfig(BaseModel):
 
         prompt_data.name = prompt_name
         self.prompt_index[prompt_name] = prompt_data
-        self.prompts.append(prompt_data)
+        if index is None:
+            self.prompts.append(prompt_data)
+        else:
+            self.prompts.insert(index, prompt_data)
 
     def update_prompt(self, prompt_name: str, prompt_data: Prompt):
         """


### PR DESCRIPTION
[AIC-py] optional: add prompt at index

add p3, add p4 at index 1.

```
[Prompt(name='get_activities', input='Tell me 10 fun attractions to do in NYC.', metadata=None, outputs=[]),
 Prompt(name='p4', input='thep', metadata=None, outputs=[]),
 Prompt(name='gen_itinerary', input='Generate an itinerary ordered by {{order_by}} for these activities: {{get_activities.output}}.', metadata=PromptMetadata(model='gpt-4', tags=None, parameters={'order_by': 'geographic location'}), outputs=[]),
 Prompt(name='p3', input='thep', metadata=None, outputs=[])]
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/599).
* #600
* __->__ #599