### PR TITLE
[editor] Use Prompt ID Instead of Index for Client-side State Actions

### DIFF
--- a/python/src/aiconfig/editor/client/src/Editor.tsx
+++ b/python/src/aiconfig/editor/client/src/Editor.tsx
@@ -50,6 +50,12 @@ export default function Editor() {
     []
   );
 
+  const deletePrompt = useCallback(async (promptName: string) => {
+    return await ufetch.post(ROUTE_TABLE.DELETE_PROMPT, {
+      prompt_name: promptName,
+    });
+  }, []);
+
   const runPrompt = useCallback(async (promptName: string) => {
     return await ufetch.post(ROUTE_TABLE.RUN_PROMPT, {
       prompt_name: promptName,
@@ -79,6 +85,7 @@ export default function Editor() {
   const callbacks: AIConfigCallbacks = useMemo(
     () => ({
       addPrompt,
+      deletePrompt,
       getModels,
       runPrompt,
       save,

--- a/python/src/aiconfig/editor/client/src/Editor.tsx
+++ b/python/src/aiconfig/editor/client/src/Editor.tsx
@@ -2,7 +2,7 @@ import EditorContainer, {
   AIConfigCallbacks,
 } from "./components/EditorContainer";
 import { Flex, Loader, MantineProvider } from "@mantine/core";
-import { AIConfig, Prompt } from "aiconfig";
+import { AIConfig, ModelMetadata, Prompt } from "aiconfig";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ufetch } from "ufetch";
 import { ROUTE_TABLE } from "./utils/api";
@@ -66,12 +66,23 @@ export default function Editor() {
     []
   );
 
+  const updateModel = useCallback(
+    async (_promptName?: string, _modelData?: string | ModelMetadata) => {
+      // return await ufetch.post(ROUTE_TABLE.UPDATE_MODEL,
+      //   prompt_name: promptName,
+      //   model_data: modelData,
+      // });
+    },
+    []
+  );
+
   const callbacks: AIConfigCallbacks = useMemo(
     () => ({
       addPrompt,
       getModels,
       runPrompt,
       save,
+      updateModel,
       updatePrompt,
     }),
     [save, getModels, addPrompt, runPrompt]

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -1,5 +1,12 @@
 import PromptContainer from "./prompt/PromptContainer";
-import { Container, Group, Button, createStyles, Stack } from "@mantine/core";
+import {
+  Container,
+  Group,
+  Button,
+  createStyles,
+  Stack,
+  Flex,
+} from "@mantine/core";
 import { showNotification } from "@mantine/notifications";
 import { AIConfig, ModelMetadata, Prompt, PromptInput } from "aiconfig";
 import { useCallback, useMemo, useReducer, useRef, useState } from "react";
@@ -11,8 +18,12 @@ import {
   clientPromptToAIConfigPrompt,
 } from "../shared/types";
 import AddPromptButton from "./prompt/AddPromptButton";
-import { getDefaultNewPromptName } from "../utils/aiconfigStateUtils";
+import {
+  getDefaultNewPromptName,
+  getPrompt,
+} from "../utils/aiconfigStateUtils";
 import { debounce, uniqueId } from "lodash";
+import PromptMenuButton from "./prompt/PromptMenuButton";
 
 type Props = {
   aiconfig: AIConfig;
@@ -25,6 +36,7 @@ export type AIConfigCallbacks = {
     prompt: Prompt,
     index: number
   ) => Promise<{ aiconfig: AIConfig }>;
+  deletePrompt: (promptName: string) => Promise<void>;
   getModels: (search: string) => Promise<string[]>;
   runPrompt: (promptName: string) => Promise<void>;
   save: (aiconfig: AIConfig) => Promise<void>;
@@ -272,6 +284,27 @@ export default function EditorContainer({
     [callbacks.addPrompt, dispatch]
   );
 
+  const onDeletePrompt = useCallback(
+    async (promptId: string) => {
+      dispatch({
+        type: "DELETE_PROMPT",
+        id: promptId,
+      });
+
+      try {
+        const prompt = getPrompt(stateRef.current, promptId)!;
+        await callbacks.deletePrompt(prompt.name);
+      } catch (err: any) {
+        showNotification({
+          title: "Error deleting prompt",
+          message: err.message,
+          color: "red",
+        });
+      }
+    },
+    [callbacks.deletePrompt, dispatch]
+  );
+
   const onRunPrompt = useCallback(
     async (promptIndex: number) => {
       const promptName = aiconfigState.prompts[promptIndex].name;
@@ -306,18 +339,24 @@ export default function EditorContainer({
         {aiconfigState.prompts.map((prompt: ClientPrompt, i: number) => {
           return (
             <Stack key={prompt._ui.id}>
-              <PromptContainer
-                index={i}
-                prompt={prompt}
-                getModels={callbacks.getModels}
-                onChangePromptInput={onChangePromptInput}
-                onChangePromptName={onChangePromptName}
-                onRunPrompt={onRunPrompt}
-                onUpdateModel={onUpdatePromptModel}
-                onUpdateModelSettings={onUpdatePromptModelSettings}
-                onUpdateParameters={onUpdatePromptParameters}
-                defaultConfigModelName={aiconfigState.metadata.default_model}
-              />
+              <Flex mt="md">
+                <PromptMenuButton
+                  promptId={prompt._ui.id}
+                  onDeletePrompt={() => onDeletePrompt(prompt._ui.id)}
+                />
+                <PromptContainer
+                  index={i}
+                  prompt={prompt}
+                  getModels={callbacks.getModels}
+                  onChangePromptInput={onChangePromptInput}
+                  onChangePromptName={onChangePromptName}
+                  onRunPrompt={onRunPrompt}
+                  onUpdateModel={onUpdatePromptModel}
+                  onUpdateModelSettings={onUpdatePromptModelSettings}
+                  onUpdateParameters={onUpdatePromptParameters}
+                  defaultConfigModelName={aiconfigState.metadata.default_model}
+                />
+              </Flex>
               <div className={classes.addPromptRow}>
                 <AddPromptButton
                   getModels={callbacks.getModels}

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -10,6 +10,7 @@ export type MutateAIConfigAction =
   | AddPromptAction
   | UpdatePromptInputAction
   | UpdatePromptNameAction
+  | UpdatePromptModelAction
   | UpdatePromptModelSettingsAction
   | UpdatePromptParametersAction;
 
@@ -35,6 +36,12 @@ export type UpdatePromptNameAction = {
   type: "UPDATE_PROMPT_NAME";
   index: number;
   name: string;
+};
+
+export type UpdatePromptModelAction = {
+  type: "UPDATE_PROMPT_MODEL";
+  index: number;
+  modelName?: string;
 };
 
 export type UpdatePromptModelSettingsAction = {
@@ -132,6 +139,20 @@ export default function aiconfigReducer(
       return reduceReplacePrompt(state, action.index, (prompt) => ({
         ...prompt,
         name: action.name,
+      }));
+    }
+    case "UPDATE_PROMPT_MODEL": {
+      return reduceReplacePrompt(state, action.index, (prompt) => ({
+        ...prompt,
+        metadata: {
+          ...prompt.metadata,
+          model: action.modelName
+            ? {
+                name: action.modelName,
+                // TODO: Consolidate settings based on schema union
+              }
+            : undefined,
+        },
       }));
     }
     case "UPDATE_PROMPT_MODEL_SETTINGS": {

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -8,6 +8,7 @@ export type AIConfigReducerAction =
 
 export type MutateAIConfigAction =
   | AddPromptAction
+  | DeletePromptAction
   | UpdatePromptInputAction
   | UpdatePromptNameAction
   | UpdatePromptModelAction
@@ -26,6 +27,12 @@ export type AddPromptAction = {
   prompt: ClientPrompt;
 };
 
+export type DeletePromptAction = {
+  type: "DELETE_PROMPT";
+  id: string;
+};
+
+// TODO: Update index to prompt id for all existing-prompt actions
 export type UpdatePromptInputAction = {
   type: "UPDATE_PROMPT_INPUT";
   index: number;
@@ -131,6 +138,12 @@ export default function aiconfigReducer(
   switch (action.type) {
     case "ADD_PROMPT_AT_INDEX": {
       return reduceInsertPromptAtIndex(state, action.index, action.prompt);
+    }
+    case "DELETE_PROMPT": {
+      return {
+        ...state,
+        prompts: state.prompts.filter((prompt) => prompt._ui.id !== action.id),
+      };
     }
     case "UPDATE_PROMPT_INPUT": {
       return reduceReplaceInput(state, action.index, () => action.input);

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -32,57 +32,56 @@ export type DeletePromptAction = {
   id: string;
 };
 
-// TODO: Update index to prompt id for all existing-prompt actions
 export type UpdatePromptInputAction = {
   type: "UPDATE_PROMPT_INPUT";
-  index: number;
+  id: string;
   input: PromptInput;
 };
 
 export type UpdatePromptNameAction = {
   type: "UPDATE_PROMPT_NAME";
-  index: number;
+  id: string;
   name: string;
 };
 
 export type UpdatePromptModelAction = {
   type: "UPDATE_PROMPT_MODEL";
-  index: number;
+  id: string;
   modelName?: string;
 };
 
 export type UpdatePromptModelSettingsAction = {
   type: "UPDATE_PROMPT_MODEL_SETTINGS";
-  index: number;
+  id: string;
   modelSettings: JSONObject;
 };
 
 // TODO: saqadri - can likely use this same action for global parameters update
 export type UpdatePromptParametersAction = {
   type: "UPDATE_PROMPT_PARAMETERS";
-  index: number;
+  id: string;
   parameters: JSONObject;
 };
 
 function reduceReplacePrompt(
   state: ClientAIConfig,
-  index: number,
+  id: string,
   replacerFn: (prompt: ClientPrompt) => ClientPrompt
 ): ClientAIConfig {
   return {
     ...state,
-    prompts: state.prompts.map((prompt, i) =>
-      i === index ? replacerFn(prompt) : prompt
+    prompts: state.prompts.map((prompt) =>
+      prompt._ui.id === id ? replacerFn(prompt) : prompt
     ),
   };
 }
 
 function reduceReplaceInput(
   state: ClientAIConfig,
-  index: number,
+  id: string,
   replacerFn: (input: PromptInput) => PromptInput
 ): ClientAIConfig {
-  return reduceReplacePrompt(state, index, (prompt) => ({
+  return reduceReplacePrompt(state, id, (prompt) => ({
     ...prompt,
     input: replacerFn(prompt.input),
   }));
@@ -108,22 +107,32 @@ function reduceConsolidateAIConfig(
   action: MutateAIConfigAction,
   responseConfig: AIConfig
 ): ClientAIConfig {
+  // Make sure prompt structure is properly updated. Client input and metadata takes precedence
+  // since it may have been updated by the user while the request was in flight
+  const consolidatePrompt = (statePrompt: ClientPrompt) => {
+    const responsePrompt = responseConfig.prompts.find(
+      (resPrompt) => resPrompt.name === statePrompt.name
+    );
+    return {
+      ...responsePrompt,
+      ...statePrompt,
+      metadata: {
+        ...responsePrompt!.metadata,
+        ...statePrompt.metadata,
+      },
+    } as ClientPrompt;
+  };
+
   switch (action.type) {
-    case "ADD_PROMPT_AT_INDEX":
+    case "ADD_PROMPT_AT_INDEX": {
+      return reduceReplacePrompt(
+        state,
+        action.prompt._ui.id,
+        consolidatePrompt
+      );
+    }
     case "UPDATE_PROMPT_INPUT": {
-      // Make sure prompt structure is properly updated. Client input and metadata takes precedence
-      // since it may have been updated by the user while the request was in flight
-      return reduceReplacePrompt(state, action.index, (prompt) => {
-        const responsePrompt = responseConfig.prompts[action.index];
-        return {
-          ...responsePrompt,
-          ...prompt,
-          metadata: {
-            ...responsePrompt.metadata,
-            ...prompt.metadata,
-          },
-        } as ClientPrompt;
-      });
+      return reduceReplacePrompt(state, action.id, consolidatePrompt);
     }
     default: {
       return state;
@@ -146,16 +155,16 @@ export default function aiconfigReducer(
       };
     }
     case "UPDATE_PROMPT_INPUT": {
-      return reduceReplaceInput(state, action.index, () => action.input);
+      return reduceReplaceInput(state, action.id, () => action.input);
     }
     case "UPDATE_PROMPT_NAME": {
-      return reduceReplacePrompt(state, action.index, (prompt) => ({
+      return reduceReplacePrompt(state, action.id, (prompt) => ({
         ...prompt,
         name: action.name,
       }));
     }
     case "UPDATE_PROMPT_MODEL": {
-      return reduceReplacePrompt(state, action.index, (prompt) => ({
+      return reduceReplacePrompt(state, action.id, (prompt) => ({
         ...prompt,
         metadata: {
           ...prompt.metadata,
@@ -169,7 +178,7 @@ export default function aiconfigReducer(
       }));
     }
     case "UPDATE_PROMPT_MODEL_SETTINGS": {
-      return reduceReplacePrompt(state, action.index, (prompt) => ({
+      return reduceReplacePrompt(state, action.id, (prompt) => ({
         ...prompt,
         metadata: {
           ...prompt.metadata,
@@ -186,7 +195,7 @@ export default function aiconfigReducer(
       }));
     }
     case "UPDATE_PROMPT_PARAMETERS": {
-      return reduceReplacePrompt(state, action.index, (prompt) => ({
+      return reduceReplacePrompt(state, action.id, (prompt) => ({
         ...prompt,
         metadata: {
           ...prompt.metadata,

--- a/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
@@ -1,7 +1,7 @@
 import { ActionIcon, Menu, TextInput } from "@mantine/core";
 import { IconPlus, IconSearch, IconTextCaption } from "@tabler/icons-react";
-import { memo, useCallback, useEffect, useState } from "react";
-import { showNotification } from "@mantine/notifications";
+import { memo, useCallback, useState } from "react";
+import useLoadModels from "../../hooks/useLoadModels";
 
 type Props = {
   addPrompt: (prompt: string) => void;
@@ -41,30 +41,14 @@ function ModelMenuItems({
 
 export default memo(function AddPromptButton({ addPrompt, getModels }: Props) {
   const [modelSearch, setModelSearch] = useState("");
-  const [models, setModels] = useState<string[]>([]);
   const [isOpen, setIsOpen] = useState(false);
-
-  const loadModels = useCallback(async (modelSearch: string) => {
-    try {
-      const models = await getModels(modelSearch);
-      setModels(models);
-    } catch (err: any) {
-      showNotification({
-        title: "Error loading models",
-        message: err?.message,
-        color: "red",
-      });
-    }
-  }, []);
 
   const onAddPrompt = useCallback((model: string) => {
     addPrompt(model);
     setIsOpen(false);
   }, []);
 
-  useEffect(() => {
-    loadModels(modelSearch);
-  }, [loadModels, modelSearch]);
+  const models = useLoadModels(modelSearch, getModels);
 
   return (
     <Menu

--- a/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
@@ -1,0 +1,82 @@
+import { Autocomplete, AutocompleteItem, Button } from "@mantine/core";
+import { memo, useState } from "react";
+import { getPromptModelName } from "../../utils/promptUtils";
+import { Prompt } from "aiconfig";
+import useLoadModels from "../../hooks/useLoadModels";
+import { IconX } from "@tabler/icons-react";
+
+type Props = {
+  prompt: Prompt;
+  getModels: (search: string) => Promise<string[]>;
+  onSetModel: (model?: string) => void;
+  defaultConfigModelName?: string;
+};
+
+export default memo(function ModelSelector({
+  prompt,
+  getModels,
+  onSetModel,
+  defaultConfigModelName,
+}: Props) {
+  const [selectedModel, setSelectedModel] = useState<string | undefined>(
+    getPromptModelName(prompt, defaultConfigModelName)
+  );
+  const [showAll, setShowAll] = useState(true);
+  const [autocompleteSearch, setAutocompleteSearch] = useState(
+    getPromptModelName(prompt, defaultConfigModelName)
+  );
+
+  const models = useLoadModels(showAll ? "" : autocompleteSearch, getModels);
+
+  const onSelectModel = (model?: string) => {
+    setSelectedModel(model);
+    onSetModel(model);
+  };
+
+  return (
+    <Autocomplete
+      placeholder="Select model"
+      limit={100}
+      maxDropdownHeight={200}
+      rightSection={
+        selectedModel ? (
+          <Button
+            size="xs"
+            variant="subtle"
+            mr={10}
+            onClick={() => {
+              onSelectModel(undefined);
+              setShowAll(true);
+              setAutocompleteSearch("");
+            }}
+          >
+            <IconX size={10} />
+          </Button>
+        ) : null
+      }
+      filter={(searchValue: string, item: AutocompleteItem) => {
+        if (showAll) {
+          return true;
+        }
+
+        const modelName: string = item.value;
+        return modelName
+          .toLocaleLowerCase()
+          .includes(searchValue.toLocaleLowerCase().trim());
+      }}
+      data={models}
+      value={autocompleteSearch}
+      onChange={(value: string) => {
+        setAutocompleteSearch(value);
+        setShowAll(false);
+        onSelectModel(value);
+        models.some((model) => {
+          if (model === value) {
+            setShowAll(true);
+            return true;
+          }
+        });
+      }}
+    />
+  );
+});

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
@@ -107,7 +107,7 @@ export default memo(function PromptContainer({
   const { classes } = useStyles();
 
   return (
-    <Flex justify="space-between" mt="md">
+    <Flex justify="space-between" w="100%">
       <Card withBorder className={classes.promptInputCard}>
         <Flex direction="column">
           <Flex justify="space-between" mb="0.5em">

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
@@ -2,23 +2,26 @@ import PromptActionBar from "./PromptActionBar";
 import PromptInputRenderer from "./prompt_input/PromptInputRenderer";
 import PromptOutputsRenderer from "./prompt_outputs/PromptOutputsRenderer";
 import { ClientPrompt } from "../../shared/types";
-import { getPromptModelName, getPromptSchema } from "../../utils/promptUtils";
-import { Flex, Card, Text, createStyles } from "@mantine/core";
+import { getPromptSchema } from "../../utils/promptUtils";
+import { Flex, Card, createStyles } from "@mantine/core";
 import { PromptInput as AIConfigPromptInput } from "aiconfig";
 import { memo, useCallback } from "react";
 import { ParametersArray } from "../ParametersRenderer";
 import PromptOutputBar from "./PromptOutputBar";
 import PromptName from "./PromptName";
+import ModelSelector from "./ModelSelector";
 
 type Props = {
   index: number;
   prompt: ClientPrompt;
+  getModels: (search: string) => Promise<string[]>;
   onChangePromptInput: (
     promptIndex: number,
     newPromptInput: AIConfigPromptInput
   ) => void;
   onChangePromptName: (promptIndex: number, newName: string) => void;
   onRunPrompt(promptIndex: number): Promise<void>;
+  onUpdateModel: (promptIndex: number, newModel?: string) => void;
   onUpdateModelSettings: (promptIndex: number, newModelSettings: any) => void;
   onUpdateParameters: (promptIndex: number, newParameters: any) => void;
   defaultConfigModelName?: string;
@@ -42,10 +45,12 @@ const useStyles = createStyles((theme) => ({
 export default memo(function PromptContainer({
   prompt,
   index,
+  getModels,
   onChangePromptInput,
   onChangePromptName,
   defaultConfigModelName,
   onRunPrompt,
+  onUpdateModel,
   onUpdateModelSettings,
   onUpdateParameters,
 }: Props) {
@@ -87,6 +92,11 @@ export default memo(function PromptContainer({
     [index, onRunPrompt]
   );
 
+  const updateModel = useCallback(
+    (model?: string) => onUpdateModel(index, model),
+    [index, onUpdateModel]
+  );
+
   // TODO: When adding support for custom PromptContainers, implement a PromptContainerRenderer which
   // will take in the index and callback and render the appropriate PromptContainer with new memoized
   // callback and not having to pass index down to PromptContainer
@@ -102,7 +112,12 @@ export default memo(function PromptContainer({
         <Flex direction="column">
           <Flex justify="space-between" mb="0.5em">
             <PromptName name={prompt.name} onUpdate={onChangeName} />
-            <Text>{getPromptModelName(prompt, defaultConfigModelName)}</Text>
+            <ModelSelector
+              getModels={getModels}
+              prompt={prompt}
+              onSetModel={updateModel}
+              defaultConfigModelName={defaultConfigModelName}
+            />
           </Flex>
           <PromptInputRenderer
             input={prompt.input}

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
@@ -12,18 +12,17 @@ import PromptName from "./PromptName";
 import ModelSelector from "./ModelSelector";
 
 type Props = {
-  index: number;
   prompt: ClientPrompt;
   getModels: (search: string) => Promise<string[]>;
   onChangePromptInput: (
-    promptIndex: number,
+    promptId: string,
     newPromptInput: AIConfigPromptInput
   ) => void;
-  onChangePromptName: (promptIndex: number, newName: string) => void;
-  onRunPrompt(promptIndex: number): Promise<void>;
-  onUpdateModel: (promptIndex: number, newModel?: string) => void;
-  onUpdateModelSettings: (promptIndex: number, newModelSettings: any) => void;
-  onUpdateParameters: (promptIndex: number, newParameters: any) => void;
+  onChangePromptName: (promptId: string, newName: string) => void;
+  onRunPrompt(promptId: string): Promise<void>;
+  onUpdateModel: (promptId: string, newModel?: string) => void;
+  onUpdateModelSettings: (ppromptId: string, newModelSettings: any) => void;
+  onUpdateParameters: (promptId: string, newParameters: any) => void;
   defaultConfigModelName?: string;
 };
 
@@ -44,7 +43,6 @@ const useStyles = createStyles((theme) => ({
 
 export default memo(function PromptContainer({
   prompt,
-  index,
   getModels,
   onChangePromptInput,
   onChangePromptName,
@@ -54,19 +52,21 @@ export default memo(function PromptContainer({
   onUpdateModelSettings,
   onUpdateParameters,
 }: Props) {
+  const promptId = prompt._ui.id;
   const onChangeInput = useCallback(
-    (newInput: AIConfigPromptInput) => onChangePromptInput(index, newInput),
-    [index, onChangePromptInput]
+    (newInput: AIConfigPromptInput) => onChangePromptInput(promptId, newInput),
+    [promptId, onChangePromptInput]
   );
 
   const onChangeName = useCallback(
-    (newName: string) => onChangePromptName(index, newName),
-    [index, onChangePromptName]
+    (newName: string) => onChangePromptName(promptId, newName),
+    [promptId, onChangePromptName]
   );
 
   const updateModelSettings = useCallback(
-    (newModelSettings: any) => onUpdateModelSettings(index, newModelSettings),
-    [index, onUpdateModelSettings]
+    (newModelSettings: any) =>
+      onUpdateModelSettings(promptId, newModelSettings),
+    [promptId, onUpdateModelSettings]
   );
 
   const updateParameters = useCallback(
@@ -82,24 +82,24 @@ export default memo(function PromptContainer({
         newParameters[key] = val;
       }
 
-      onUpdateParameters(index, newParameters);
+      onUpdateParameters(promptId, newParameters);
     },
-    [index, onUpdateParameters]
+    [promptId, onUpdateParameters]
   );
 
   const runPrompt = useCallback(
-    async () => await onRunPrompt(index),
-    [index, onRunPrompt]
+    async () => await onRunPrompt(promptId),
+    [promptId, onRunPrompt]
   );
 
   const updateModel = useCallback(
-    (model?: string) => onUpdateModel(index, model),
-    [index, onUpdateModel]
+    (model?: string) => onUpdateModel(promptId, model),
+    [promptId, onUpdateModel]
   );
 
   // TODO: When adding support for custom PromptContainers, implement a PromptContainerRenderer which
-  // will take in the index and callback and render the appropriate PromptContainer with new memoized
-  // callback and not having to pass index down to PromptContainer
+  // will take in the promptId and callback and render the appropriate PromptContainer with new memoized
+  // callback and not having to pass promptId down to PromptContainer
 
   const promptSchema = getPromptSchema(prompt, defaultConfigModelName);
   const inputSchema = promptSchema?.input;

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptMenuButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptMenuButton.tsx
@@ -1,0 +1,44 @@
+import { Button, Menu, createStyles } from "@mantine/core";
+import { IconDotsVertical, IconTrash } from "@tabler/icons-react";
+import { memo } from "react";
+
+const useStyles = createStyles((theme) => ({
+  promptMenuButton: {
+    marginLeft: -8,
+  },
+}));
+
+export default memo(function PromptMenuButton({
+  promptId,
+  onDeletePrompt,
+}: {
+  promptId: string;
+  onDeletePrompt: (id: string) => void;
+}) {
+  const { classes } = useStyles();
+
+  return (
+    <Menu position="bottom-end">
+      <Menu.Target>
+        <Button
+          size="xs"
+          variant="subtle"
+          color="dark"
+          className={classes.promptMenuButton}
+        >
+          <IconDotsVertical size={14} />
+        </Button>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <Menu.Item
+          icon={<IconTrash size={16} />}
+          color="red"
+          onClick={() => onDeletePrompt(promptId)}
+        >
+          Delete Prompt
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+});

--- a/python/src/aiconfig/editor/client/src/hooks/useLoadModels.ts
+++ b/python/src/aiconfig/editor/client/src/hooks/useLoadModels.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from "react";
+import { showNotification } from "@mantine/notifications";
+
+export default function useLoadModels(
+  modelSearch: string,
+  getModels: (search: string) => Promise<string[]>
+) {
+  const [models, setModels] = useState<string[]>([]);
+
+  const loadModels = useCallback(
+    async (modelSearch: string) => {
+      try {
+        const models = await getModels(modelSearch);
+        setModels(models);
+      } catch (err: any) {
+        showNotification({
+          title: "Error loading models",
+          message: err?.message,
+          color: "red",
+        });
+      }
+    },
+    [getModels]
+  );
+
+  useEffect(() => {
+    loadModels(modelSearch);
+  }, [loadModels, modelSearch]);
+
+  return models;
+}

--- a/python/src/aiconfig/editor/client/src/utils/aiconfigStateUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/aiconfigStateUtils.ts
@@ -1,4 +1,5 @@
 import { AIConfig } from "aiconfig";
+import { ClientAIConfig, ClientPrompt } from "../shared/types";
 
 export function getDefaultNewPromptName(aiconfig: AIConfig): string {
   const existingNames = aiconfig.prompts.map((prompt) => prompt.name);
@@ -7,4 +8,11 @@ export function getDefaultNewPromptName(aiconfig: AIConfig): string {
     i++;
   }
   return `prompt_${i}`;
+}
+
+export function getPrompt(
+  aiconfig: ClientAIConfig,
+  id: string
+): ClientPrompt | undefined {
+  return aiconfig.prompts.find((prompt) => prompt._ui.id === id);
 }

--- a/python/src/aiconfig/editor/client/src/utils/api.ts
+++ b/python/src/aiconfig/editor/client/src/utils/api.ts
@@ -10,6 +10,7 @@ const API_ENDPOINT = `${HOST_ENDPOINT}/api`;
 
 export const ROUTE_TABLE = {
   ADD_PROMPT: urlJoin(API_ENDPOINT, "/add_prompt"),
+  DELETE_PROMPT: urlJoin(API_ENDPOINT, "/delete_prompt"),
   SAVE: urlJoin(API_ENDPOINT, "/save"),
   LOAD: urlJoin(API_ENDPOINT, "/load"),
   LIST_MODELS: urlJoin(API_ENDPOINT, "/list_models"),

--- a/python/src/aiconfig/editor/client/src/utils/api.ts
+++ b/python/src/aiconfig/editor/client/src/utils/api.ts
@@ -14,5 +14,6 @@ export const ROUTE_TABLE = {
   LOAD: urlJoin(API_ENDPOINT, "/load"),
   LIST_MODELS: urlJoin(API_ENDPOINT, "/list_models"),
   RUN_PROMPT: urlJoin(API_ENDPOINT, "/run"),
+  UPDATE_MODEL: urlJoin(API_ENDPOINT, "/update_model"),
   UPDATE_PROMPT: urlJoin(API_ENDPOINT, "/update_prompt"),
 };


### PR DESCRIPTION
[editor] Use Prompt ID Instead of Index for Client-side State Actions

# [editor] Use Prompt ID Instead of Index for Client-side State Actions

We can uniquely identify prompts in client-side state using their client-side id, so let's use that instead of index for referencing them in the actions. This should be a bit more robust than using index.

## Testing:
Went through all relevant actions and made sure they work as expected

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/666).
* #667
* __->__ #666
* #665
* #662