### PR TITLE
[easy] Simplify update parameters callback

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/GlobalParametersContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/GlobalParametersContainer.tsx
@@ -1,7 +1,7 @@
 import { createStyles, Container, Accordion, Text } from "@mantine/core";
 import { JSONObject } from "aiconfig";
-import { memo, useCallback, useState } from "react";
-import ParametersRenderer, { ParametersArray } from "./ParametersRenderer";
+import { memo, useState } from "react";
+import ParametersRenderer from "./ParametersRenderer";
 
 type Props = {
   initialValue: JSONObject;
@@ -22,24 +22,6 @@ export default memo(function GlobalParametersContainer({
   onUpdateParameters,
 }: Props) {
   const [isParametersDrawerOpen, setIsParametersDrawerOpen] = useState(false);
-
-  const updateGlobalParameters = useCallback(
-    (data: {
-      promptName?: string | undefined;
-      newParameters: ParametersArray;
-    }) => {
-      const newParameters: Record<string, unknown> = {};
-      for (const paramTuple of data.newParameters ?? []) {
-        const key = paramTuple.parameterName;
-        const val = paramTuple.parameterValue;
-
-        newParameters[key] = val;
-      }
-
-      onUpdateParameters(newParameters);
-    },
-    [onUpdateParameters]
-  );
 
   const { classes } = useStyles();
 
@@ -65,7 +47,7 @@ export default memo(function GlobalParametersContainer({
             {isParametersDrawerOpen && (
               <ParametersRenderer
                 initialValue={initialValue}
-                onUpdateParameters={updateGlobalParameters}
+                onUpdateParameters={onUpdateParameters}
               />
             )}
           </Accordion.Panel>

--- a/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
@@ -129,12 +129,23 @@ export type ParametersArray = {
   key: string;
 }[];
 
+function parametersArrayToJSONObject(
+  parametersArray: ParametersArray
+): JSONObject {
+  const parameters: JSONObject = {};
+  for (const paramTuple of parametersArray ?? []) {
+    const key = paramTuple.parameterName;
+    const val = paramTuple.parameterValue;
+
+    parameters[key] = val;
+  }
+
+  return parameters;
+}
+
 export default memo(function ParametersRenderer(props: {
   initialValue?: JSONObject;
-  onUpdateParameters: (data: {
-    promptName?: string;
-    newParameters: ParametersArray;
-  }) => void;
+  onUpdateParameters: (parameters: JSONObject) => void;
   customDescription?: React.ReactNode;
   maxHeight?: string | number;
 }) {
@@ -164,7 +175,7 @@ export default memo(function ParametersRenderer(props: {
     async (key: string, _parameterName?: string) => {
       setParameters((prev) => {
         const newParameters = prev.filter((item) => item.key !== key);
-        onUpdateParameters({ newParameters });
+        onUpdateParameters(parametersArrayToJSONObject(newParameters));
         return newParameters;
       });
     },
@@ -181,7 +192,7 @@ export default memo(function ParametersRenderer(props: {
           parameterValue: "",
         },
       ];
-      onUpdateParameters({ newParameters });
+      onUpdateParameters(parametersArrayToJSONObject(newParameters));
       return newParameters;
     });
   }, [onUpdateParameters]);
@@ -215,7 +226,9 @@ export default memo(function ParametersRenderer(props: {
                   currentElement.parameterName = parameterName;
                   currentElement.parameterValue = parameterValue ?? "";
 
-                  onUpdateParameters({ newParameters });
+                  onUpdateParameters(
+                    parametersArrayToJSONObject(newParameters)
+                  );
 
                   return newParameters;
                 });

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
@@ -8,18 +8,16 @@ import {
 import { ActionIcon, Container, Flex, Tabs } from "@mantine/core";
 import { IconClearAll } from "@tabler/icons-react";
 import { memo, useState } from "react";
-import ParametersRenderer, { ParametersArray } from "../ParametersRenderer";
+import ParametersRenderer from "../ParametersRenderer";
 import RunPromptButton from "./RunPromptButton";
+import { JSONObject } from "aiconfig";
 
 type Props = {
   prompt: ClientPrompt;
   promptSchema?: PromptSchema;
   onRunPrompt: () => Promise<void>;
   onUpdateModelSettings: (settings: Record<string, unknown>) => void;
-  onUpdateParameters: (data: {
-    promptName?: string;
-    newParameters: ParametersArray;
-  }) => void;
+  onUpdateParameters: (parameters: JSONObject) => void;
 };
 
 // Don't default to config-level model settings since that could be confusing

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
@@ -6,7 +6,6 @@ import { getPromptSchema } from "../../utils/promptUtils";
 import { Flex, Card, createStyles } from "@mantine/core";
 import { PromptInput as AIConfigPromptInput, JSONObject } from "aiconfig";
 import { memo, useCallback } from "react";
-import { ParametersArray } from "../ParametersRenderer";
 import PromptOutputBar from "./PromptOutputBar";
 import PromptName from "./PromptName";
 import ModelSelector from "./ModelSelector";
@@ -76,20 +75,7 @@ export default memo(function PromptContainer({
   );
 
   const updateParameters = useCallback(
-    (data: {
-      promptName?: string | undefined;
-      newParameters: ParametersArray;
-    }) => {
-      const newParameters: Record<string, unknown> = {};
-      for (const paramTuple of data.newParameters ?? []) {
-        const key = paramTuple.parameterName;
-        const val = paramTuple.parameterValue;
-
-        newParameters[key] = val;
-      }
-
-      onUpdateParameters(promptId, newParameters);
-    },
+    (parameters: JSONObject) => onUpdateParameters(promptId, parameters),
     [promptId, onUpdateParameters]
   );
 


### PR DESCRIPTION
[easy] Simplify update parameters callback

Have updateParameters take a JSONObject. Makes it much cleaner to use elsewhere.

ParametersRenderer simply converts its ParametersArray to JSONObject before triggering the update.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/674).
* __->__ #674
* #673