### PR TITLE
[editor][easy] Use JSONObject import from 'aiconfig'

### DIFF
--- a/python/src/aiconfig/editor/client/src/Editor.tsx
+++ b/python/src/aiconfig/editor/client/src/Editor.tsx
@@ -57,12 +57,23 @@ export default function Editor() {
     });
   }, []);
 
+  const updatePrompt = useCallback(
+    async (promptName: string, promptData: Prompt) => {
+      return await ufetch.post(ROUTE_TABLE.UPDATE_PROMPT, {
+        prompt_name: promptName,
+        prompt_data: promptData,
+      });
+    },
+    []
+  );
+
   const callbacks: AIConfigCallbacks = useMemo(
     () => ({
       addPrompt,
       getModels,
       runPrompt,
       save,
+      updatePrompt,
     }),
     [save, getModels, addPrompt, runPrompt]
   );

--- a/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
@@ -11,14 +11,7 @@ import {
 import { IconTrash, IconPlus } from "@tabler/icons-react";
 import { debounce, uniqueId } from "lodash";
 import { useState, useCallback, memo, useMemo } from "react";
-
-interface JSONArray extends Array<JSONValue> {}
-
-interface JSONObject {
-  [x: string]: JSONValue;
-}
-
-type JSONValue = string | number | boolean | JSONObject | JSONArray | unknown;
+import { JSONValue, JSONObject } from "aiconfig";
 
 type Parameter = { parameterName: string; parameterValue: JSONValue };
 

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -88,7 +88,8 @@ function reduceConsolidateAIConfig(
   responseConfig: AIConfig
 ): ClientAIConfig {
   switch (action.type) {
-    case "ADD_PROMPT_AT_INDEX": {
+    case "ADD_PROMPT_AT_INDEX":
+    case "UPDATE_PROMPT_INPUT": {
       // Make sure prompt structure is properly updated. Client input and metadata takes precedence
       // since it may have been updated by the user while the request was in flight
       return reduceReplacePrompt(state, action.index, (prompt) => {

--- a/python/src/aiconfig/editor/client/src/utils/aiconfigStateUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/aiconfigStateUtils.ts
@@ -8,7 +8,3 @@ export function getDefaultNewPromptName(aiconfig: AIConfig): string {
   }
   return `prompt_${i}`;
 }
-
-export function getPromptName(aiconfig: AIConfig, promptIndex: number): string {
-  return aiconfig.prompts[promptIndex]!.name;
-}

--- a/python/src/aiconfig/editor/client/src/utils/api.ts
+++ b/python/src/aiconfig/editor/client/src/utils/api.ts
@@ -14,4 +14,5 @@ export const ROUTE_TABLE = {
   LOAD: urlJoin(API_ENDPOINT, "/load"),
   LIST_MODELS: urlJoin(API_ENDPOINT, "/list_models"),
   RUN_PROMPT: urlJoin(API_ENDPOINT, "/run"),
+  UPDATE_PROMPT: urlJoin(API_ENDPOINT, "/update_prompt"),
 };


### PR DESCRIPTION
[editor][easy] Use JSONObject import from 'aiconfig'

# [editor][easy] Use JSONObject import from 'aiconfig'

Fix import path to import from "aiconfig" instead of "aiconfig/dist/common" and don't redefine JSONObject in parameters renderer

## Testing:
- Load model settings and parameters drawers & set some values without issue

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/643).
* #647
* #644
* __->__ #643
* #642