### PR TITLE
rawResponse -> raw_response for snake_case consistency

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
@@ -109,7 +109,7 @@ def construct_stream_output(
 
 
 def construct_regular_output(response: TextGenerationResponse, response_includes_details: bool) -> Output:
-    metadata = {"rawResponse": response}
+    metadata = {"raw_response": response}
     if response_includes_details:
         metadata["details"] = response.details
 
@@ -209,15 +209,13 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         prompt = Prompt(
             name=prompt_name,
             input=prompt_input,
-            metadata=PromptMetadata(
-                model=model_metadata, parameters=parameters, **kwargs
-            ),
+            metadata=PromptMetadata(model=model_metadata, parameters=parameters, **kwargs),
         )
 
         prompts.append(prompt)
-        
-        await ai_config.callback_manager.run_callbacks(CallbackEvent("on_serialize_complete", __name__, {"result": prompts }))
-        
+
+        await ai_config.callback_manager.run_callbacks(CallbackEvent("on_serialize_complete", __name__, {"result": prompts}))
+
         return prompts
 
     async def deserialize(
@@ -251,9 +249,7 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
 
         return completion_data
 
-    async def run_inference(
-        self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: dict[Any, Any]
-    ) -> List[Output]:
+    async def run_inference(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: dict[Any, Any]) -> List[Output]:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform
         the actual model inference based on the provided prompt and inference settings.

--- a/extensions/HuggingFace/typescript/hf.ts
+++ b/extensions/HuggingFace/typescript/hf.ts
@@ -311,7 +311,7 @@ function constructOutput(response: TextGenerationOutput): Output {
     output_type: "execute_result",
     data: response.generated_text,
     execution_count: 0,
-    metadata: { rawResponse: response },
+    metadata: { raw_response: response },
   } as ExecuteResult;
 
   return output;

--- a/python/src/aiconfig/default_parsers/hf.py
+++ b/python/src/aiconfig/default_parsers/hf.py
@@ -109,14 +109,14 @@ def construct_stream_output(
 
 
 def construct_regular_output(response: TextGenerationResponse, response_includes_details: bool) -> Output:
-    metadata = {"rawResponse": response}
+    metadata = {"raw_response": response}
     if response_includes_details:
         metadata["details"] = response.details
 
     output = ExecuteResult(
         **{
             "output_type": "execute_result",
-            "data": response.generated_text or '',
+            "data": response.generated_text or "",
             "execution_count": 0,
             "metadata": metadata,
         }
@@ -209,15 +209,13 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         prompt = Prompt(
             name=prompt_name,
             input=prompt_input,
-            metadata=PromptMetadata(
-                model=model_metadata, parameters=parameters, **kwargs
-            ),
+            metadata=PromptMetadata(model=model_metadata, parameters=parameters, **kwargs),
         )
 
         prompts.append(prompt)
-        
-        await ai_config.callback_manager.run_callbacks(CallbackEvent("on_serialize_complete", __name__, {"result": prompts }))
-        
+
+        await ai_config.callback_manager.run_callbacks(CallbackEvent("on_serialize_complete", __name__, {"result": prompts}))
+
         return prompts
 
     async def deserialize(
@@ -251,9 +249,7 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
 
         return completion_data
 
-    async def run_inference(
-        self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: dict[Any, Any]
-    ) -> List[Output]:
+    async def run_inference(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: dict[Any, Any]) -> List[Output]:
         """
         Invoked to run a prompt in the .aiconfig. This method should perform
         the actual model inference based on the provided prompt and inference settings.

--- a/python/tests/parsers/test_openai_util.py
+++ b/python/tests/parsers/test_openai_util.py
@@ -23,9 +23,7 @@ def test_refine_chat_completion_params():
         "system_prompt": "system_prompt",
         "random_attribute": "value_doesn't_matter",
     }
-    refined_params = refine_chat_completion_params(
-        model_settings_with_stream_and_system_prompt
-    )
+    refined_params = refine_chat_completion_params(model_settings_with_stream_and_system_prompt)
 
     assert "system_prompt" not in refined_params
     assert "stream" in refined_params
@@ -35,13 +33,9 @@ def test_refine_chat_completion_params():
 
 @pytest.mark.asyncio
 async def test_get_output_text(set_temporary_env_vars):
-    with patch.object(
-        openai.chat.completions, "create", side_effect=mock_openai_chat_completion
-    ):
+    with patch.object(openai.chat.completions, "create", side_effect=mock_openai_chat_completion):
         config_relative_path = "../aiconfigs/basic_chatgpt_query_config.json"
-        config_absolute_path = get_absolute_file_path_from_relative(
-            __file__, config_relative_path
-        )
+        config_absolute_path = get_absolute_file_path_from_relative(__file__, config_relative_path)
         aiconfig = AIConfigRuntime.load(config_absolute_path)
 
         await aiconfig.run("prompt1", {})
@@ -56,9 +50,7 @@ async def test_get_output_text(set_temporary_env_vars):
 
 @pytest.mark.asyncio
 async def test_serialize(set_temporary_env_vars):
-    with patch.object(
-        openai.chat.completions, "create", side_effect=mock_openai_chat_completion
-    ):
+    with patch.object(openai.chat.completions, "create", side_effect=mock_openai_chat_completion):
         # Test with one input prompt and system. No output
         completion_params = {
             "model": "gpt-3.5-turbo",
@@ -71,9 +63,7 @@ async def test_serialize(set_temporary_env_vars):
         }
 
         aiconfig = AIConfigRuntime.create()
-        serialized_prompts = await aiconfig.serialize(
-            "gpt-3.5-turbo", completion_params, prompt_name="the prompt"
-        )
+        serialized_prompts = await aiconfig.serialize("gpt-3.5-turbo", completion_params, prompt_name="the prompt")
         new_prompt = serialized_prompts[0]
 
         # assert prompt serialized correctly into config
@@ -112,9 +102,7 @@ async def test_serialize(set_temporary_env_vars):
             ],
         }
 
-        serialized_prompts = await aiconfig.serialize(
-            "gpt-3.5-turbo", completion_params, "prompt"
-        )
+        serialized_prompts = await aiconfig.serialize("gpt-3.5-turbo", completion_params, "prompt")
         new_prompt = serialized_prompts[0]
 
         expected_prompt = Prompt(
@@ -141,13 +129,10 @@ async def test_serialize(set_temporary_env_vars):
                 ExecuteResult(
                     output_type="execute_result",
                     execution_count=None,
-                    data='Hello! How can I assist you today?',
+                    data="Hello! How can I assist you today?",
                     metadata={
-                        'rawResponse': {
-                            'role': 'assistant',
-                            'content': 'Hello! How can I assist you today?'
-                        },
-                        'role': 'assistant',
+                        "raw_response": {"role": "assistant", "content": "Hello! How can I assist you today?"},
+                        "role": "assistant",
                     },
                     mime_type=None,
                 )
@@ -158,7 +143,6 @@ async def test_serialize(set_temporary_env_vars):
         assert new_prompt.outputs == expected_prompt.outputs
         assert new_prompt.name == expected_prompt.name
         assert new_prompt == expected_prompt
-
 
         # Test completion params with a function call input
 
@@ -192,9 +176,7 @@ async def test_serialize(set_temporary_env_vars):
             ],
         }
 
-        serialized_prompts = await aiconfig.serialize(
-            "gpt-3.5-turbo", completion_params, "prompt"
-        )
+        serialized_prompts = await aiconfig.serialize("gpt-3.5-turbo", completion_params, "prompt")
         new_prompt = serialized_prompts[0]
         assert new_prompt == Prompt(
             name="prompt",
@@ -285,10 +267,9 @@ async def test_serialize(set_temporary_env_vars):
             ],
         }
 
-
         prompts = await aiconfig.serialize("gpt-3.5-turbo", completion_params, "prompt")
         new_prompt = prompts[1]
-        
+
         expected_prompt = Prompt(
             name="prompt",
             input=PromptInput(
@@ -339,11 +320,11 @@ async def test_serialize(set_temporary_env_vars):
                     execution_count=None,
                     data="The current weather in Boston is 22 degrees Celsius and sunny.",
                     metadata={
-                        'rawResponse': {
-                            'role': 'assistant',
-                            'content': 'The current weather in Boston is 22 degrees Celsius and sunny.',
+                        "raw_response": {
+                            "role": "assistant",
+                            "content": "The current weather in Boston is 22 degrees Celsius and sunny.",
                         },
-                        'role': 'assistant',
+                        "role": "assistant",
                     },
                     mime_type=None,
                 )

--- a/typescript/__tests__/parsers/hf/hf.test.ts
+++ b/typescript/__tests__/parsers/hf/hf.test.ts
@@ -260,7 +260,7 @@ describe("HuggingFaceTextGeneration ModelParser", () => {
       data: "Test text generation",
       execution_count: 0,
       metadata: {
-        rawResponse: {
+        raw_response: {
           generated_text: "Test text generation",
         },
       },

--- a/typescript/lib/parsers/hf.ts
+++ b/typescript/lib/parsers/hf.ts
@@ -305,7 +305,7 @@ function constructOutput(response: TextGenerationOutput): Output {
     output_type: "execute_result",
     data: response.generated_text,
     execution_count: 0,
-    metadata: { rawResponse: response },
+    metadata: { raw_response: response },
   } as ExecuteResult;
   return output;
 }

--- a/typescript/lib/parsers/openai.ts
+++ b/typescript/lib/parsers/openai.ts
@@ -183,7 +183,7 @@ export class OpenAIModelParser extends ParameterizedModelParser<CompletionCreate
           metadata: {
             finish_reason: choice.finish_reason,
             logprobs: choice.logprobs,
-            rawResponse: response,
+            raw_response: response,
           },
         };
         outputs.push(output);
@@ -402,7 +402,7 @@ export class OpenAIChatModelParser extends ParameterizedModelParser<Chat.ChatCom
                 output_type: "execute_result",
                 data: assistantOutputData,
                 metadata: {
-                  rawResponse: assistantResponse,
+                  raw_response: assistantResponse,
                   ..._.omit(assistantResponse, ["content", "function_call"]),
                 },
               },
@@ -585,7 +585,7 @@ export class OpenAIChatModelParser extends ParameterizedModelParser<Chat.ChatCom
           metadata: {
             finish_reason: choice.finish_reason,
             ...responseWithoutChoices,
-            rawResponse: choice.message,
+            raw_response: choice.message,
             ..._.omit(choice.message, ["content", "function_call"]),
           },
         };
@@ -643,7 +643,7 @@ export class OpenAIChatModelParser extends ParameterizedModelParser<Chat.ChatCom
             execution_count: choice.index,
             metadata: {
               finish_reason: choice.finish_reason,
-              rawResponse: message,
+              raw_response: message,
             },
           };
           outputs.set(choice.index, output);
@@ -742,7 +742,7 @@ export class OpenAIChatModelParser extends ParameterizedModelParser<Chat.ChatCom
       if (output.output_type === "execute_result") {
         if (
           output.metadata?.role ??
-          output.metadata?.rawResponse?.role === "assistant"
+          output.metadata?.raw_response?.role === "assistant"
         ) {
           output as ExecuteResult;
           let content: string | null = null;
@@ -764,7 +764,7 @@ export class OpenAIChatModelParser extends ParameterizedModelParser<Chat.ChatCom
           }
 
           const name: string | undefined | null =
-            output.metadata?.name ?? output.metadata?.rawResponse?.name;
+            output.metadata?.name ?? output.metadata?.raw_response?.name;
           messages.push({
             content,
             role: "assistant",

--- a/typescript/lib/parsers/palm.ts
+++ b/typescript/lib/parsers/palm.ts
@@ -247,7 +247,7 @@ function constructOutputs(
       output_type: "execute_result",
       data: candidate.output ?? "",
       execution_count: i,
-      metadata: { rawResponse: candidate },
+      metadata: { raw_response: candidate },
     };
 
     outputs.push(output);


### PR DESCRIPTION
# rawResponse -> raw_response for snake_case consistency

Just updating the `rawResponse` property name to `raw_response` for snake_case consistency in the schema. All other changes here are just auto-formatted

## Testing
`pytest`
```
=========================================================== 88 passed, 38 warnings in 3.28s ===========================================================
```

`yarn test`
```
(aiconfig) ryanholinshead@Ryans-MBP typescript % yarn test 
yarn run v1.22.19
$ jest --runInBand
 PASS  __tests__/parsers/hf/hf.test.ts
  HuggingFaceTextGeneration ModelParser
    ✓ uses HuggingFace API token from environment variable if it exists (9 ms)
    ✓ serializing params to config prompt (1 ms)
    ✓ serialize callbacks (1 ms)
    ✓ deserializing config prompt to params (1 ms)
    ✓ deserialize callbacks (1 ms)
    ✓ run prompt, non-streaming (4 ms)
    ✓ run prompt, streaming (2 ms)
    ✓ run callbacks (1 ms)

 PASS  __tests__/config.test.ts
  Loading an AIConfig
    ✓ loading a basic chatgpt query config (6 ms)
    ✓ loading a prompt chain (4 ms)
    ✓ deserialize and re-serialize a prompt chain (2 ms)
    ✓ serialize a prompt chain with different settings (1 ms)

 PASS  __tests__/parsers/palm-text/palm.test.ts
  PaLM Text ModelParser
    ✓ serializing params to config prompt (4 ms)
    ✓ deserializing params to config (2 ms)
    ✓ run prompt, non-streaming (87 ms)

 PASS  __tests__/testProgramaticallyCreateConfig.ts
  test Get Global Settings
    ✓ Retrieving global setting from AIConfig with 1 model (1 ms)
  ExtractOverrideSettings function
    ✓ Should return initial settings when no global settings are defined
    ✓ Should return an override when initial settings differ from global settings (1 ms)
    ✓ Should return empty override when global settings match initial settings
    ✓ Should return empty override when Global settings defined and initial settings are empty

 PASS  __tests__/testSave.ts
  AIConfigRuntime save()
    ✓ saves the config and checks if the config json doesn't have key filePath (4 ms)

Test Suites: 5 passed, 5 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        2.303 s
Ran all test suites.
✨  Done in 3.58s.
```

Ran `npx ts-node function-call-stream.ts` and confirmed correct output metadata with raw_response, e.g.:
```
      "outputs": [
        {
          "output_type": "execute_result",
          "data": {
            "kind": "tool_calls",
            "value": [
              {
                "type": "function",
                "function": {
                  "name": "list",
                  "arguments": "{\n\"genre\": \"historical\"\n}"
                }
              }
            ]
          },
          "execution_count": 0,
          "metadata": {
            "finish_reason": "function_call",
            "raw_response": {
              "role": "assistant",
              "content": null,
              "function_call": {
                "name": "list",
                "arguments": "{\n\"genre\": \"historical\"\n}"
              }
            }
          }
        }
      ]
```
