### PR TITLE
[python][non-image]Save output.data with text content instead of response data

### DIFF
--- a/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py
+++ b/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py
@@ -208,12 +208,21 @@ class GeminiModelParser(ParameterizedModelParser):
                 user_message_parts = user_message["parts"]
                 outputs = []
                 if i + 1 < len(contents):
+                    # TODO (rossdanlm): Support function calls
                     model_message = contents[i + 1]
                     model_message_parts = model_message["parts"]
                     # Gemini api currently only supports one candidate aka one output. Model should only be retuning one part in response.
                     # Should output data be this list of parts? or just the first one? TODO: figure out if Gemini outputs may contain more than one part.
                     # see https://ai.google.dev/tutorials/python_quickstart#multi-turn_conversations:~:text=Note%3A%20For%20multi%2Dturn%20conversations%2C%20you%20need%20to%20send%20the%20whole%20conversation%20history%20with%20each%20request
-                    outputs = [ExecuteResult(**{"output_type": "execute_result", "data": model_message_parts[0], "metadata": {}})]
+                    outputs = [
+                        ExecuteResult(
+                            **{
+                                "output_type": "execute_result", 
+                                "data": model_message_parts[0], 
+                                "metadata": {"rawResponse": model_message}
+                            }
+                        )
+                    ]
                     i += 1
                 prompt = Prompt(**{"name": f'{prompt_name}_{len(prompts) + 1}', "input": user_message_parts, "metadata": {"model": model_metadata}, "outputs": outputs})
                 prompts.append(prompt)

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
@@ -108,16 +108,14 @@ def construct_stream_output(
 
 
 def construct_regular_output(response: TextGenerationResponse, response_includes_details: bool) -> Output:
-    metadata = {}
-    data = response
+    metadata = {"rawResponse": response}
     if response_includes_details:
-        data = response.generated_text
-        metadata = {"details": response.details}
+        metadata["details"] = response.details
 
     output = ExecuteResult(
         **{
             "output_type": "execute_result",
-            "data": data,
+            "data": response.generated_text,
             "execution_count": 0,
             "metadata": metadata,
         }

--- a/python/src/aiconfig/default_parsers/hf.py
+++ b/python/src/aiconfig/default_parsers/hf.py
@@ -108,16 +108,14 @@ def construct_stream_output(
 
 
 def construct_regular_output(response: TextGenerationResponse, response_includes_details: bool) -> Output:
-    metadata = {}
-    data = response
+    metadata = {"rawResponse": response}
     if response_includes_details:
-        data = response.generated_text
-        metadata = {"details": response.details}
+        metadata["details"] = response.details
 
     output = ExecuteResult(
         **{
             "output_type": "execute_result",
-            "data": data,
+            "data": response.generated_text,
             "execution_count": 0,
             "metadata": metadata,
         }
@@ -318,7 +316,14 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
             return ""
 
         if output.output_type == "execute_result":
-            if isinstance(output.data, str):
-                return output.data
-        else:
-            return ""
+            assert isinstance(output, ExecuteResult)
+            output_data = output.data
+            if isinstance(output_data, str):
+                return output_data
+
+            # Doing this to be backwards-compatible with old output format
+            # where we used to save the TextGenerationResponse or
+            # TextGenerationStreamResponse in output.data
+            elif hasattr(output_data, "generated_text"):
+                return output_data.generated_text
+        return ""


### PR DESCRIPTION
[python][non-image]Save output.data with text content instead of response data

Same as last diff except now for Python.

Going to do the image outputs next diff because those actually require updating the data as a key-value pair with kinds and values

For extensions,
- Gemini and Llama-Guard are already in text output format, so not need to do any changes
- updated Llama and the HuggingFace ones (non-image)


## Test plan
Updated automated tests
