### PR TITLE
[RFC] Add "function" as an explicit kind of output data

### DIFF
--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -20,6 +20,27 @@ class OutputData(BaseModel):
     value: str
 
 
+class FunctionCallData(BaseModel):
+    """
+    Function call data reprsenting a single function call
+    """
+
+    name: str
+    arguments: str
+
+    class Config:
+        extra = "allow"
+
+
+class FunctionCall(BaseModel):
+    """
+    Standard format for data representing function call(s)
+    """
+
+    kind: Literal["function"]
+    value: List[FunctionCallData]
+
+
 class ExecuteResult(BaseModel):
     """
     ExecuteResult represents the result of executing a prompt.

--- a/typescript/types.ts
+++ b/typescript/types.ts
@@ -196,6 +196,14 @@ export type ExecuteResult = {
     | {
         kind: "string" | "file_uri" | "base64";
         value: string;
+      }
+    | {
+        kind: "function";
+        value: {
+          name: string;
+          arguments: string;
+          [k: string]: any;
+        }[];
       };
   /**
    * The MIME type of the result. If not specified, the MIME type will be assumed to be plain text.


### PR DESCRIPTION
[RFC] Add "function" as an explicit kind of output data

This can help us distinguish function calling from regular strings quickly -- since function calling is now supported across multiple models, it deserves to be a top-level output kind in the schema.

For example, current models that support it:
* GPT-3.5, GPT-4, GPT-4V
* Gemini
* [Mixtral (using Anyscale endpoints)](https://docs.endpoints.anyscale.com/guides/function-calling/#:~:text=With%20Anyscale%20Endpoints%2C%20you%20can,parameters%20to%20pass%20to%20it.)
* There will be more to come
