### PR TITLE
[ez] Remove fixed TODO comments in HF text_generation local inference model parser

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_generation.py
@@ -250,11 +250,6 @@ class HuggingFaceTextGenerationTransformer(ParameterizedModelParser):
             not "stream" in completion_data or completion_data.get("stream") != False
         )
         if should_stream:
-            # TODO (rossdanlm): I noticed that some models are incohorent when used as a tokenizer for streaming
-            # mistralai/Mistral-7B-v0.1 is able to generate text no problem, but doesn't make sense when it tries to tokenize
-            # in these cases, I would use `gpt2`. I'm wondering if there's a heuristic 
-            # we can use to determine if a model is applicable for being used as a tokenizer
-            # For now I can just default the line below to gpt2? Maybe we can also define it somehow in the aiconfig?
             tokenizer : AutoTokenizer = AutoTokenizer.from_pretrained(model_name)
             streamer = TextIteratorStreamer(tokenizer)
             completion_data["streamer"] = streamer


### PR DESCRIPTION
[ez] Remove fixed TODO comments in HF text_generation local inference model parser

This was fixed in https://github.com/lastmile-ai/aiconfig/pull/410, but forgot to remove the TODO, doing it in this diff
