### PR TITLE
[AIC-py][Bug fix][editor] simplify and add missing await to run endpoint

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -167,26 +167,26 @@ async def run() -> FlaskResponse:
     aiconfig = state.aiconfig
     request_json = request.get_json()
 
-    _op = make_op_run_method(MethodName("run"))
-
-    def _get_op_args():
-        prompt_name = request_json.get("prompt_name", None)
-        stream = request_json.get("stream", True)
-        LOGGER.info(f"Running prompt: {prompt_name}, {stream=}")
-        inference_options = InferenceOptions(stream=stream)
-        return Ok(
-            OpArgs(
-                {
-                    "prompt_name": prompt_name,
-                    #
-                    "options": inference_options,
-                }
-            )
-        )
-
-    op_args = _get_op_args()
-
-    return run_aiconfig_operation_with_op_args(aiconfig, "run", _op, op_args)
+    try:
+        prompt_name = request_json["prompt_name"]
+        params = request_json.get("params", {})
+        stream = request_json.get("stream", False)
+        options = InferenceOptions(stream=stream)
+        run_output = await aiconfig.run(prompt_name, params, options)  # type: ignore
+        LOGGER.debug(f"run_output: {run_output}")
+        return HttpResponseWithAIConfig(
+            #
+            message="Ran prompt",
+            code=200,
+            aiconfig=aiconfig,
+        ).to_flask_format()
+    except Exception as e:
+        return HttpResponseWithAIConfig(
+            #
+            message=f"Failed to run prompt: {type(e)}, {e}",
+            code=400,
+            aiconfig=None,
+        ).to_flask_format()
 
 
 @app.route("/api/add_prompt", methods=["POST"])


### PR DESCRIPTION
[AIC-py][Bug fix][editor] simplify and add missing await to run endpoint

Currently we're not awaiting `run()`. This awaits the run method call.
Also, I'm taking the opportunity to simplify the code by removing some abstractions.

Later if we simplify more and end up with repetition we can refactor again
to dedup.

Test:

```
url = "http://localhost:8080/api/run"

for data in [
    {},
    {    "prompt_name": "get_activities"},
    {
        "prompt_name": "get_activities",
        "params": {
            "city": "karachi"
        }
    }
]:

    print(f"\n\n{url=}, {data=}")

    response = requests.post(url, json=data)
    print(f"\n{response=}"),

    import json
    response_json = json.loads(response.text)
    print(f"{response_json=}")
    print(f"{response_json['message']=}")
    aic = response_json.get('aiconfig', {})
    print("AIC:", aic)


url='http://localhost:8080/api/run', data={}

response=<Response [400]>
response_json={'message': "Failed to run prompt: <class 'KeyError'>, 'prompt_name'"}


url='http://localhost:8080/api/run', data={'prompt_name': 'get_activities'}


response=<Response [200]>
response_json={'aiconfig': {'$schema':...
response_json['message']='Ran prompt'

AIC: {'$schema': 'https://json.schem... '1. Visit  in . It is a unique and interactive...

url='http://localhost:8080/api/run', data={'prompt_name': 'get_activities', 'params': {'city': 'karachi'}}


response=<Response [200]>
response_json={'aiconfig': {'$schema':...
response_json['message']='Ran prompt'
"1. Clifton Beach: Locat...


```
