### PR TITLE
[editor][server endpoints][3/n]: Proof-of-Concept for Streaming

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -119,12 +119,23 @@ def create() -> FlaskResponse:
 async def run() -> FlaskResponse:
     state = get_server_state(app)
     request_json = request.get_json()
-    prompt_name = request_json.get("prompt_name", None)
-    stream = request_json.get("stream", True)
+    prompt_name : str = request_json.get("prompt_name", None)
+    if prompt_name is None:
+        return HttpResponseWithAIConfig(
+            message="No prompt name provided, cannot execute `run` command",
+            code=400,
+            aiconfig=None,
+        ).to_flask_format()
+    params : str = request_json.get("params", None)
+    stream : bool = request_json.get("stream", True)
     LOGGER.info(f"Running prompt: {prompt_name}, {stream=}")
     inference_options = InferenceOptions(stream=stream)
     try:
-        result = await state.aiconfig.run(prompt_name, options=inference_options)  # type: ignore
+        result = await state.aiconfig.run( # type: ignore
+            prompt_name,
+            params,
+            options=inference_options,
+        ) 
         LOGGER.debug(f"Result: {result=}")
         return HttpResponseWithAIConfig(
             message="Done",

--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -19,7 +19,7 @@ from aiconfig.editor.server.server_utils import (
 )
 from aiconfig.model_parser import InferenceOptions
 from flask import Flask, request
-from flask_cors import CORS
+from flask_cors import CORS # TODO: add this to requirements.txt
 from result import Err, Ok, Result
 
 from aiconfig.registry import ModelParserRegistry
@@ -156,6 +156,26 @@ def add_prompt() -> FlaskResponse:
         LOGGER.error(f"Failed to add prompt: {err}")
         return HttpResponseWithAIConfig(
             message=f"Failed to add prompt: {err}",
+            code=400,
+            aiconfig=None,
+        ).to_flask_format()
+
+@app.route("/api/delete_prompt", methods=["POST"])
+def delete_prompt() -> FlaskResponse:
+    state = get_server_state(app)
+    request_json = request.get_json()
+    try:
+        LOGGER.info(f"Deleting prompt: {request_json}")
+        state.aiconfig.delete_prompt(**request_json)  # type: ignore
+        return HttpResponseWithAIConfig(
+            message="Done",
+            aiconfig=state.aiconfig,
+        ).to_flask_format()
+    except Exception as e:
+        err: Err[str] = core_utils.ErrWithTraceback(e)
+        LOGGER.error(f"Failed to delete prompt: {err}")
+        return HttpResponseWithAIConfig(
+            message=f"Failed to delete prompt: {err}",
             code=400,
             aiconfig=None,
         ).to_flask_format()


### PR DESCRIPTION
[editor][server endpoints][3/n]: Proof-of-Concept for Streaming

The actual call in the `run` command will be a bit more complex since we'll have to attach a stream callback and probably create a text queue iterator like what we did for Gradio, but this shows that it's possible and shouldn't be too complicated.

Sorry Jonathan, I didn't use any of your super useful generic functions, but we can do that later.

A big thing I wanted to point out is that in the `yield` generator, I need explicitly return a string (not a json object), otherwise this will not work, so the frontend needs to be able to parse that result somehow. We should sync on this but I feel jsons are strings anyways and as long as we follow the same output "formula" (ex: in the `list_models` we out `data` key vs other commands we directly return the AIConfig json), it should be fine.

## Test plan

https://github.com/lastmile-ai/aiconfig/assets/151060367/4c99cec1-9342-4876-8300-ddb27eb7a2cf




---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/615).
* __->__ #615
* #613
* #612