### PR TITLE
[typescript] Use OutputDataWithValue type for function calls

### DIFF
--- a/typescript/demo/function-call-stream.ts
+++ b/typescript/demo/function-call-stream.ts
@@ -10,7 +10,12 @@ import {
 } from "openai/resources/chat";
 import * as path from "path";
 import { AIConfigRuntime } from "../lib/config";
-import { Prompt } from "../types";
+import {
+  FunctionData,
+  Prompt,
+  OutputDataWithValue,
+  OutputDataWithToolCallsValue,
+} from "../types";
 import { uniqueId } from "lodash";
 
 // This example is taken from https://github.com/openai/openai-node/blob/v4/examples/function-call-stream.ts
@@ -217,12 +222,21 @@ async function functionCallingWithAIConfig() {
       return;
     }
 
-    const rawResponse = output.metadata?.rawResponse;
-    const functionCall = rawResponse?.function_call;
+    let functionCall: FunctionData | null = null;
+    if (output.data?.hasOwnProperty("value")) {
+      const outputData = output.data as OutputDataWithValue;
+      if (outputData.kind === "tool_calls") {
+        outputData as OutputDataWithToolCallsValue;
+        // Typescript schema does not support array of function calls yet,
+        // but Python does, so extracting from an array is for
+        // forwards compatibility
+        functionCall = outputData.value[outputData.value.length - 1].function;
+      }
+    }
     console.log("functionCall=", functionCall);
 
     // If there is no function call, we're done and can exit this loop
-    if (!functionCall) {
+    if (functionCall == null) {
       return;
     }
 

--- a/typescript/lib/parsers/palm.ts
+++ b/typescript/lib/parsers/palm.ts
@@ -1,6 +1,12 @@
 import { TextServiceClient, protos } from "@google-ai/generativelanguage";
 import { JSONObject } from "../../common";
-import { Prompt, Output, ModelMetadata, ExecuteResult } from "../../types";
+import {
+  ExecuteResult,
+  ModelMetadata,
+  Output,
+  OutputDataWithValue,
+  Prompt,
+} from "../../types";
 import { AIConfigRuntime } from "../config";
 import { InferenceOptions } from "../modelParser";
 import { ParameterizedModelParser } from "../parameterizedModelParser";
@@ -180,10 +186,17 @@ export class PaLMTextParser extends ParameterizedModelParser {
     }
 
     if (output.output_type === "execute_result") {
-      return output.data as string;
-    } else {
-      return "";
+      if (output.data?.hasOwnProperty("value")) {
+        const outputData = output.data as OutputDataWithValue;
+        if (typeof outputData.value === "string") {
+          return outputData.value;
+        }
+        return JSON.stringify(outputData.value);
+      } else if (typeof output.data === "string") {
+        return output.data;
+      }
     }
+    return "";
   }
 }
 
@@ -232,7 +245,7 @@ function constructOutputs(
     const candidate = response.candidates[i];
     const output: ExecuteResult = {
       output_type: "execute_result",
-      data: candidate.output,
+      data: candidate.output ?? "",
       execution_count: i,
       metadata: { rawResponse: candidate },
     };


### PR DESCRIPTION
[typescript] Use OutputDataWithValue type for function calls





After discussion and based on comments, we are going to keep pure string form as is, but still need to support non-pure string types to make sure that they're supported. Specifically images (which we don't have on ts) and function calls.

I didn't need to update the hugging face files because those already are just pure text

##Test plan
Pass automated tests, running these commands from `aiconfig` top-level dir
```
npx ts-node typescript/demo/function-call-stream.ts
npx ts-node typescript/demo/demo.ts
npx ts-node typescript/demo/test-hf.ts
```

Also run `yarn test` from typescript dir
