### PR TITLE
[editor] Prompt Name Component

### DIFF
--- a/python/src/aiconfig/editor/client/src/Editor.tsx
+++ b/python/src/aiconfig/editor/client/src/Editor.tsx
@@ -1,7 +1,6 @@
 import EditorContainer, {
   AIConfigCallbacks,
 } from "./components/EditorContainer";
-import { ClientAIConfig } from "./shared/types";
 import { Flex, Loader, MantineProvider } from "@mantine/core";
 import { AIConfig, Prompt } from "aiconfig";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -9,7 +8,7 @@ import { ufetch } from "ufetch";
 import { ROUTE_TABLE } from "./utils/api";
 
 export default function Editor() {
-  const [aiconfig, setAiConfig] = useState<ClientAIConfig | undefined>();
+  const [aiconfig, setAiConfig] = useState<AIConfig | undefined>();
 
   const loadConfig = useCallback(async () => {
     const res = await ufetch.post(ROUTE_TABLE.LOAD, {});

--- a/python/src/aiconfig/editor/client/src/Editor.tsx
+++ b/python/src/aiconfig/editor/client/src/Editor.tsx
@@ -57,12 +57,23 @@ export default function Editor() {
     });
   }, []);
 
+  const updatePrompt = useCallback(
+    async (promptName: string, promptData: Prompt) => {
+      return await ufetch.post(ROUTE_TABLE.UPDATE_PROMPT, {
+        prompt_name: promptName,
+        prompt_data: promptData,
+      });
+    },
+    []
+  );
+
   const callbacks: AIConfigCallbacks = useMemo(
     () => ({
       addPrompt,
       getModels,
       runPrompt,
       save,
+      updatePrompt,
     }),
     [save, getModels, addPrompt, runPrompt]
   );

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -4,13 +4,18 @@ import { showNotification } from "@mantine/notifications";
 import { AIConfig, Prompt, PromptInput } from "aiconfig";
 import { useCallback, useMemo, useReducer, useRef, useState } from "react";
 import aiconfigReducer, { AIConfigReducerAction } from "./aiconfigReducer";
-import { ClientAIConfig, clientConfigToAIConfig } from "../shared/types";
+import {
+  ClientPrompt,
+  aiConfigToClientConfig,
+  clientConfigToAIConfig,
+  clientPromptToAIConfigPrompt,
+} from "../shared/types";
 import AddPromptButton from "./prompt/AddPromptButton";
 import { getDefaultNewPromptName } from "../utils/aiconfigStateUtils";
-import { debounce } from "lodash";
+import { debounce, uniqueId } from "lodash";
 
 type Props = {
-  aiconfig: ClientAIConfig;
+  aiconfig: AIConfig;
   callbacks: AIConfigCallbacks;
 };
 
@@ -66,7 +71,7 @@ export default function EditorContainer({
   const [isSaving, setIsSaving] = useState(false);
   const [aiconfigState, dispatch] = useReducer(
     aiconfigReducer,
-    initialAIConfig
+    aiConfigToClientConfig(initialAIConfig)
   );
 
   const stateRef = useRef(aiconfigState);
@@ -108,7 +113,9 @@ export default function EditorContainer({
       dispatch(action);
 
       try {
-        const prompt = aiconfigState.prompts[promptIndex];
+        const prompt = clientPromptToAIConfigPrompt(
+          aiconfigState.prompts[promptIndex]
+        );
         const serverConfigRes = await debouncedUpdatePrompt(prompt.name, {
           ...prompt,
           input: newPromptInput,
@@ -128,6 +135,19 @@ export default function EditorContainer({
       }
     },
     [dispatch, debouncedUpdatePrompt]
+  );
+
+  const onChangePromptName = useCallback(
+    async (promptIndex: number, newName: string) => {
+      const action: AIConfigReducerAction = {
+        type: "UPDATE_PROMPT_NAME",
+        index: promptIndex,
+        name: newName,
+      };
+
+      dispatch(action);
+    },
+    [dispatch]
   );
 
   const onUpdatePromptModelSettings = useCallback(
@@ -156,7 +176,10 @@ export default function EditorContainer({
 
   const onAddPrompt = useCallback(
     async (promptIndex: number, model: string) => {
-      const promptName = getDefaultNewPromptName(stateRef.current as AIConfig);
+      const promptName = getDefaultNewPromptName(
+        stateRef.current as unknown as AIConfig
+      );
+
       const newPrompt: Prompt = {
         name: promptName,
         input: "", // TODO: Can we use schema to get input structure, string vs object?
@@ -168,7 +191,12 @@ export default function EditorContainer({
       const action: AIConfigReducerAction = {
         type: "ADD_PROMPT_AT_INDEX",
         index: promptIndex,
-        prompt: newPrompt,
+        prompt: {
+          ...newPrompt,
+          _ui: {
+            id: uniqueId(),
+          },
+        },
       };
 
       dispatch(action);
@@ -228,13 +256,14 @@ export default function EditorContainer({
         </Group>
       </Container>
       <Container maw="80rem" className={classes.promptsContainer}>
-        {aiconfigState.prompts.map((prompt: any, i: number) => {
+        {aiconfigState.prompts.map((prompt: ClientPrompt, i: number) => {
           return (
-            <Stack key={prompt.name}>
+            <Stack key={prompt._ui.id}>
               <PromptContainer
                 index={i}
                 prompt={prompt}
                 onChangePromptInput={onChangePromptInput}
+                onChangePromptName={onChangePromptName}
                 onRunPrompt={onRunPrompt}
                 onUpdateModelSettings={onUpdatePromptModelSettings}
                 onUpdateParameters={onUpdatePromptParameters}

--- a/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
@@ -11,14 +11,7 @@ import {
 import { IconTrash, IconPlus } from "@tabler/icons-react";
 import { debounce, uniqueId } from "lodash";
 import { useState, useCallback, memo, useMemo } from "react";
-
-interface JSONArray extends Array<JSONValue> {}
-
-interface JSONObject {
-  [x: string]: JSONValue;
-}
-
-type JSONValue = string | number | boolean | JSONObject | JSONArray | unknown;
+import { JSONValue, JSONObject } from "aiconfig";
 
 type Parameter = { parameterName: string; parameterValue: JSONValue };
 

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -88,7 +88,8 @@ function reduceConsolidateAIConfig(
   responseConfig: AIConfig
 ): ClientAIConfig {
   switch (action.type) {
-    case "ADD_PROMPT_AT_INDEX": {
+    case "ADD_PROMPT_AT_INDEX":
+    case "UPDATE_PROMPT_INPUT": {
       // Make sure prompt structure is properly updated. Client input and metadata takes precedence
       // since it may have been updated by the user while the request was in flight
       return reduceReplacePrompt(state, action.index, (prompt) => {

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -9,6 +9,7 @@ export type AIConfigReducerAction =
 export type MutateAIConfigAction =
   | AddPromptAction
   | UpdatePromptInputAction
+  | UpdatePromptNameAction
   | UpdatePromptModelSettingsAction
   | UpdatePromptParametersAction;
 
@@ -21,13 +22,19 @@ export type ConsolidateAIConfigAction = {
 export type AddPromptAction = {
   type: "ADD_PROMPT_AT_INDEX";
   index: number;
-  prompt: Prompt;
+  prompt: ClientPrompt;
 };
 
 export type UpdatePromptInputAction = {
   type: "UPDATE_PROMPT_INPUT";
   index: number;
   input: PromptInput;
+};
+
+export type UpdatePromptNameAction = {
+  type: "UPDATE_PROMPT_NAME";
+  index: number;
+  name: string;
 };
 
 export type UpdatePromptModelSettingsAction = {
@@ -116,14 +123,16 @@ export default function aiconfigReducer(
 ): ClientAIConfig {
   switch (action.type) {
     case "ADD_PROMPT_AT_INDEX": {
-      return reduceInsertPromptAtIndex(
-        state,
-        action.index,
-        action.prompt as ClientPrompt
-      );
+      return reduceInsertPromptAtIndex(state, action.index, action.prompt);
     }
     case "UPDATE_PROMPT_INPUT": {
       return reduceReplaceInput(state, action.index, () => action.input);
+    }
+    case "UPDATE_PROMPT_NAME": {
+      return reduceReplacePrompt(state, action.index, (prompt) => ({
+        ...prompt,
+        name: action.name,
+      }));
     }
     case "UPDATE_PROMPT_MODEL_SETTINGS": {
       return reduceReplacePrompt(state, action.index, (prompt) => ({
@@ -135,7 +144,7 @@ export default function aiconfigReducer(
             // should properly type metadata
             name: getPromptModelName(
               prompt,
-              (state as AIConfig).metadata.default_model
+              (state as unknown as AIConfig).metadata.default_model
             ),
             settings: action.modelSettings,
           },

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
@@ -8,6 +8,7 @@ import { PromptInput as AIConfigPromptInput } from "aiconfig";
 import { memo, useCallback } from "react";
 import { ParametersArray } from "../ParametersRenderer";
 import PromptOutputBar from "./PromptOutputBar";
+import PromptName from "./PromptName";
 
 type Props = {
   index: number;
@@ -16,6 +17,7 @@ type Props = {
     promptIndex: number,
     newPromptInput: AIConfigPromptInput
   ) => void;
+  onChangePromptName: (promptIndex: number, newName: string) => void;
   onRunPrompt(promptIndex: number): Promise<void>;
   onUpdateModelSettings: (promptIndex: number, newModelSettings: any) => void;
   onUpdateParameters: (promptIndex: number, newParameters: any) => void;
@@ -41,6 +43,7 @@ export default memo(function PromptContainer({
   prompt,
   index,
   onChangePromptInput,
+  onChangePromptName,
   defaultConfigModelName,
   onRunPrompt,
   onUpdateModelSettings,
@@ -49,6 +52,11 @@ export default memo(function PromptContainer({
   const onChangeInput = useCallback(
     (newInput: AIConfigPromptInput) => onChangePromptInput(index, newInput),
     [index, onChangePromptInput]
+  );
+
+  const onChangeName = useCallback(
+    (newName: string) => onChangePromptName(index, newName),
+    [index, onChangePromptName]
   );
 
   const updateModelSettings = useCallback(
@@ -92,8 +100,8 @@ export default memo(function PromptContainer({
     <Flex justify="space-between" mt="md">
       <Card withBorder className={classes.promptInputCard}>
         <Flex direction="column">
-          <Flex justify="space-between">
-            <Text weight="bold">{`{{${prompt.name}}}}`}</Text>
+          <Flex justify="space-between" mb="0.5em">
+            <PromptName name={prompt.name} onUpdate={onChangeName} />
             <Text>{getPromptModelName(prompt, defaultConfigModelName)}</Text>
           </Flex>
           <PromptInputRenderer

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptName.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptName.tsx
@@ -1,0 +1,17 @@
+import { TextInput } from "@mantine/core";
+import { memo } from "react";
+
+type Props = {
+  name: string;
+  onUpdate: (name: string) => void;
+};
+
+export default memo(function PromptName({ name, onUpdate }: Props) {
+  return (
+    <TextInput
+      value={name}
+      placeholder="Name this prompt"
+      onChange={(e) => onUpdate(e.currentTarget.value)}
+    />
+  );
+});

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_outputs/PromptOutputsRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_outputs/PromptOutputsRenderer.tsx
@@ -1,10 +1,8 @@
-import { Error } from "aiconfig";
-import { ClientExecuteResult, ClientPromptOutput } from "../../../shared/types";
+import { Error, ExecuteResult, Output } from "aiconfig";
 import { memo } from "react";
-import { TextRenderer } from "../TextRenderer";
 
 type Props = {
-  outputs: ClientPromptOutput[];
+  outputs: Output[];
 };
 
 const ErrorOutput = memo(function ErrorOutput({ output }: { output: Error }) {
@@ -14,7 +12,7 @@ const ErrorOutput = memo(function ErrorOutput({ output }: { output: Error }) {
 const ExecuteResultOutput = memo(function ExecuteResultOutput({
   output,
 }: {
-  output: ClientExecuteResult;
+  output: ExecuteResult;
 }) {
   return null;
   // switch (output.renderData.type) {
@@ -24,11 +22,7 @@ const ExecuteResultOutput = memo(function ExecuteResultOutput({
   // }
 });
 
-const Output = memo(function Output({
-  output,
-}: {
-  output: ClientPromptOutput;
-}) {
+const OutputRenderer = memo(function Output({ output }: { output: Output }) {
   switch (output.output_type) {
     case "execute_result":
       return <ExecuteResultOutput output={output} />;
@@ -38,5 +32,5 @@ const Output = memo(function Output({
 });
 
 export default memo(function PromptOutputsRenderer({ outputs }: Props) {
-  return outputs.map((output, i) => <Output key={i} output={output} />);
+  return outputs.map((output, i) => <OutputRenderer key={i} output={output} />);
 });

--- a/python/src/aiconfig/editor/client/src/shared/types.ts
+++ b/python/src/aiconfig/editor/client/src/shared/types.ts
@@ -1,4 +1,5 @@
-import { AIConfig, Prompt, Error, ExecuteResult } from "aiconfig";
+import { AIConfig, Prompt } from "aiconfig";
+import { uniqueId } from "lodash";
 
 export type EditorFile = {
   name: string;
@@ -8,36 +9,42 @@ export type EditorFile = {
   disabled?: boolean;
 };
 
-export type TextExecuteResultOutput = {
-  type: "text";
-  text: string;
-};
-
-export type ClientExecuteResultOutput = TextExecuteResultOutput; // TODO: Add non-text types
-
-export type ClientExecuteResult = ExecuteResult & {
-  renderData: ClientExecuteResultOutput;
-};
-
-export type ClientPromptOutput = ClientExecuteResult | Error;
-
-export type ClientPrompt = Omit<Prompt, "outputs"> & {
-  outputs?: ClientPromptOutput[];
+export type ClientPrompt = Prompt & {
+  _ui: {
+    id: string;
+  };
 };
 
 export type ClientAIConfig = Omit<AIConfig, "prompts"> & {
   prompts: ClientPrompt[];
 };
 
-export function clientConfigToAIConfig(config: ClientAIConfig): AIConfig {
+export function clientPromptToAIConfigPrompt(prompt: ClientPrompt): Prompt {
+  const configPrompt = {
+    ...prompt,
+    _ui: undefined,
+  };
+  delete configPrompt._ui;
+  return configPrompt;
+}
+
+export function clientConfigToAIConfig(clientConfig: ClientAIConfig): AIConfig {
+  // For some reason, TS thinks ClientAIConfig is missing properties from
+  // AIConfig, so we have to cast it
   return {
-    ...config,
-    prompts: config.prompts.map((prompt) => ({
+    ...clientConfig,
+    prompts: clientConfig.prompts.map(clientPromptToAIConfigPrompt),
+  } as unknown as AIConfig;
+}
+
+export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
+  return {
+    ...aiconfig,
+    prompts: aiconfig.prompts.map((prompt) => ({
       ...prompt,
-      outputs: prompt.outputs?.map((output) => ({
-        ...output,
-        client: undefined,
-      })),
+      _ui: {
+        id: uniqueId(),
+      },
     })),
-  } as AIConfig;
+  };
 }

--- a/python/src/aiconfig/editor/client/src/utils/aiconfigStateUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/aiconfigStateUtils.ts
@@ -8,7 +8,3 @@ export function getDefaultNewPromptName(aiconfig: AIConfig): string {
   }
   return `prompt_${i}`;
 }
-
-export function getPromptName(aiconfig: AIConfig, promptIndex: number): string {
-  return aiconfig.prompts[promptIndex]!.name;
-}

--- a/python/src/aiconfig/editor/client/src/utils/api.ts
+++ b/python/src/aiconfig/editor/client/src/utils/api.ts
@@ -14,4 +14,5 @@ export const ROUTE_TABLE = {
   LOAD: urlJoin(API_ENDPOINT, "/load"),
   LIST_MODELS: urlJoin(API_ENDPOINT, "/list_models"),
   RUN_PROMPT: urlJoin(API_ENDPOINT, "/run"),
+  UPDATE_PROMPT: urlJoin(API_ENDPOINT, "/update_prompt"),
 };


### PR DESCRIPTION
[editor] Prompt Name Component

# [editor] Prompt Name Component

Implement the Prompt Name component, which is currently just updating state -- need endpoint to be implemented server side before we can call it.

As part of this change, I've update the `ClientAIConfig` type to remove the `renderData` and custom output typing (in preparation for updated AIConfig output types). We still need `ClientAIConfig` and `ClientPrompt` type since our client state needs to have some custom properties. In this case, we need unique ids associated with each prompt so that we can properly render them in a list. Using name would cause the entire prompt container to fully remount every time the name input changes (and that also loses focus on the input). I've updated to use an `_ui` key on prompt for this and using helper methods for converting to/from AIConfig and ClientAIConfig (similarly for Prompt/ClientPrompt) at the boundaries.

## Testing:
- Change prompt name
- Change prompt input
- Add new prompt & change input
- Save and see the proper request is sent without _ui fields

Note: Save failing since not supplying path, will need to follow up on that


https://github.com/lastmile-ai/aiconfig/assets/5060851/f80272a5-6d74-4be2-b4cd-c5453a934c11

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/644).
* #647
* __->__ #644
* #643
* #642