### PR TITLE
[editor][server endpoints][2/n]: Add params arg to run command and check for undefined prompt_name

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import Any, Dict, Type, Union
 
@@ -169,8 +168,19 @@ async def run() -> FlaskResponse:
     request_json = request.get_json()
 
     try:
-        prompt_name = request_json["prompt_name"]
-        params = request_json.get("params", {})
+        prompt_name: Union[str, None] = request_json.get("prompt_name")
+        if prompt_name is None:
+            return HttpResponseWithAIConfig(
+                message="No prompt name provided, cannot execute `run` command",
+                code=400,
+                aiconfig=None,
+            ).to_flask_format()
+
+        # TODO (rossdanlm): Refactor aiconfig.run() to not take in `params`
+        # as a function arg since we can now just call
+        # aiconfig.get_parameters(prompt_name) directly inside of run. See:
+        # https://github.com/lastmile-ai/aiconfig/issues/671
+        params = request_json.get("params", aiconfig.get_parameters(prompt_name))  # type: ignore
         stream = request_json.get("stream", False)
         options = InferenceOptions(stream=stream)
         run_output = await aiconfig.run(prompt_name, params, options)  # type: ignore


### PR DESCRIPTION
[editor][server endpoints][2/n]: Add params arg to run command and check for undefined prompt_name



TSIA, pretty simple otherwise we'd be using empty params field and that would error. For the future, I created issue https://github.com/lastmile-ai/aiconfig/issues/671 where we shouldn't even need to pass in params into run and this works implicitly

## Test Plan
Follow dev README to setup the local editor: https://github.com/lastmile-ai/aiconfig/tree/main/python/src/aiconfig/editor#dev, then run this command
```
curl http://localhost:8080/api/run -d '{"prompt_name":"get_activities"}' -X POST -H 'Content-Type: application/json'
```

Without params

https://github.com/lastmile-ai/aiconfig/assets/151060367/7233a4db-9042-4fa9-affb-0f854ae8a50e


With params

https://github.com/lastmile-ai/aiconfig/assets/151060367/6c078804-ea66-4358-824d-21d0fe26bafa
