### PR TITLE
Remove declaration of generic T from server.py

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Type, TypeVar
+from typing import Any, Type
 
 import lastmile_utils.lib.core.api as core_utils
 import result
@@ -24,11 +24,11 @@ from aiconfig.editor.server.server_utils import (
     safe_run_aiconfig_static_method,
 )
 from aiconfig.model_parser import InferenceOptions
+from aiconfig.registry import ModelParserRegistry
 from flask import Flask, request
 from flask_cors import CORS
 from result import Err, Ok, Result
 
-from aiconfig.registry import ModelParserRegistry
 from aiconfig.schema import Prompt
 
 logging.getLogger("werkzeug").disabled = True
@@ -41,8 +41,6 @@ formatter = logging.Formatter(core_utils.LOGGER_FMT)
 log_handler.setFormatter(formatter)
 
 LOGGER.addHandler(log_handler)
-
-T = TypeVar("T")
 
 
 app = Flask(__name__, static_url_path="")

--- a/python/src/aiconfig/editor/server/server_utils.py
+++ b/python/src/aiconfig/editor/server/server_utils.py
@@ -3,11 +3,11 @@ import importlib.util
 import logging
 import os
 import sys
+import typing
 from dataclasses import dataclass
 from enum import Enum
 from types import ModuleType
 from typing import Any, Callable, NewType, Optional, Type, TypeVar, cast
-import typing
 
 import lastmile_utils.lib.core.api as core_utils
 import result


### PR DESCRIPTION
Remove declaration of generic T from server.py


Not being used, let's get rid of it dawg!

I also ran the linter based on Jonathan's command from this comment: https://github.com/lastmile-ai/aiconfig/pull/613#discussion_r1437724642

```
fd --glob '*.py'  python/src/aiconfig/editor/server | xargs python -m 'scripts.lint' --mode=fix --files
```

^ (btw you can install fd on Mac using `brew install fd`, looks pretty cool). It actually seems pretty cool https://github.com/sharkdp/fd?tab=readme-ov-file
