### PR TITLE
Export OutputData type

### DIFF
--- a/python/src/aiconfig/__init__.py
+++ b/python/src/aiconfig/__init__.py
@@ -20,6 +20,7 @@ from .schema import (
     JSONObject,
     ModelMetadata,
     Output,
+    OutputData,
     Prompt,
     PromptInput,
     PromptMetadata,

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -10,8 +10,7 @@ JSONObject = Dict[str, Any]
 # InferenceSettings represents settings for model inference as a JSON object
 InferenceSettings = JSONObject
 
-
-class OutputData(BaseModel):
+class OutputDataWithStringValue(BaseModel):
     """
     OutputData represents the output content in a standard format.
     """
@@ -32,13 +31,16 @@ class FunctionCallData(BaseModel):
         extra = "allow"
 
 
-class FunctionCall(BaseModel):
+class OutputDataWithFunctionValue(BaseModel):
     """
     Standard format for data representing function call(s)
     """
 
     kind: Literal["function"]
     value: List[FunctionCallData]
+
+
+OutputData = Union[OutputDataWithStringValue, OutputDataWithFunctionValue]
 
 
 class ExecuteResult(BaseModel):
@@ -51,7 +53,7 @@ class ExecuteResult(BaseModel):
     # nth choice.
     execution_count: Union[int, None] = None
     # The result of the executing prompt.
-    data: Union[Any, OutputData]
+    data: Union[OutputData, Any]
     # The MIME type of the result. If not specified, the MIME type will be assumed to be plain text.
     mime_type: Optional[str] = None
     # Output metadata

--- a/schema/aiconfig.schema.json
+++ b/schema/aiconfig.schema.json
@@ -164,6 +164,7 @@
                 "type": "object",
                 "properties": {
                   "data": {
+                    "$ref": "#/definitions/JSONValue",
                     "description": "The data representing the attachment"
                   },
                   "mime_type": {
@@ -182,12 +183,35 @@
               }
             },
             "data": {
+              "$ref": "#/definitions/JSONValue",
               "description": "Input to the model. This can represent a single input, or multiple inputs.\nThe structure of the data object is up to the ModelParser."
             }
           }
         },
         {
           "type": "string"
+        }
+      ]
+    },
+    "JSONValue": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JSONValue"
+          }
+        },
+        {
+          "type": [
+            "null",
+            "string",
+            "number",
+            "boolean"
+          ]
         }
       ]
     },
@@ -208,7 +232,79 @@
               "type": "number"
             },
             "data": {
-              "description": "The result of executing the prompt."
+              "description": "The result of executing the prompt.",
+              "anyOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/JSONValue"
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "enum": [
+                        "base64",
+                        "file_uri",
+                        "string"
+                      ],
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "value"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "const": "function"
+                    },
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "arguments": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "arguments",
+                          "name"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "value"
+                  ]
+                },
+                {
+                  "type": [
+                    "null",
+                    "string",
+                    "number",
+                    "boolean"
+                  ]
+                }
+              ]
             },
             "mime_type": {
               "description": "The MIME type of the result. If not specified, the MIME type will be assumed to be plain text.",

--- a/schema/aiconfig.schema.json
+++ b/schema/aiconfig.schema.json
@@ -265,15 +265,15 @@
                   ]
                 },
                 {
-                  "type": "object",
-                  "properties": {
-                    "kind": {
-                      "type": "string",
-                      "const": "function"
-                    },
-                    "value": {
-                      "type": "array",
-                      "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "function"
+                      },
+                      "value": {
                         "type": "object",
                         "additionalProperties": {},
                         "properties": {
@@ -289,12 +289,12 @@
                           "name"
                         ]
                       }
-                    }
-                  },
-                  "required": [
-                    "kind",
-                    "value"
-                  ]
+                    },
+                    "required": [
+                      "kind",
+                      "value"
+                    ]
+                  }
                 },
                 {
                   "type": [

--- a/typescript/common.ts
+++ b/typescript/common.ts
@@ -1,5 +1,5 @@
 // From https://github.com/microsoft/TypeScript/issues/1897
-export type JSONPrimitive = string | number | boolean | null | unknown;
+export type JSONPrimitive = string | number | boolean | null | undefined;
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
-export type JSONObject = { [member: string]: JSONValue };
+export type JSONObject = { [member: string]: JSONValue | any };
 export type JSONArray = JSONValue[];

--- a/typescript/types.ts
+++ b/typescript/types.ts
@@ -175,6 +175,24 @@ export type Prompt = {
 export type Output = ExecuteResult | Error;
 
 /**
+ * The output type of the result from executing a prompt.
+ * We use this the kind field to determine how to parse it.
+ */
+export type OutputData =
+  | {
+      kind: "string" | "file_uri" | "base64";
+      value: string;
+    }
+  | {
+      kind: "function";
+      value: {
+        name: string;
+        arguments: string;
+        [k: string]: any;
+      };
+    }[];
+
+/**
  * Result of executing a prompt.
  */
 export type ExecuteResult = {
@@ -191,20 +209,8 @@ export type ExecuteResult = {
   /**
    * The result of executing the prompt.
    */
-  data:
-    | JSONValue
-    | {
-        kind: "string" | "file_uri" | "base64";
-        value: string;
-      }
-    | {
-        kind: "function";
-        value: {
-          name: string;
-          arguments: string;
-          [k: string]: any;
-        }[];
-      };
+  data: OutputData | JSONValue;
+
   /**
    * The MIME type of the result. If not specified, the MIME type will be assumed to be plain text.
    */


### PR DESCRIPTION
Export OutputData type


Need to export this so we can set it as explicit typing and not break typescript. Also this just makes it easier to manage now. Also removed the `[]` form from the function_call, because that's just a value not an array.

I also rebased on top of https://github.com/lastmile-ai/aiconfig/pull/631 (changed `unknown` --> `undefined`) because the schema wasn't be generated properly otherwise

Also made the python version `OutputData` also encompass function calls just like in typescript

## Test plan
```
cd typescript
yarn gen-schema
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/634).
* #636
* __->__ #634
* #635