### PR TITLE
[python] Updated `set_parameter()` to work if parameters haven't been defined before

### DIFF
--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -414,25 +414,57 @@ class AIConfig(BaseModel):
             return prompt.metadata
         return prompt.metadata.parameters
 
-    def set_parameter(self, parameter_name: str, parameter_value, prompt_name: Optional[str] = None):
+    def set_parameter(
+        self,
+        parameter_name: str,
+        parameter_value : Union[str, JSONObject],
+        prompt_name: Optional[str] = None):
         """
-        Sets a parameter in the AI configuration metadata. If a prompt_name is specified, it adds the parameter to
-        a specific prompt's metadata in the AI configuration. Otherwise, it adds the parameter to the global metadata.
+        Sets a parameter in the AI configuration metadata. If a prompt_name 
+        is specified, it adds the parameter to a specific prompt's metadata 
+        in the AI configuration. Otherwise, it adds the parameter to the 
+        global metadata.
 
         Args:
             parameter_name (str): The name of the parameter.
-            parameter_value: The value of the parameter. It can be more than just a string. It can be a string or a JSON object. For example:
-                {
-                person: {
-                    firstname: "john",
-                    lastname: "smith",
-                    },
-                }
-                Using the parameter in a prompt with handlebars syntax would look like this:
-                "{{person.firstname}} {{person.lastname}}"
-            prompt_name (str, optional): The name of the prompt to add the parameter to. Defaults to None.
+            parameter_value: The value of the parameter. It can be more than
+                just a string. It can be a string or a JSON object. For 
+                example:
+                    {
+                    person: {
+                        firstname: "john",
+                        lastname: "smith",
+                        },
+                    }
+                Using the parameter in a prompt with handlebars syntax would 
+                look like this:
+                    "{{person.firstname}} {{person.lastname}}"
+            prompt_name (str, optional): The name of the prompt to add the 
+                parameter to. Defaults to None.
         """
         target_metadata = self.get_metadata(prompt_name)
+        if not target_metadata:
+            # Technically this check is not needed since the metadata is a 
+            # required field in Config while it is not required in Prompt.
+            # Therefore, if it's not defined, we can infer that it should
+            # be a PromptMetadata type, but this is just good robustness
+            # in case we ever change our schema in the future
+            if prompt_name:
+                prompt = self.get_prompt(prompt_name)
+                # check next line not needed since it's already assumed
+                # we got here because target_metadata is None, just being 
+                # extra safe
+                if not prompt.metadata:
+                    target_metadata = PromptMetadata(parameters={})
+                    prompt.metadata = target_metadata
+            else:
+                if not self.metadata:
+                    target_metadata = ConfigMetadata()
+                    self.metadata = target_metadata
+
+        assert target_metadata is not None
+        if target_metadata.parameters is None:
+            target_metadata.parameters = {}
         target_metadata.parameters[parameter_name] = parameter_value
 
     def update_parameter(

--- a/python/src/aiconfig/util/params.py
+++ b/python/src/aiconfig/util/params.py
@@ -310,7 +310,7 @@ def resolve_prompt_string(
     augmented_params = collect_prompt_references(current_prompt, ai_config)
 
     # augment params with config-level params
-    augmented_params.update(ai_config.metadata.parameters)
+    augmented_params.update(ai_config.get_global_parameters())
 
     # augment params with prompt level params
     augmented_params.update(ai_config.get_prompt_parameters(current_prompt))

--- a/python/tests/test_parameter_api.py
+++ b/python/tests/test_parameter_api.py
@@ -1,0 +1,326 @@
+import pytest
+from aiconfig.Config import AIConfigRuntime
+from aiconfig.util.config_utils import extract_override_settings
+
+from aiconfig.schema import (
+    AIConfig,
+    ConfigMetadata,
+    ExecuteResult,
+    ModelMetadata,
+    Prompt,
+    PromptMetadata,
+)
+
+
+@pytest.fixture
+def ai_config_runtime():
+    runtime = AIConfigRuntime.create("Untitled AIConfig")
+    return runtime
+
+@pytest.fixture
+def ai_config():
+    config = AIConfig(
+        name="Untitled AIConfig",
+        schema_version="latest",
+        metadata=ConfigMetadata(),
+        prompts=[],
+    )
+    return config
+
+def test_delete_nonexistent_parameter(ai_config_runtime: AIConfigRuntime):
+    """
+    Test deleting a nonexistent parameter.
+    """
+    config = ai_config_runtime
+    parameter_name_to_delete = "param1"
+    config.add_prompt(
+        "prompt1",
+        Prompt(
+            name="prompt_name",
+            input="This is a prompt",
+            metadata=PromptMetadata(model="fakemodel"),
+        ),
+    )
+
+    # Ensure deleting a nonexistent parameter raises a KeyError
+    with pytest.raises(
+        KeyError, match=f"Parameter '{parameter_name_to_delete}' does not exist."
+    ):
+        config.delete_parameter(parameter_name_to_delete)
+
+
+def test_set_global_parameter(ai_config: AIConfig):
+    """
+    Test setting a global parameter.
+    """
+    parameter_name = "global_param"
+    parameter_value = "global_value"
+
+    ai_config.set_parameter(parameter_name, parameter_value, prompt_name=None)
+
+    # Ensure the global parameter is set correctly
+    assert ai_config.metadata.parameters[parameter_name] == parameter_value
+
+
+def test_set_parameter_for_prompt(ai_config: AIConfig):
+    """
+    Test setting a parameter for a specific prompt.
+    """
+    prompt_name = "prompt1"
+    parameter_name = "prompt_param"
+    parameter_value = "prompt_value"
+
+    # Create a sample prompt for testing
+    prompt_data = Prompt(
+        name=prompt_name,
+        input="This is a prompt",
+        metadata=PromptMetadata(model="fakemodel"),
+    )
+    ai_config.add_prompt(prompt_name, prompt_data)
+
+    ai_config.set_parameter(parameter_name, parameter_value, prompt_name=prompt_name)
+
+    # Ensure the parameter is set for the specific prompt
+    assert (
+        ai_config.prompt_index[prompt_name].metadata.parameters[parameter_name]
+        == parameter_value
+    )
+    assert ai_config.prompts[0].metadata.parameters[parameter_name] == parameter_value
+
+
+def test_update_existing_parameter(ai_config: AIConfig):
+    """
+    Test updating an existing parameter.
+    """
+    parameter_name = "existing_param"
+    initial_value = "initial_value"
+    updated_value = "updated_value"
+
+    ai_config.set_parameter(parameter_name, initial_value, prompt_name=None)
+    ai_config.update_parameter(parameter_name, updated_value, prompt_name=None)
+
+    assert ai_config.metadata.parameters is not None
+    assert ai_config.metadata.parameters[parameter_name] == updated_value
+
+
+def test_delete_existing_parameter(ai_config: AIConfig):
+    """
+    Test deleting an existing parameter.
+    """
+    parameter_name_to_delete = "param_to_delete"
+    parameter_value = "param_value"
+
+    ai_config.set_parameter(parameter_name_to_delete, parameter_value, prompt_name=None)
+    ai_config.delete_parameter(parameter_name_to_delete, prompt_name=None)
+
+    assert ai_config.metadata.parameters is not None
+    assert parameter_name_to_delete not in ai_config.metadata.parameters
+
+
+# | With both local and global (should use local override) 
+# | Without AIConfig but local is `{}` |
+def test_get_parameter_prompt_has_parameters(ai_config: AIConfig):
+    """
+    Test getting a parameter for a prompt
+    """
+    prompt_name = "prompt1"
+    prompt_data = Prompt(
+        name=prompt_name,
+        input="This is a prompt",
+        metadata=PromptMetadata(model="fakemodel"),
+    )
+    ai_config.add_prompt(prompt_name, prompt_data)
+
+    parameter_name = "param1"
+    parameter_value = "param_value"
+    ai_config.set_parameter(
+        parameter_name,
+        parameter_value,
+        prompt_name=prompt_name,
+    )
+
+    ai_config.set_parameter(
+        "this value",
+        "does not matter",
+        prompt_name=None,
+    )
+
+    parameters = ai_config.get_parameters(prompt_name)
+    assert ai_config.prompt_index["prompt1"].metadata is not None
+    assert parameters == ai_config.prompt_index["prompt1"].metadata.parameters
+
+
+def test_get_parameter_prompt_has_no_metadata(
+    ai_config: AIConfig,
+):
+    """
+    Test getting a parameter when only aiconfig param is set.
+    Prompt does not have metadata.
+    """
+    prompt_name = "prompt1"
+    prompt_data = Prompt(
+        name=prompt_name,
+        input="This is a prompt",
+    )
+    ai_config.add_prompt(prompt_name, prompt_data)
+
+    parameter_name = "param1"
+    parameter_value = "param_value"
+    ai_config.set_parameter(
+        parameter_name,
+        parameter_value,
+        prompt_name=None,
+    )
+
+    parameters = ai_config.get_parameters(prompt_name)
+    assert parameters == ai_config.metadata.parameters
+
+
+def test_get_parameter_prompt_has_metadata_no_parameters(
+    ai_config: AIConfig
+):
+    """
+    Test getting a parameter when only aiconfig param is set.
+    Prompt has metadata but no parameters.
+    """
+    prompt_name = "prompt1"
+    prompt_data = Prompt(
+        name=prompt_name,
+        input="This is a prompt",
+        metadata=PromptMetadata(model="fakemodel"),
+    )
+    ai_config.add_prompt(prompt_name, prompt_data)
+
+    parameter_name = "param1"
+    parameter_value = "param_value"
+    ai_config.set_parameter(
+        parameter_name,
+        parameter_value,
+        prompt_name=None,
+    )
+
+    parameters = ai_config.get_parameters(prompt_name)
+    assert parameters == ai_config.metadata.parameters
+
+
+def test_get_parameter_prompt_has_empty_parameters(
+    ai_config: AIConfig
+):
+    """
+    Test getting a parameter when only aiconfig param is set.
+    Prompt has empty parameters.
+    """
+    prompt_name = "prompt1"
+    prompt_data = Prompt(
+        name=prompt_name,
+        input="This is a prompt",
+        metadata=PromptMetadata(model="fakemodel", parameters={}),
+    )
+    ai_config.add_prompt(prompt_name, prompt_data)
+
+    parameter_name = "param1"
+    parameter_value = "param_value"
+    ai_config.set_parameter(
+        parameter_name,
+        parameter_value,
+        prompt_name=None,
+    )
+
+    parameters = ai_config.get_parameters(prompt_name)
+    assert parameters == ai_config.metadata.parameters
+
+
+def test_get_parameter_prompt_has_empty_parameters(
+    ai_config: AIConfig
+):
+    """
+    Test getting a parameter when only aiconfig param is set.
+    Prompt has empty parameters.
+    """
+    prompt_name = "prompt1"
+    prompt_data = Prompt(
+        name=prompt_name,
+        input="This is a prompt",
+        metadata=PromptMetadata(model="fakemodel", parameters={}),
+    )
+    ai_config.add_prompt(prompt_name, prompt_data)
+
+    parameter_name = "param1"
+    parameter_value = "param_value"
+    ai_config.set_parameter(
+        parameter_name,
+        parameter_value,
+        prompt_name=None,
+    )
+
+    parameters = ai_config.get_parameters(prompt_name)
+    assert parameters == ai_config.metadata.parameters
+
+def test_get_parameter_aiconfig_has_parameters(ai_config: AIConfig):
+    """
+    Test getting a parameter for an aiconfig
+    """
+    prompt_name = "prompt1"
+    prompt_data = Prompt(
+        name=prompt_name,
+        input="This is a prompt",
+        metadata=PromptMetadata(model="fakemodel"),
+    )
+    ai_config.add_prompt(prompt_name, prompt_data)
+
+    ai_config.set_parameter(
+        "this does",
+        "this matter",
+        prompt_name=prompt_name,
+    )
+
+    parameter_name = "param1"
+    parameter_value = "param_value"
+    ai_config.set_parameter(
+        parameter_name,
+        parameter_value,
+        prompt_name=None,
+    )
+
+    parameters = ai_config.get_parameters()
+    assert parameters == ai_config.metadata.parameters
+
+
+def test_get_parameter_aiconfig_no_parameters(ai_config: AIConfig):
+    """
+    Test getting a parameter for an aiconfig when no parameters are set
+    on the aiconfig
+    """
+    prompt_name = "prompt1"
+    prompt_data = Prompt(
+        name=prompt_name,
+        input="This is a prompt",
+        metadata=PromptMetadata(model="fakemodel"),
+    )
+    ai_config.add_prompt(prompt_name, prompt_data)
+
+    ai_config.set_parameter(
+        "this does",
+        "this matter",
+        prompt_name=prompt_name,
+    )
+
+    parameters = ai_config.get_parameters()
+    assert parameters == {}
+
+
+def test_get_parameter_prompt_no_parameters(ai_config: AIConfig):
+    """
+    Test getting a parameter for a prompt when no parameters are set
+    on either the prompt of the aiconfig
+    """
+    prompt_name = "prompt1"
+    prompt_data = Prompt(
+        name=prompt_name,
+        input="This is a prompt",
+        metadata=PromptMetadata(model="fakemodel"),
+    )
+    ai_config.add_prompt(prompt_name, prompt_data)
+
+    parameters = ai_config.get_parameters()
+    assert parameters == {}

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -238,28 +238,6 @@ def test_get_metadata_with_nonexistent_prompt(ai_config_runtime: AIConfigRuntime
         config.get_metadata(prompt_name)
 
 
-def test_delete_nonexistent_parameter(ai_config_runtime: AIConfigRuntime):
-    """
-    Test deleting a nonexistent parameter.
-    """
-    config = ai_config_runtime
-    parameter_name_to_delete = "param1"
-    config.add_prompt(
-        "prompt1",
-        Prompt(
-            name="prompt_name",
-            input="This is a prompt",
-            metadata=PromptMetadata(model="fakemodel"),
-        ),
-    )
-
-    # Ensure deleting a nonexistent parameter raises a KeyError
-    with pytest.raises(
-        KeyError, match=f"Parameter '{parameter_name_to_delete}' does not exist."
-    ):
-        config.delete_parameter(parameter_name_to_delete)
-
-
 @pytest.fixture
 def ai_config():
     config = AIConfig(
@@ -269,74 +247,6 @@ def ai_config():
         prompts=[],
     )
     return config
-
-
-def test_set_global_parameter(ai_config: AIConfig):
-    """
-    Test setting a global parameter.
-    """
-    parameter_name = "global_param"
-    parameter_value = "global_value"
-
-    ai_config.set_parameter(parameter_name, parameter_value, prompt_name=None)
-
-    # Ensure the global parameter is set correctly
-    assert ai_config.metadata.parameters[parameter_name] == parameter_value
-
-
-def test_set_parameter_for_prompt(ai_config: AIConfig):
-    """
-    Test setting a parameter for a specific prompt.
-    """
-    prompt_name = "prompt1"
-    parameter_name = "prompt_param"
-    parameter_value = "prompt_value"
-
-    # Create a sample prompt for testing
-    prompt_data = Prompt(
-        name=prompt_name,
-        input="This is a prompt",
-        metadata=PromptMetadata(model="fakemodel"),
-    )
-    ai_config.add_prompt(prompt_name, prompt_data)
-
-    ai_config.set_parameter(parameter_name, parameter_value, prompt_name=prompt_name)
-
-    # Ensure the parameter is set for the specific prompt
-    assert (
-        ai_config.prompt_index[prompt_name].metadata.parameters[parameter_name]
-        == parameter_value
-    )
-    assert ai_config.prompts[0].metadata.parameters[parameter_name] == parameter_value
-
-
-def test_update_existing_parameter(ai_config: AIConfig):
-    """
-    Test updating an existing parameter.
-    """
-    parameter_name = "existing_param"
-    initial_value = "initial_value"
-    updated_value = "updated_value"
-
-    ai_config.set_parameter(parameter_name, initial_value, prompt_name=None)
-    ai_config.update_parameter(parameter_name, updated_value, prompt_name=None)
-
-    # Ensure the existing parameter is updated correctly
-    assert ai_config.metadata.parameters[parameter_name] == updated_value
-
-
-def test_delete_existing_parameter(ai_config: AIConfig):
-    """
-    Test deleting an existing parameter.
-    """
-    parameter_name_to_delete = "param_to_delete"
-    parameter_value = "param_value"
-
-    ai_config.set_parameter(parameter_name_to_delete, parameter_value, prompt_name=None)
-    ai_config.delete_parameter(parameter_name_to_delete, prompt_name=None)
-
-    # Ensure the existing parameter is deleted correctly
-    assert parameter_name_to_delete not in ai_config.metadata.parameters
 
 
 def test_load_saved_config(tmp_path):
@@ -368,6 +278,7 @@ def test_load_saved_config(tmp_path):
     assert loaded_config.name == "My AIConfig"
     assert loaded_config.metadata.parameters == {"config_param": "config_value"}
     assert "prompt1" in loaded_config.prompt_index
+    assert loaded_config.prompt_index["prompt1"].metadata is not None
     assert loaded_config.prompt_index["prompt1"].metadata.parameters == {
         "prompt_param": "prompt_value"
     }


### PR DESCRIPTION
[python] Updated `set_parameter()` to work if parameters haven't been defined before




Before this function would have failed to set any parameters if:

1. The prompt_name was passed in but `prompt.metadata` (possible) or `prompt.metadata.parameters` (not possible because it defaults to `{}`) was `None`
2. The prompt_name was not passed in (so update aiconfig) but the `aiconfig.metadata.parameters` was `None` (this is actually never possible because we default to using `{}`, but still just good to be thorough and future-proof)

See example below
<img width="410" alt="Screenshot 2023-12-29 at 01 04 48" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/d3db50c7-866c-4f05-a279-284baf97d595">


## Test plan
Added automated tests: `pytest -vv`

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/670).
* #693
* #692
* #691
* #690
* #688
* __->__ #670
* #668