### PR TITLE
[easy] Reference local version of aiconfig package for local editor

### DIFF
--- a/python/src/aiconfig/editor/client/package.json
+++ b/python/src/aiconfig/editor/client/package.json
@@ -33,7 +33,7 @@
     "@mantine/notifications": "^6.0.7",
     "@mantine/prism": "^6.0.7",
     "@tabler/icons-react": "^2.44.0",
-    "aiconfig": "^1.1.0",
+    "aiconfig": "../../../../../typescript",
     "lodash": "^4.17.21",
     "node-fetch": "^3.3.2",
     "react": "^18",

--- a/python/src/aiconfig/editor/client/src/components/prompt/model_settings/ModelSettingsConfigRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/model_settings/ModelSettingsConfigRenderer.tsx
@@ -1,4 +1,4 @@
-import { JSONObject } from "aiconfig/dist/common";
+import { JSONObject } from "aiconfig";
 import { memo } from "react";
 
 type Props = {

--- a/python/src/aiconfig/editor/client/src/components/prompt/model_settings/ModelSettingsSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/model_settings/ModelSettingsSchemaRenderer.tsx
@@ -1,6 +1,6 @@
 import SettingsPropertyRenderer from "../../SettingsPropertyRenderer";
 import { GenericPropertiesSchema } from "../../../utils/promptUtils";
-import { JSONObject } from "aiconfig/dist/common";
+import { JSONObject } from "aiconfig";
 import { memo, useCallback, useMemo } from "react";
 import { debounce } from "lodash";
 

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputDataSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputDataSchemaRenderer.tsx
@@ -1,6 +1,6 @@
 import { PromptInputObjectDataSchema } from "../../../../utils/promptUtils";
 import { Textarea } from "@mantine/core";
-import { JSONValue } from "aiconfig/dist/common";
+import { JSONValue } from "aiconfig";
 import { memo } from "react";
 
 type Props = {

--- a/python/src/aiconfig/editor/client/yarn.lock
+++ b/python/src/aiconfig/editor/client/yarn.lock
@@ -3054,10 +3054,8 @@ agentkeepalive@^4.2.1:
   dependencies:
     humanize-ms "^1.2.1"
 
-aiconfig@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/aiconfig/-/aiconfig-1.1.1.tgz#e4a13b0891140e487cdfe50da3652345e671789a"
-  integrity sha512-rkmzOKfas6n5rCnRf2++rgLkzm+8cJovNgtZIuJ9trnzmwUyZx+LRHzzEiSQbaQmhU5HjCcrLx6CuTdIXAM4SQ==
+aiconfig@../../../../../typescript:
+  version "1.1.2"
   dependencies:
     "@google-ai/generativelanguage" "^1.1.0"
     "@huggingface/inference" "^2.6.4"
@@ -3065,7 +3063,9 @@ aiconfig@^1.1.0:
     google-auth-library "^9.1.0"
     gpt-3-encoder "^1.1.4"
     handlebars "^4.7.8"
+    js-yaml "^4.1.0"
     lodash "^4.17.21"
+    node-fetch "^3.3.2"
     openai "4.11.1"
     typescript-json-schema "^0.60.0"
     uuid "^9.0.1"


### PR DESCRIPTION
[easy] Reference local version of aiconfig package for local editor

While we iterate on the aiconfig schema and SDK, it's better to reference the latest code for the local editor (typescript side) to ensure we are in sync on the schema updates coming in.

It also means we don't need to publish to npm/pypi until we have let the changes bake.
