### PR TITLE
[editor] Connect UPDATE_PROMPT_INPUT to update_prompt endpoint

### DIFF
--- a/python/src/aiconfig/editor/client/src/Editor.tsx
+++ b/python/src/aiconfig/editor/client/src/Editor.tsx
@@ -57,12 +57,23 @@ export default function Editor() {
     });
   }, []);
 
+  const updatePrompt = useCallback(
+    async (promptName: string, promptData: Prompt) => {
+      return await ufetch.post(ROUTE_TABLE.UPDATE_PROMPT, {
+        prompt_name: promptName,
+        prompt_data: promptData,
+      });
+    },
+    []
+  );
+
   const callbacks: AIConfigCallbacks = useMemo(
     () => ({
       addPrompt,
       getModels,
       runPrompt,
       save,
+      updatePrompt,
     }),
     [save, getModels, addPrompt, runPrompt]
   );

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -88,7 +88,8 @@ function reduceConsolidateAIConfig(
   responseConfig: AIConfig
 ): ClientAIConfig {
   switch (action.type) {
-    case "ADD_PROMPT_AT_INDEX": {
+    case "ADD_PROMPT_AT_INDEX":
+    case "UPDATE_PROMPT_INPUT": {
       // Make sure prompt structure is properly updated. Client input and metadata takes precedence
       // since it may have been updated by the user while the request was in flight
       return reduceReplacePrompt(state, action.index, (prompt) => {

--- a/python/src/aiconfig/editor/client/src/utils/aiconfigStateUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/aiconfigStateUtils.ts
@@ -8,7 +8,3 @@ export function getDefaultNewPromptName(aiconfig: AIConfig): string {
   }
   return `prompt_${i}`;
 }
-
-export function getPromptName(aiconfig: AIConfig, promptIndex: number): string {
-  return aiconfig.prompts[promptIndex]!.name;
-}

--- a/python/src/aiconfig/editor/client/src/utils/api.ts
+++ b/python/src/aiconfig/editor/client/src/utils/api.ts
@@ -14,4 +14,5 @@ export const ROUTE_TABLE = {
   LOAD: urlJoin(API_ENDPOINT, "/load"),
   LIST_MODELS: urlJoin(API_ENDPOINT, "/list_models"),
   RUN_PROMPT: urlJoin(API_ENDPOINT, "/run"),
+  UPDATE_PROMPT: urlJoin(API_ENDPOINT, "/update_prompt"),
 };


### PR DESCRIPTION
[editor] Connect UPDATE_PROMPT_INPUT to update_prompt endpoint

# [editor] Connect UPDATE_PROMPT_INPUT to update_prompt endpoint

Hook up the `UPDATE_PROMPT_INPUT` action to the server `update_prompt` endpoint, sending requests with a 250ms debounce so that we don't spam the server and avoid potential overlap.

We don't have server-side endpoints for updating specific parts of the prompt right now (not sure if that would be any major improvement), so we currently need to send a Prompt constructed with the updated input as a spread into the current prompt in state. We still maintain the UI state in the reducer instead of passing in this new spread prompt to the reducer from this callback since the reducer should be the source of truth for UI state and will ensure the proper immutable state flow is maintained. We can also add other state values (e.g. 'isExecuting', 'isDirty', 'isReadonly') in this reducer but leaving that out for now until it's for sure needed.

## Testing:
- Make some quick changes to the prompt input and see the proper updates and debounced requests

https://github.com/lastmile-ai/aiconfig/assets/5060851/b95d5116-9484-4d2f-88c3-de441507a140

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/642).
* #647
* #644
* #643
* __->__ #642