### PR TITLE
[editor][server endpoints][3/n]: Proof-of-Concept for Streaming

### DIFF
--- a/python/src/aiconfig/editor/client/package.json
+++ b/python/src/aiconfig/editor/client/package.json
@@ -36,6 +36,7 @@
     "aiconfig": "../../../../../typescript",
     "lodash": "^4.17.21",
     "node-fetch": "^3.3.2",
+    "oboe": "^2.1.5",
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^8.0.6",
@@ -47,6 +48,7 @@
   "devDependencies": {
     "@types/lodash": "^4.14.202",
     "@types/node": "^20",
+    "@types/oboe": "^2.1.4",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8",

--- a/python/src/aiconfig/editor/client/src/Editor.tsx
+++ b/python/src/aiconfig/editor/client/src/Editor.tsx
@@ -52,9 +52,11 @@ export default function Editor() {
   );
 
   const runPrompt = useCallback(async (promptName: string) => {
-    return await ufetch.post(ROUTE_TABLE.RUN_PROMPT, {
+    const res = await ufetch.post("http://localhost:8080/api/test_streaming", {
       prompt_name: promptName,
     });
+    console.log("stream res: ", res);
+    return res;
   }, []);
 
   const callbacks: AIConfigCallbacks = useMemo(

--- a/python/src/aiconfig/editor/client/yarn.lock
+++ b/python/src/aiconfig/editor/client/yarn.lock
@@ -2525,6 +2525,13 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/oboe@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/oboe/-/oboe-2.1.4.tgz#d92c4636d0b7737803e4361e10e8dad488f39634"
+  integrity sha512-bXt4BXSQy0N/buSIak1o0TjYAk2SAeK1aZV9xKcb+xVGWYP8NcMOFy2T7Um3kIvEcQJzrdgJ8R6fpbRcp/LEww==
+  dependencies:
+    "@types/node" "*"
+
 "@types/parse-json@^4.0.0":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
@@ -5983,6 +5990,11 @@ http-errors@~1.6.2:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
+http-https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/http-https/-/http-https-1.0.0.tgz#2f908dd5f1db4068c058cd6e6d4ce392c913389b"
+  integrity sha512-o0PWwVCSp3O0wS6FvNr6xfBCHgt0m1tvPLFOCc2iFDKTRAXhB7m8klDf7ErowFH8POa6dVdGatKU5I1YYwzUyg==
+
 http-parser-js@>=0.5.1:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.8.tgz#af23090d9ac4e24573de6f6aecc9d84a48bf20e3"
@@ -8416,6 +8428,13 @@ object.values@^1.1.0, object.values@^1.1.6, object.values@^1.1.7:
     call-bind "^1.0.2"
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
+
+oboe@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/oboe/-/oboe-2.1.5.tgz#5554284c543a2266d7a38f17e073821fbde393cd"
+  integrity sha512-zRFWiF+FoicxEs3jNI/WYUrVEgA7DeET/InK0XQuudGHRg8iIob3cNPrJTKaz4004uaA9Pbe+Dwa8iluhjLZWA==
+  dependencies:
+    http-https "^1.0.0"
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"

--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -3,6 +3,7 @@ from typing import Any, Type, TypeVar
 
 import lastmile_utils.lib.core.api as core_utils
 import result
+import time
 from aiconfig.Config import AIConfigRuntime
 from aiconfig.editor.server.server_utils import (
     EditServerConfig,
@@ -24,8 +25,9 @@ from aiconfig.editor.server.server_utils import (
     safe_run_aiconfig_static_method,
 )
 from aiconfig.model_parser import InferenceOptions
-from flask import Flask, request
-from flask_cors import CORS
+from aiconfig.schema import ExecuteResult, Prompt
+from flask import Flask, Response, request, stream_with_context
+from flask_cors import CORS  # TODO: add this to requirements.txt
 from result import Err, Ok, Result
 
 from aiconfig.registry import ModelParserRegistry
@@ -155,6 +157,65 @@ def create() -> FlaskResponse:
             return HttpResponseWithAIConfig(message="Created new AIConfig", aiconfig=aiconfig_ok).to_flask_format()
         case Err(e):
             return HttpResponseWithAIConfig(message=f"Failed to create AIConfig: {e}", code=400, aiconfig=None).to_flask_format()
+
+
+@app.route("/api/test_streaming", methods=["POST"])
+def test_streaming():
+    EXCLUDE_OPTIONS = {
+        "prompt_index": True,
+        "file_path": True,
+        "callback_manager": True,
+    }
+    state = get_server_state(app)
+    request_json = request.get_json()
+    num_stream_steps: int = request_json.get("num_stream_steps", 10)
+    prompt_name: str = request_json.get("prompt_name", "get_activities")
+    print(f"{num_stream_steps=}")
+    print(f"{type(num_stream_steps)=}")
+
+    def generate(num_stream_steps: int):
+        prompt: Prompt = state.aiconfig.get_prompt(prompt_name)
+        for i in range(num_stream_steps):
+            time.sleep(1)
+            output = ExecuteResult(
+                output_type="execute_result",
+                execution_count=0,
+                data="Rossdan" + str(i + 1),
+                metadata={},
+            )
+            prompt.outputs = [output]
+            print(f"Done step {i+1}/{num_stream_steps}...")
+
+            aiconfig_json = state.aiconfig.model_dump(exclude=EXCLUDE_OPTIONS)
+            # print(f"{aiconfig_json=}\n")
+            # yield_output = core_utils.JSONObject({"data": aiconfig_json})
+            # print(f"{yield_output=}")
+            print(f"{str(aiconfig_json)=}\n")
+            yield str(aiconfig_json) + "\n\n"
+            # yield aiconfig_json
+
+            # HttpResponseWithAIConfig(
+            #     message=f"Done step {i+1}/{num_stream_steps}...",
+            #     aiconfig=state.aiconfig,
+            # ).to_flask_format()
+
+    try:
+        LOGGER.info(f"Testing streaming: {request_json}")
+        # Stream based on https://stackoverflow.com/questions/73275517/flask-not-streaming-json-response
+        return Response(
+            stream_with_context(generate(num_stream_steps)),
+            status=200,
+            content_type="application/json",
+        )
+        # return generate(num_stream_steps) #, {"Content-Type": "application/json"}
+    except Exception as e:
+        err: Err[str] = core_utils.ErrWithTraceback(e)
+        LOGGER.error(f"Failed to test streaming: {err}")
+        return HttpResponseWithAIConfig(
+            message=f"Failed to test streaming: {err}",
+            code=400,
+            aiconfig=None,
+        ).to_flask_format()
 
 
 @app.route("/api/run", methods=["POST"])


### PR DESCRIPTION
[editor][server endpoints][3/n]: Proof-of-Concept for Streaming

The actual call in the `run` command will be a bit more complex since we'll have to attach a stream callback and probably create a text queue iterator like what we did for Gradio, but this shows that it's possible and shouldn't be too complicated.

Sorry Jonathan, I didn't use any of your super useful generic functions, but we can do that later.

A big thing I wanted to point out is that in the `yield` generator, I need explicitly return a string (not a json object), otherwise this will not work, so the frontend needs to be able to parse that result somehow. We should sync on this but I feel jsons are strings anyways and as long as we follow the same output "formula" (ex: in the `list_models` we out `data` key vs other commands we directly return the AIConfig json), it should be fine.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/650).
* #651
* __->__ #650