### PR TITLE
[ez] Rename llama extension to aiconfig_extension_llama

### DIFF
--- a/cookbooks/llama/python/README.md
+++ b/cookbooks/llama/python/README.md
@@ -8,7 +8,7 @@ All GGUF LLaMA models from https://huggingface.co/TheBloke?search_models=gguf sh
 ## Install
 
 ```
-pip install python-aiconfig python-aiconfig-llama
+pip install python-aiconfig aiconfig-extension-llama
 ```
 
 ## Usage:

--- a/extensions/llama/python/pyproject.toml
+++ b/extensions/llama/python/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools", "wheel"]
 
 [project]
-name = "python-aiconfig"
+name = "aiconfig_extension_llama"
 version = "0.0.1"
 authors = [
   { name="Jonathan Lessinger", email="jonathan@lastmileai.dev" },


### PR DESCRIPTION
[ez] Rename llama extension to aiconfig_extension_llama

TSIA, we shouldn't be making this as part of the generalized `python_aiconfig` module since this is an extension

Will publish this package after it's been stamped
