### PR TITLE
[editor] Prevent Setting Duplicate Names

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigContext.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigContext.tsx
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+import { ClientAIConfig } from "../shared/types";
+
+/**
+ * Context for overall editor config state. This context should
+ * be memoized to prevent unnecessary re-renders
+ */
+const AIConfigContext = createContext<{
+  getState: () => ClientAIConfig;
+}>({
+  getState: () => ({ prompts: [] }),
+});
+
+export default AIConfigContext;

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -31,6 +31,7 @@ import {
 import { debounce, uniqueId } from "lodash";
 import PromptMenuButton from "./prompt/PromptMenuButton";
 import GlobalParametersContainer from "./GlobalParametersContainer";
+import AIConfigContext from "./AIConfigContext";
 
 type Props = {
   aiconfig: AIConfig;
@@ -380,8 +381,16 @@ export default function EditorContainer({
 
   const { classes } = useStyles();
 
+  const getState = useCallback(() => stateRef.current, []);
+  const contextValue = useMemo(
+    () => ({
+      getState,
+    }),
+    [getState]
+  );
+
   return (
-    <>
+    <AIConfigContext.Provider value={contextValue}>
       <Container maw="80rem">
         <Group grow m="sm">
           {/* <Text sx={{ textOverflow: "ellipsis", overflow: "hidden" }} size={14}>
@@ -432,6 +441,6 @@ export default function EditorContainer({
           );
         })}
       </Container>
-    </>
+    </AIConfigContext.Provider>
   );
 }

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -196,6 +196,15 @@ export default function aiconfigReducer(
       return reduceReplaceInput(state, action.id, () => action.input);
     }
     case "UPDATE_PROMPT_NAME": {
+      // Validate that no prompt has a name that conflicts with this one:
+      const existingPromptNames = state.prompts.map((prompt) => prompt.name);
+
+      if (
+        existingPromptNames.find((existingName) => action.name === existingName)
+      ) {
+        // Don't allow duplicate names
+        return state;
+      }
       return reduceReplacePrompt(state, action.id, (prompt) => ({
         ...prompt,
         name: action.name,

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
@@ -117,7 +117,11 @@ export default memo(function PromptContainer({
       <Card withBorder className={classes.promptInputCard}>
         <Flex direction="column">
           <Flex justify="space-between" mb="0.5em">
-            <PromptName name={prompt.name} onUpdate={onChangeName} />
+            <PromptName
+              promptId={promptId}
+              name={prompt.name}
+              onUpdate={onChangeName}
+            />
             <ModelSelector
               getModels={getModels}
               prompt={prompt}

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptName.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptName.tsx
@@ -1,17 +1,37 @@
 import { TextInput } from "@mantine/core";
-import { memo } from "react";
+import { ChangeEvent, memo, useContext, useState } from "react";
+import AIConfigContext from "../AIConfigContext";
 
 type Props = {
+  promptId: string;
   name: string;
   onUpdate: (name: string) => void;
 };
 
-export default memo(function PromptName({ name, onUpdate }: Props) {
+export default memo(function PromptName({ promptId, name, onUpdate }: Props) {
+  const { getState } = useContext(AIConfigContext);
+
+  // Use local component state to show error for duplicate names
+  // AIConfig state will not set duplicates to be safe
+  const [nameInput, setNameInput] = useState(name);
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setNameInput(e.currentTarget.value);
+    onUpdate(e.currentTarget.value);
+  };
+
   return (
     <TextInput
-      value={name}
+      value={nameInput}
       placeholder="Name this prompt"
-      onChange={(e) => onUpdate(e.currentTarget.value)}
+      onChange={onChange}
+      error={
+        getState().prompts.some(
+          (p) => p.name === nameInput && p._ui.id !== promptId
+        )
+          ? "Name already exists"
+          : null
+      }
     />
   );
 });


### PR DESCRIPTION
[editor] Prevent Setting Duplicate Names

# [editor] Prevent Setting Duplicate Names

Many of the AIConfig API methods rely on specifying the prompt name. We should be careful not to allow duplicate prompt names in the editor to prevent any issues, so add an error in the UI if the prompt name matches an existing prompt name:


https://github.com/lastmile-ai/aiconfig/assets/5060851/8bb4a659-755e-44cf-93f8-b00d27070cf0
