### PR TITLE
[editor] Functionality to run server on multiple configs without specifying port

### DIFF
--- a/python/src/aiconfig/scripts/aiconfig_cli.py
+++ b/python/src/aiconfig/scripts/aiconfig_cli.py
@@ -3,6 +3,7 @@ import logging
 import signal
 import subprocess
 import sys
+import socket
 
 import lastmile_utils.lib.core.api as core_utils
 import result
@@ -64,8 +65,33 @@ def _sigint(procs: list[subprocess.Popen[bytes]]) -> Result[str, str]:
         p.send_signal(signal.SIGINT)
     return Ok("Sent SIGINT to frontend servers.")
 
+def is_port_in_use(port: int) -> bool:
+    """ 
+    Checks if a port is in use at localhost.
+    
+    Creates a temporary connection.
+    Context manager will automatically close the connection
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(('localhost', port)) == 0
+
 
 def _run_editor_servers(edit_config: EditServerConfig) -> Result[list[str], str]:
+    
+    port = edit_config.server_port
+
+    while is_port_in_use(port):
+        LOGGER.warning(f"Port {port} is in use. Checking next port.")
+        port += 1
+
+    # Must reconstruct, EditServerConfig is an immutable type (frozen dataclass)
+    edit_config_dict = edit_config.model_dump()
+    edit_config_dict["server_port"] = port
+    edit_config = EditServerConfig(**edit_config_dict)
+
+    LOGGER.warning(f"Using {port}.")
+
+    # Check if server is already running
     LOGGER.info("Running editor servers")
     frontend_procs = _run_frontend_server_background() if edit_config.server_mode in [ServerMode.DEBUG_SERVERS] else Ok([])
     match frontend_procs:


### PR DESCRIPTION
[editor] Functionality to run server on multiple configs without specifying port





## What:

Before creating the server process, check if the port to be used is taken. If so, find the next available one before continuing

for context: this builds on top of #619 

## Why

When running the editor, user should be able to open multiple configs.

Under the hood this means spinning up another server in an unused port. Frontend already supports dynamic ports.

## Testplan

1. yarn build in aiconfig/python/src/aiconfig/editor/client
2. Open two aiconfigs with "prod" editor"

| Getting Started aiconfig | Chain Of Verification aiconfig|
|------------|-------------|
| ![Screenshot 1](https://github.com/lastmile-ai/aiconfig/assets/141073967/ae710711-17f6-498f-a5cb-6eee04baa8eb) |  ![Screenshot 2](https://github.com/lastmile-ai/aiconfig/assets/141073967/9f2d2b85-f60e-4c9e-a76c-e22cfbecd16e)|
| ![Screenshot 3](https://github.com/lastmile-ai/aiconfig/assets/141073967/10b28a80-2d60-4352-a296-bc0231a76002) | ![Screenshot 4](https://github.com/lastmile-ai/aiconfig/assets/141073967/96a5df41-99fb-4bee-8f3a-5826e88c8e53)|

Terminals showcase the command used to open editor. Each one has a seperate config file path. No port is passed in from the user.

Chain of verification Uses Port 8080
Getting Started in a new process using Port 8081