### PR TITLE
[python] Use OutputDataWithValue type for function calls

### DIFF
--- a/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py
+++ b/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py
@@ -1,17 +1,27 @@
 # Define a Model Parser for LLama-Guard
 from typing import TYPE_CHECKING, Dict, List, Optional, Any
 import copy
+import json
 
 import google.generativeai as genai
-import copy
-
-from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
-from aiconfig.model_parser import InferenceOptions
-from aiconfig.schema import ExecuteResult, Output, Prompt
-from aiconfig.util.params import resolve_prompt, resolve_prompt_string
-from aiconfig import CallbackEvent, get_api_key_from_environment, AIConfigRuntime, PromptMetadata, PromptInput
 from google.generativeai.types import content_types
 from google.protobuf.json_format import MessageToDict
+
+from aiconfig import (
+    AIConfigRuntime,
+    CallbackEvent,
+    get_api_key_from_environment,
+)
+from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
+from aiconfig.model_parser import InferenceOptions
+from aiconfig.schema import (
+    ExecuteResult,
+    Output,
+    OutputDataWithValue,
+    Prompt,
+    PromptInput,
+)
+from aiconfig.util.params import resolve_prompt, resolve_prompt_string
 
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
@@ -208,7 +218,6 @@ class GeminiModelParser(ParameterizedModelParser):
                 user_message_parts = user_message["parts"]
                 outputs = []
                 if i + 1 < len(contents):
-                    # TODO (rossdanlm): Support function calls
                     model_message = contents[i + 1]
                     model_message_parts = model_message["parts"]
                     # Gemini api currently only supports one candidate aka one output. Model should only be retuning one part in response.
@@ -218,8 +227,8 @@ class GeminiModelParser(ParameterizedModelParser):
                         ExecuteResult(
                             **{
                                 "output_type": "execute_result", 
-                                "data": model_message_parts[0], 
-                                "metadata": {"rawResponse": model_message}
+                                "data": model_message_parts[0],
+                                "metadata": {"rawResponse": model_message},
                             }
                         )
                     ]
@@ -359,11 +368,20 @@ class GeminiModelParser(ParameterizedModelParser):
             output_data = output.data
             if isinstance(output_data, str):
                 return output_data
-            else:
-                raise ValueError("Not Implemented")
+            if isinstance(output_data, OutputDataWithValue):
+                if isinstance(output_data.value, str):
+                    return output_data.value
 
-        else:
-            return ""
+        # We use this method in the model parser functionality itself,
+        # so we must error to let the user know non-string
+        # formats are not supported
+        error_message = \
+"""
+We currently only support chats where prior messages from a user are only a 
+single message string instance, please see docstring for more details:
+https://github.com/lastmile-ai/aiconfig/blob/v1.1.8/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py#L31-L33
+"""
+        raise ValueError(error_message)
 
     def _construct_chat_history(
         self, prompt: Prompt, aiconfig: "AIConfigRuntime", params: Dict

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_generation.py
@@ -1,11 +1,23 @@
 import copy
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from transformers import AutoTokenizer, Pipeline, pipeline, TextIteratorStreamer
+import json
 import threading
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from transformers import (
+    AutoTokenizer,
+    Pipeline,
+    pipeline,
+    TextIteratorStreamer,
+)
 
 from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
 from aiconfig.model_parser import InferenceOptions
-from aiconfig.schema import ExecuteResult, Output, Prompt, PromptMetadata
+from aiconfig.schema import (
+    ExecuteResult,
+    Output,
+    OutputDataWithValue,
+    Prompt,
+    PromptMetadata,
+)
 from aiconfig.util.params import resolve_prompt
 
 # Circuluar Dependency Type Hints
@@ -101,19 +113,21 @@ def construct_stream_output(
     Constructs the output for a stream response.
 
     Args:
-        streamer (TextIteratorStreamer): Streams the output. See https://huggingface.co/docs/transformers/v4.35.2/en/internal/generation_utils#transformers.TextIteratorStreamer
-        options (InferenceOptions): The inference options. Used to determine the stream callback.
+        streamer (TextIteratorStreamer): Streams the output. See:
+            https://huggingface.co/docs/transformers/v4.35.2/en/internal/generation_utils#transformers.TextIteratorStreamer
+        options (InferenceOptions): The inference options. Used to determine
+            the stream callback.
 
     """
-    accumulated_message = ""
     output = ExecuteResult(
             **{
                 "output_type": "execute_result",
-                "data": accumulated_message,
+                "data": "", # We update this below
                 "execution_count": 0, #Multiple outputs are not supported for streaming
                 "metadata": {},
             }
         )
+    accumulated_message = ""
     for new_text in streamer:
         accumulated_message += new_text
         options.stream_callback(new_text, accumulated_message, 0)
@@ -283,7 +297,13 @@ class HuggingFaceTextGenerationTransformer(ParameterizedModelParser):
         # TODO (rossdanlm): Handle multiple outputs in list
         # https://github.com/lastmile-ai/aiconfig/issues/467
         if output.output_type == "execute_result":
-            if isinstance(output.data, str):
-                return output.data
-        else:
-            return ""
+            output_data = output.data
+            if isinstance(output_data, str):
+                return output_data
+            if isinstance(output_data, OutputDataWithValue):
+                if isinstance(output_data.value, str):
+                    return output_data.value
+                # HuggingFace Text generation does not support function
+                # calls so shouldn't get here, but just being safe
+                return json.dumps(output_data.value, indent=2)
+        return ""

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
@@ -1,9 +1,6 @@
 import copy
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
-
-from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
-from aiconfig.model_parser import InferenceOptions
-from aiconfig.util.config_utils import get_api_key_from_environment
+import json
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Union
 
 # HuggingFace API imports
 from huggingface_hub import InferenceClient
@@ -12,13 +9,19 @@ from huggingface_hub.inference._text_generation import (
     TextGenerationStreamResponse,
 )
 
-from aiconfig.schema import ExecuteResult, Output, Prompt, PromptMetadata
 from aiconfig import CallbackEvent
-
+from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
+from aiconfig.model_parser import InferenceOptions
+from aiconfig.schema import (
+    ExecuteResult,
+    Output,
+    OutputDataWithValue,
+    Prompt,
+    PromptMetadata,
+)
+from aiconfig.util.config_utils import get_api_key_from_environment
 from aiconfig.util.params import resolve_prompt
 
-# ModelParser Utils
-# Type hint imports
 
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
@@ -63,7 +66,7 @@ def refine_chat_completion_params(model_settings: dict[Any, Any]) -> dict[str, A
 
 
 def construct_stream_output(
-    response: TextGenerationStreamResponse,
+    response: Union[Iterable[TextGenerationStreamResponse], Iterable[str]],
     response_includes_details: bool,
     options: InferenceOptions,
 ) -> Output:
@@ -79,26 +82,24 @@ def construct_stream_output(
     accumulated_message = ""
     for iteration in response:
         metadata = {}
-        data = iteration
+        # If response_includes_details is false, `iteration` will be a string,
+        # otherwise, `iteration` is a TextGenerationStreamResponse
+        new_text = iteration
         if response_includes_details:
             iteration: TextGenerationStreamResponse
-            data = iteration.token.text
+            new_text = iteration.token.text
             metadata = {"token": iteration.token, "details": iteration.details}
-        else:
-            data: str
 
         # Reduce
-        accumulated_message += data
+        accumulated_message += new_text
 
         index = 0  # HF Text Generation api doesn't support multiple outputs
-        delta = data
         if options and options.stream_callback:
-            options.stream_callback(delta, accumulated_message, index)
-
+            options.stream_callback(new_text, accumulated_message, index)
         output = ExecuteResult(
             **{
                 "output_type": "execute_result",
-                "data": copy.deepcopy(accumulated_message),
+                "data": accumulated_message,
                 "execution_count": index,
                 "metadata": metadata,
             }
@@ -316,7 +317,13 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
             return ""
 
         if output.output_type == "execute_result":
-            if isinstance(output.data, str):
-                return output.data
-        else:
-            return ""
+            output_data = output.data
+            if isinstance(output_data, str):
+                return output_data
+            if isinstance(output_data, OutputDataWithValue):
+                if isinstance(output_data.value, str):
+                    return output_data.value
+                # HuggingFace Text generation does not support function
+                # calls so shouldn't get here, but just being safe
+                return json.dumps(output_data.value, indent=2)
+        return ""

--- a/extensions/LLama-Guard/python/python/src/aiconfig_extension_llama_guard/LLamaGuard.py
+++ b/extensions/LLama-Guard/python/python/src/aiconfig_extension_llama_guard/LLamaGuard.py
@@ -1,24 +1,27 @@
-# Define a Model Parser for LLama-Guard
-
+"""Define a Model Parser for LLama-Guard"""
 
 import copy
+import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from transformers import AutoTokenizer
-
-from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
-from aiconfig.model_parser import InferenceOptions
-from aiconfig.schema import ExecuteResult, Output, Prompt, PromptMetadata
-from aiconfig.util.params import resolve_prompt
-from aiconfig import CallbackEvent
 
 from transformers import AutoTokenizer, AutoModelForCausalLM
 import torch
 
+from aiconfig import CallbackEvent
+from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
+from aiconfig.model_parser import InferenceOptions
+from aiconfig.schema import (
+    ExecuteResult,
+    Output,
+    OutputDataWithValue,
+    Prompt,
+    PromptMetadata,
+)
+from aiconfig.util.params import resolve_prompt
+
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
     from aiconfig.Config import AIConfigRuntime
-
-
 
 
 # Step 1: define Helpers
@@ -242,8 +245,7 @@ class LLamaGuardParser(ParameterizedModelParser):
         output_text = self.tokenizer.decode(
             response[0][prompt_len:], skip_special_tokens=True
         )
-
-        Output = ExecuteResult(
+        output = ExecuteResult(
             **{
                 "output_type": "execute_result",
                 "data": output_text,
@@ -252,7 +254,7 @@ class LLamaGuardParser(ParameterizedModelParser):
             }
         )
 
-        prompt.outputs = [Output]
+        prompt.outputs = [output]
         return prompt.outputs
 
     def get_output_text(
@@ -268,7 +270,13 @@ class LLamaGuardParser(ParameterizedModelParser):
             return ""
 
         if output.output_type == "execute_result":
-            if isinstance(output.data, str):
-                return output.data
-        else:
-            return ""
+            output_data = output.data
+            if isinstance(output_data, str):
+                return output_data
+            if isinstance(output_data, OutputDataWithValue):
+                if isinstance(output_data.value, str):
+                    return output_data.value
+                # LlamaGuard does not support function
+                # calls so shouldn't get here, but just being safe
+                return json.dumps(output_data.value, indent=2)
+        return ""

--- a/python/src/aiconfig/default_parsers/hf.py
+++ b/python/src/aiconfig/default_parsers/hf.py
@@ -1,9 +1,6 @@
 import copy
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
-
-from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
-from aiconfig.model_parser import InferenceOptions
-from aiconfig.util.config_utils import get_api_key_from_environment
+import json
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 
 # HuggingFace API imports
 from huggingface_hub import InferenceClient
@@ -12,13 +9,19 @@ from huggingface_hub.inference._text_generation import (
     TextGenerationStreamResponse,
 )
 
-from aiconfig.schema import ExecuteResult, Output, Prompt, PromptMetadata
 from aiconfig import CallbackEvent
-
+from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
+from aiconfig.model_parser import InferenceOptions
+from aiconfig.schema import (
+    ExecuteResult,
+    Output,
+    OutputDataWithValue,
+    Prompt,
+    PromptMetadata,
+)
+from aiconfig.util.config_utils import get_api_key_from_environment
 from aiconfig.util.params import resolve_prompt
 
-# ModelParser Utils
-# Type hint imports
 
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
@@ -63,7 +66,7 @@ def refine_chat_completion_params(model_settings: dict[Any, Any]) -> dict[str, A
 
 
 def construct_stream_output(
-    response: TextGenerationStreamResponse,
+    response: Union[Iterable[TextGenerationStreamResponse], Iterable[str]],
     response_includes_details: bool,
     options: InferenceOptions,
 ) -> Output:
@@ -79,26 +82,24 @@ def construct_stream_output(
     accumulated_message = ""
     for iteration in response:
         metadata = {}
-        data = iteration
+        # If response_includes_details is false, `iteration` will be a string,
+        # otherwise, `iteration` is a TextGenerationStreamResponse
+        new_text = iteration
         if response_includes_details:
             iteration: TextGenerationStreamResponse
-            data = iteration.token.text
+            new_text = iteration.token.text
             metadata = {"token": iteration.token, "details": iteration.details}
-        else:
-            data: str
 
         # Reduce
-        accumulated_message += data
+        accumulated_message += new_text
 
         index = 0  # HF Text Generation api doesn't support multiple outputs
-        delta = data
         if options and options.stream_callback:
-            options.stream_callback(delta, accumulated_message, index)
-
+            options.stream_callback(new_text, accumulated_message, index)
         output = ExecuteResult(
             **{
                 "output_type": "execute_result",
-                "data": copy.deepcopy(accumulated_message),
+                "data": accumulated_message,
                 "execution_count": index,
                 "metadata": metadata,
             }
@@ -115,7 +116,7 @@ def construct_regular_output(response: TextGenerationResponse, response_includes
     output = ExecuteResult(
         **{
             "output_type": "execute_result",
-            "data": response.generated_text,
+            "data": response.generated_text or '',
             "execution_count": 0,
             "metadata": metadata,
         }
@@ -316,14 +317,19 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
             return ""
 
         if output.output_type == "execute_result":
-            assert isinstance(output, ExecuteResult)
             output_data = output.data
             if isinstance(output_data, str):
                 return output_data
+            if isinstance(output_data, OutputDataWithValue):
+                if isinstance(output_data.value, str):
+                    return output_data.value
+                # HuggingFace Text generation does not support function
+                # calls so shouldn't get here, but just being safe
+                return json.dumps(output_data.value, indent=2)
 
             # Doing this to be backwards-compatible with old output format
             # where we used to save the TextGenerationResponse or
             # TextGenerationStreamResponse in output.data
-            elif hasattr(output_data, "generated_text"):
+            if hasattr(output_data, "generated_text"):
                 return output_data.generated_text
         return ""

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -1,4 +1,5 @@
 import copy
+import json
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
@@ -7,7 +8,17 @@ from openai.types.chat import ChatCompletionMessage
 from aiconfig.callback import CallbackEvent
 from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
 from aiconfig.model_parser import InferenceOptions
-from aiconfig.schema import ExecuteResult, Output, Prompt, PromptInput, PromptMetadata
+from aiconfig.schema import (
+    ExecuteResult,
+    FunctionCallData,
+    Output,
+    OutputDataWithValue,
+    OutputDataWithToolCallsValue,
+    Prompt,
+    PromptInput,
+    PromptMetadata,
+    ToolCallData,
+)
 from aiconfig.util.config_utils import get_api_key_from_environment
 from aiconfig.util.params import (
     resolve_prompt,
@@ -94,7 +105,7 @@ class OpenAIInference(ParameterizedModelParser):
             role = messsage["role"]
             if role == "user" or role == "function":
                 # Serialize User message as a prompt and save the assistant response as an output
-                assistant_response = None
+                assistant_response : Union[ChatCompletionMessage, None] = None
                 if i + 1 < len(conversation_data["messages"]):
                     next_message = conversation_data["messages"][i + 1]
                     if next_message["role"] == "assistant":
@@ -108,13 +119,16 @@ class OpenAIInference(ParameterizedModelParser):
 
                 assistant_output = []
                 if assistant_response is not None:
-                    assistant_content = assistant_response.get("content", "")
+                    output_data = build_output_data(assistant_response)
+                    metadata = {"rawResponse": assistant_response}
+                    if assistant_response.get("role", None) is not None:
+                        metadata["role"] = assistant_response.get("role")
                     assistant_output = [
                         ExecuteResult(
                             output_type="execute_result",
                             execution_count=None,
-                            data=assistant_content,
-                            metadata={"rawResponse": assistant_response},
+                            data=output_data,
+                            metadata=metadata,
                         )
                     ]
                 prompt = Prompt(
@@ -272,18 +286,25 @@ class OpenAIInference(ParameterizedModelParser):
                 if key != "choices"
             }
             for i, choice in enumerate(response.get("choices")):
+                output_message = choice["message"]
+                output_data = build_output_data(output_message)
+
                 response_without_choices.update(
                     {"finish_reason": choice.get("finish_reason")}
                 )
-                output_message = choice["message"]
-                # TODO (rossdanlm): Support function call handling as output_data
-                output_content = output_message.get("content", "")
+                metadata = {
+                    "rawResponse": output_message, 
+                    **response_without_choices
+                }
+                if output_message.get("role", None) is not None:
+                    metadata["role"] = output_message.get("role")
+
                 output = ExecuteResult(
                     **{
                         "output_type": "execute_result",
-                        "data": output_content,
+                        "data": output_data,
                         "execution_count": i,
-                        "metadata": {"rawResponse": output_message, **response_without_choices},
+                        "metadata": metadata,
                     }
                 )
 
@@ -299,7 +320,7 @@ class OpenAIInference(ParameterizedModelParser):
 
                 for i, choice in enumerate(chunk["choices"]):
                     index = choice.get("index")
-                    accumulated_message_for_choice = messages.get(index, {})
+                    accumulated_message_for_choice = messages.get(index, "")
                     delta = choice.get("delta")
 
                     if options and options.stream_callback:
@@ -310,7 +331,7 @@ class OpenAIInference(ParameterizedModelParser):
                     output = ExecuteResult(
                         **{
                             "output_type": "execute_result",
-                            "data": copy.deepcopy(accumulated_message_for_choice),
+                            "data": accumulated_message_for_choice,
                             "execution_count": index,
                             "metadata": {"finish_reason": choice.get("finish_reason")},
                         }
@@ -353,19 +374,22 @@ class OpenAIInference(ParameterizedModelParser):
             return ""
 
         if output.output_type == "execute_result":
-            message = output.data
-            if isinstance(message, str):
-                return message
-            elif output.metadata["rawResponse"].get("function_call", None):
-                return output.metadata["rawResponse"].function_call
+            output_data = output.data
+            if isinstance(output_data, str):
+                return output_data
+            if isinstance(output_data, OutputDataWithValue):
+                if isinstance(output_data.value, str):
+                    return output_data.value
+                # If we get here that means it must be of kind tool_calls
+                return json.dumps(output_data.value, indent=2)
 
             # Doing this to be backwards-compatible with old output format
             # where we used to save the ChatCompletionMessage in output.data
-            if isinstance(message, ChatCompletionMessage):
-                if hasattr(message, "content") and message.content is not None:
-                    return message.content
-                elif message.function_call is not None:
-                    return str(message.function_call)
+            if isinstance(output_data, ChatCompletionMessage):
+                if hasattr(output_data, "content") and output_data.content is not None:
+                    return output_data.content
+                elif output_data.function_call is not None:
+                    return str(output_data.function_call)
         return ""
 
 
@@ -505,27 +529,48 @@ def add_prompt_as_message(
         if output.output_type == "execute_result":
             assert isinstance(output, ExecuteResult)
             output_data = output.data
-            # TODO (rossdanlm): Support function call handling as output_data
-            if isinstance(output_data, str):
-                if output.metadata["rawResponse"].get("role", "") == "assistant":
-                    output_message = {
-                        "content": output_data,
-                        "role": "assistant",
-                    }
-                    function_call = output.metadata["rawResponse"].get("function_call", None)
-                    tool_calls = output.metadata["rawResponse"].get("tool_calls", None)
-                    if function_call is not None:
-                        output_message["function_call"] = function_call
-                    if tool_calls is not None:
-                        output_message["tool_calls"] = tool_calls
-                    messages.append(output_message)
+            role = output.metadata.get("role", None) or \
+                ("rawResponse" in output.metadata and
+                    output.metadata["rawResponse"].get("role", None))
+
+            if role == "assistant":
+                output_message = {}
+                content : Union[str, None] = None
+                function_call : Union[FunctionCallData, None] = None
+                if isinstance(output_data, str):
+                    content = output_data
+                elif isinstance(output_data, OutputDataWithValue):
+                    if isinstance(output_data.value, str):
+                        content = output_data.value
+                    elif output_data.kind == "tool_calls":
+                        assert isinstance(output, OutputDataWithToolCallsValue)
+                        function_call = \
+                            output_data.value[len(output_data.value) - 1] \
+                            .function
+
+                output_message["content"] = content
+                output_message["role"] = role
+
+                # We should update this to use ChatCompletionAssistantMessageParam
+                # object with field `tool_calls. See comment for details:
+                # https://github.com/lastmile-ai/aiconfig/pull/610#discussion_r1437174736 
+                if function_call is not None:
+                    output_message["function_call"] = function_call
+
+                name = output.metadata.get("name", None) or \
+                    ("rawResponse" in output.metadata and
+                        output.metadata["rawResponse"].get("name", None))
+                if name is not None:
+                    output_message["name"] = name
+
+                messages.append(output_message)
 
             # Doing this to be backwards-compatible with old output format
             # where we used to save the ChatCompletionMessage in output.data
             elif isinstance(output_data, ChatCompletionMessage):
                 if output_data.role == "assistant":
                     messages.append(output_data)
-                    
+
     return messages
 
 
@@ -536,3 +581,52 @@ def is_prompt_template(prompt: Prompt):
     return isinstance(prompt.input, str) or (
         hasattr(prompt.input, "data") and isinstance(prompt.input.data, str)
     )
+
+def build_output_data(
+    message: Union[ChatCompletionMessage, None],
+) -> Union[OutputDataWithValue, str, None]:
+    if message is None:
+        return None
+
+    output_data : Union[OutputDataWithValue, str, None] = None
+    if message.get("content") is not None:
+        output_data = message.get("content") #string
+    elif message.get("tool_calls") is not None:
+        tool_calls = [
+                ToolCallData(
+                    id = item.id,
+                    function=FunctionCallData(
+                        arguments=item.function.arguments,
+                        name=item.function.name,
+                    ),
+                    type='function'
+                )
+            for item in message.get("tool_calls")
+                # It's possible that ChatCompletionMessageToolCall may
+                # support more than just function calls in the future
+                # so filter out other types
+                if item.type == 'function'
+        ]
+        output_data = OutputDataWithToolCallsValue(
+            kind="tool_calls",
+            value = tool_calls,
+        )
+
+    # Deprecated, use tool_calls instead
+    elif message.get("function_call") is not None:
+        function_call = message.get("function_call")
+        tool_calls = [
+            ToolCallData(
+                id = "function_call_data", # value here does not matter
+                function=FunctionCallData(
+                    arguments=function_call["arguments"],
+                    name=function_call["name"],
+                ),
+                type='function'
+            )
+        ]
+        output_data = OutputDataWithToolCallsValue(
+            kind="tool_calls",
+            value = tool_calls,
+        )
+    return output_data

--- a/python/src/aiconfig/default_parsers/palm.py
+++ b/python/src/aiconfig/default_parsers/palm.py
@@ -1,15 +1,21 @@
+import json
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import google.generativeai as palm
 from google.generativeai.text import Completion
 from google.generativeai.types.discuss_types import MessageDict
+from aiconfig.callback import CallbackEvent
 from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
+from aiconfig.model_parser import InferenceOptions
+from aiconfig.schema import (
+    ExecuteResult, 
+    Output, 
+    OutputDataWithValue, 
+    Prompt, 
+    PromptMetadata,
+)
 from aiconfig.util.params import resolve_parameters, resolve_prompt
 
-
-from ..callback import CallbackEvent
-from ..model_parser import InferenceOptions
-from ..schema import ExecuteResult, Output, Prompt, PromptMetadata
 
 if TYPE_CHECKING:
     from aiconfig.Config import AIConfigRuntime
@@ -377,15 +383,19 @@ class PaLMChatParser(ParameterizedModelParser):
             return ""
 
         if output.output_type == "execute_result":
-            assert isinstance(output, ExecuteResult)
             output_data = output.data
-
             if isinstance(output_data, str):
                 return output_data
+            if isinstance(output_data, OutputDataWithValue):
+                if isinstance(output_data.value, str):
+                    return output_data.value
+                # PaLM does not support function calls so shouldn't get here,
+                # but just being safe
+                return json.dumps(output_data.value, indent=2)
 
             # Doing this to be backwards-compatible with old output format
             # where we used to save the MessageDict in output.data
-            elif isinstance(output_data, MessageDict):
+            if isinstance(output_data, MessageDict):
                 if output_data.get("content"):
                     return output_data("content")
         return ""

--- a/python/tests/parsers/test_openai_util.py
+++ b/python/tests/parsers/test_openai_util.py
@@ -2,9 +2,15 @@ import openai
 import pytest
 from aiconfig.Config import AIConfigRuntime
 from aiconfig.default_parsers.openai import refine_chat_completion_params
+from aiconfig.schema import (
+    ExecuteResult,
+    OutputDataWithValue,
+    Prompt,
+    PromptInput,
+    PromptMetadata,
+)
 from mock import patch
 
-from aiconfig import ExecuteResult, Prompt, PromptInput, PromptMetadata
 
 from ..conftest import mock_openai_chat_completion
 from ..util.file_path_utils import get_absolute_file_path_from_relative
@@ -136,10 +142,12 @@ async def test_serialize(set_temporary_env_vars):
                     output_type="execute_result",
                     execution_count=None,
                     data='Hello! How can I assist you today?',
-                    metadata={'rawResponse': {
+                    metadata={
+                        'rawResponse': {
+                            'role': 'assistant',
+                            'content': 'Hello! How can I assist you today?'
+                        },
                         'role': 'assistant',
-                        'content': 'Hello! How can I assist you today?'
-                        }
                     },
                     mime_type=None,
                 )
@@ -277,7 +285,7 @@ async def test_serialize(set_temporary_env_vars):
             ],
         }
 
-        
+
         prompts = await aiconfig.serialize("gpt-3.5-turbo", completion_params, "prompt")
         new_prompt = prompts[1]
         
@@ -330,10 +338,12 @@ async def test_serialize(set_temporary_env_vars):
                     output_type="execute_result",
                     execution_count=None,
                     data="The current weather in Boston is 22 degrees Celsius and sunny.",
-                    metadata={'rawResponse': {
+                    metadata={
+                        'rawResponse': {
+                            'role': 'assistant',
+                            'content': 'The current weather in Boston is 22 degrees Celsius and sunny.',
+                        },
                         'role': 'assistant',
-                        'content': 'The current weather in Boston is 22 degrees Celsius and sunny.',
-                        }
                     },
                     mime_type=None,
                 )


### PR DESCRIPTION
[python] Use OutputDataWithValue type for function calls






This is extending https://github.com/lastmile-ai/aiconfig/pull/605 where I converted from model-specific response types --> pure strings. Now I'm going to also support function calls --> OutputData types

Same as last diff (https://github.com/lastmile-ai/aiconfig/pull/610) except now for python files instead of typescript

Don't need to do this for the image outputs since I already did that in https://github.com/lastmile-ai/aiconfig/pull/608

Actually like typescript, the only model parser we need to support for function calling is `openai.py`
