### PR TITLE
[editor][server endpoints][1/n]: Add delete_prompt() event

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -19,7 +19,7 @@ from aiconfig.editor.server.server_utils import (
 )
 from aiconfig.model_parser import InferenceOptions
 from flask import Flask, request
-from flask_cors import CORS
+from flask_cors import CORS # TODO: add this to requirements.txt
 from result import Err, Ok, Result
 
 from aiconfig.registry import ModelParserRegistry
@@ -156,6 +156,26 @@ def add_prompt() -> FlaskResponse:
         LOGGER.error(f"Failed to add prompt: {err}")
         return HttpResponseWithAIConfig(
             message=f"Failed to add prompt: {err}",
+            code=400,
+            aiconfig=None,
+        ).to_flask_format()
+
+@app.route("/api/delete_prompt", methods=["POST"])
+def delete_prompt() -> FlaskResponse:
+    state = get_server_state(app)
+    request_json = request.get_json()
+    try:
+        LOGGER.info(f"Deleting prompt: {request_json}")
+        state.aiconfig.delete_prompt(**request_json)  # type: ignore
+        return HttpResponseWithAIConfig(
+            message="Done",
+            aiconfig=state.aiconfig,
+        ).to_flask_format()
+    except Exception as e:
+        err: Err[str] = core_utils.ErrWithTraceback(e)
+        LOGGER.error(f"Failed to delete prompt: {err}")
+        return HttpResponseWithAIConfig(
+            message=f"Failed to delete prompt: {err}",
             code=400,
             aiconfig=None,
         ).to_flask_format()


### PR DESCRIPTION
[editor][server endpoints][1/n]: Add delete_prompt() event


To test, follow the readme to run the backend server in a terminal, then go to another terminal and enter:

## Test plan
```bash
alias aiconfig="python -m 'aiconfig.scripts.aiconfig_cli'"
aiconfig edit --aiconfig-path="/Users/rossdancraig/Projects/aiconfig/cookbooks/Getting-Started/travel.aiconfig.json" --server-port=8080 --server-mode=debug_servers

# Now run this from another terminal
curl http://localhost:8080/api/run -d '{"prompt_name":"get_activities"}' -X POST -H 'Content-Type: application/json'
```

This results in `get_activities` prompt being deleted (notice that the second prompt is now the one that appears first):
<img width="969" alt="Screenshot 2023-12-26 at 00 30 23" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/5dd905c8-7cb6-4c1f-a97b-284337196506">
<img width="824" alt="Screenshot 2023-12-26 at 00 30 49" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/8bfc5003-72d0-4e5a-9bf9-14e849acade7">

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/612).
* #615
* #613
* __->__ #612