### PR TITLE
[ez] Add `List[Prompt]` output type to all serialize methods

### DIFF
--- a/cookbooks/HuggingFace/hf.py
+++ b/cookbooks/HuggingFace/hf.py
@@ -173,7 +173,7 @@ class HuggingFaceTextParser(ParameterizedModelParser):
         ai_config: "AIConfigRuntime",
         parameters: Optional[Dict] = None,
         **kwargs
-    ) -> Prompt:
+    ) -> List[Prompt]:
         """
         Defines how a prompt and model inference settings get serialized in the .aiconfig.
 

--- a/cookbooks/HuggingFace/python/hf.py
+++ b/cookbooks/HuggingFace/python/hf.py
@@ -173,7 +173,7 @@ class HuggingFaceTextParser(ParameterizedModelParser):
         ai_config: "AIConfigRuntime",
         parameters: Optional[Dict] = None,
         **kwargs
-    ) -> Prompt:
+    ) -> List[Prompt]:
         """
         Defines how a prompt and model inference settings get serialized in the .aiconfig.
 

--- a/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py
+++ b/extensions/Gemini/python/src/aiconfig_extension_gemini/Gemini.py
@@ -185,7 +185,7 @@ class GeminiModelParser(ParameterizedModelParser):
 
         contents_is_str = isinstance(contents, str)
         contents_is_list_of_strings = all(isinstance(item, str) for item in contents) if isinstance(contents, list) else False
-        
+
         # Role Dict looks like this:
         #     {'role':'user',
         #      'parts': ["Briefly explain how a computer works to a young child."]

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_2_image.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_2_image.py
@@ -182,7 +182,7 @@ class HuggingFaceText2ImageDiffusor(ParameterizedModelParser):
         ai_config: "AIConfigRuntime",
         parameters: Optional[Dict[str, Any]] = None,
         **completion_params,
-    ) -> Prompt:
+    ) -> List[Prompt]:
         """
         Defines how a prompt and model inference settings get serialized in the .aiconfig.
 
@@ -213,7 +213,7 @@ class HuggingFaceText2ImageDiffusor(ParameterizedModelParser):
                 model=model_metadata, parameters=parameters, **completion_params
             ),
         )
-        return prompt
+        return [prompt]
 
     async def deserialize(
         self,

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_generation.py
@@ -153,16 +153,16 @@ class HuggingFaceTextGenerationTransformer(ParameterizedModelParser):
         ai_config: "AIConfigRuntime",
         parameters: Optional[Dict[str, Any]] = None,
         **kwargs,
-    ) -> Prompt:
+    ) -> List[Prompt]:
         """
         Defines how a prompt and model inference settings get serialized in the .aiconfig.
 
         Args:
-            prompt (str): The prompt to be serialized.
+            prompt_name (str): The prompt to be serialized.
             inference_settings (dict): Model-specific inference settings to be serialized.
 
         Returns:
-            str: Serialized representation of the prompt and inference settings.
+            List[Prompt]: Serialized representation of the prompt and inference settings.
         """
         data = copy.deepcopy(data)
 
@@ -180,7 +180,7 @@ class HuggingFaceTextGenerationTransformer(ParameterizedModelParser):
                 model=model_metadata, parameters=parameters, **kwargs
             ),
         )
-        return prompt
+        return [prompt]
 
     async def deserialize(
         self,

--- a/extensions/LLama-Guard/python/python/src/aiconfig_extension_llama_guard/LLamaGuard.py
+++ b/extensions/LLama-Guard/python/python/src/aiconfig_extension_llama_guard/LLamaGuard.py
@@ -144,7 +144,7 @@ class LLamaGuardParser(ParameterizedModelParser):
         ai_config: "AIConfigRuntime",
         parameters: Optional[Dict[str, Any]] = None,
         **kwargs,
-    ) -> Prompt:
+    ) -> List[Prompt]:
         """
         Defines how a prompt and model inference settings get serialized in the .aiconfig.
 
@@ -171,7 +171,7 @@ class LLamaGuardParser(ParameterizedModelParser):
                 model=model_metadata, parameters=parameters, **kwargs
             ),
         )
-        return prompt
+        return [prompt]
 
     async def deserialize(
         self,

--- a/extensions/llama/python/llama.py
+++ b/extensions/llama/python/llama.py
@@ -23,7 +23,7 @@ class LlamaModelParser(ParameterizedModelParser):
         ai_config: AIConfigRuntime,
         parameters: dict | None = None,
         **kwargs,
-    ) -> Prompt:
+    ) -> List[Prompt]:
         parameters = parameters or {}
         out = Prompt(name=prompt_name, input=data)
         return [out]

--- a/python/src/aiconfig/ChatCompletion.py
+++ b/python/src/aiconfig/ChatCompletion.py
@@ -76,7 +76,10 @@ def extract_outputs_from_response(response) -> List[Output]:
     return outputs
 
 
-def async_run_serialize_helper(aiconfig: AIConfigRuntime, request_kwargs: Dict):
+def async_run_serialize_helper(
+    aiconfig: AIConfigRuntime, 
+    request_kwargs: Dict,
+) -> List[Prompt]:
     """
     Method serialize() of AIConfig is an async method. If not, create a new one and await serialize().
     """

--- a/python/src/aiconfig/default_parsers/dalle.py
+++ b/python/src/aiconfig/default_parsers/dalle.py
@@ -97,7 +97,7 @@ class DalleImageGenerationParser(ParameterizedModelParser):
         ai_config: "AIConfigRuntime",
         parameters: Optional[Dict] = None,
         **kwargs,
-    ) -> Prompt:
+    ) -> List[Prompt]:
         """
         Defines how a prompt and model inference settings get serialized in the .aiconfig.
 

--- a/python/src/aiconfig/default_parsers/hf.py
+++ b/python/src/aiconfig/default_parsers/hf.py
@@ -170,7 +170,7 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         ai_config: "AIConfigRuntime",
         parameters: Optional[dict[Any, Any]] = None,
         **kwargs,
-    ) -> list[Prompt]:
+    ) -> List[Prompt]:
         """
         Defines how a prompt and model inference settings get serialized in the .aiconfig.
 

--- a/python/src/aiconfig/default_parsers/palm.py
+++ b/python/src/aiconfig/default_parsers/palm.py
@@ -239,6 +239,7 @@ class PaLMChatParser(ParameterizedModelParser):
 
         event = CallbackEvent("on_serialize_complete", __name__, {"result": prompts})
         await ai_config.callback_manager.run_callbacks(event)
+        return prompts
 
     async def deserialize(
         self, prompt: Prompt, aiconfig: "AIConfigRuntime", params: Optional[Dict] = {}

--- a/python/src/aiconfig/model_parser.py
+++ b/python/src/aiconfig/model_parser.py
@@ -1,7 +1,14 @@
 from abc import ABC, abstractmethod
 import asyncio
 import copy
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+)
 
 from aiconfig.schema import AIConfig, ExecuteResult, Output, Prompt
 
@@ -24,9 +31,10 @@ class ModelParser(ABC):
         ai_config: "AIConfigRuntime",
         parameters: Optional[Dict] = None,
         **kwargs,
-    ) -> Prompt:
+    ) -> List[Prompt]:
         """
-        Serialize a prompt and additional metadata/model settings into a Prompt object that can be saved in the AIConfig.
+        Serialize a prompt and additional metadata/model settings into a 
+        list of Prompt objects that can be saved in the AIConfig.
 
         Args:
             prompt_name (str): Name to identify the prompt.
@@ -36,7 +44,7 @@ class ModelParser(ABC):
             **kwargs: Additional keyword arguments, if needed.
 
         Returns:
-            Prompt: Serialized representation of the input data.
+            List[Prompt]: Serialized representation of the input data.
         """
 
     @abstractmethod


### PR DESCRIPTION
[ez] Add `List[Prompt]` output type to all serialize methods

This caused confusion because typing wasn't clearly defined: https://github.com/lastmile-ai/aiconfig/pull/608#discussion_r1436528231

I also noticed that the `palm.py` one didn't actually return `prompts`, so I added it there too

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/632).
* #608
* __->__ #632