### PR TITLE
[editor] Fix Client Request API Endpoint to Work for Any Prod Port

### DIFF
--- a/python/src/aiconfig/editor/client/src/utils/api.ts
+++ b/python/src/aiconfig/editor/client/src/utils/api.ts
@@ -1,9 +1,12 @@
 import urlJoin from "url-join";
 
-// TODO: Figure out how to dynamically set this based on port specified by script
-const ENDPOINT = "http://localhost:8080";
+// For development, run the python server at port 8080
+// For prod, client is bundled and served by the python server at the same port as
+// the server so use "/" as the host endpoint and the port doesn't matter
+const HOST_ENDPOINT =
+  process.env.NODE_ENV === "development" ? "http://localhost:8080" : "";
 
-const API_ENDPOINT = `${ENDPOINT}/api`;
+const API_ENDPOINT = `${HOST_ENDPOINT}/api`;
 
 export const ROUTE_TABLE = {
   LOAD: urlJoin(API_ENDPOINT, "/load"),


### PR DESCRIPTION
# [editor] Fix Client Request API Endpoint to Work for Any Prod Port

In development, the client will be served via a node process from `react-scripts` at localhost:3000 by default. The python server will be at localhost:8080 by default.

In 'prod', the client will be bundled and statically served by the python server at the same port as the python server.

So, for prod we should make requests to '/api/*' which will resolve to the hostname/port of the server that served the JS.

For dev, we can just hardcode to the correct server port for now.

## Testing:
`yarn build` in `aiconfig/python/src/aiconfig/editor/client`
Then run the prod server mode: `aiconfig edit --aiconfig-path=cli/aiconfig-editor/travel.aiconfig.json --server-mode='prod'`
and see the editor at localhost:8080 sending correct requests
<img width="1081" alt="Screenshot 2023-12-26 at 1 51 18 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/cf1d56de-4673-47c5-8876-e0e52f350df9">

Simultaneously, start up on another port:
`ryanholinshead@Ryans-MacBook-Pro aiconfig % aiconfig edit --aiconfig-path=cli/aiconfig-editor/travel.aiconfig.json --server-mode='prod' --server-port=1234`
and see the editor there as well

<img width="1704" alt="Screenshot 2023-12-26 at 1 57 13 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/fa1a6ad2-2ae3-46a3-934f-7acc1e4a0de9">



