### PR TITLE
[editor] Initialize Empty Config with a First Prompt

### DIFF
--- a/python/src/aiconfig/editor/server/server_utils.py
+++ b/python/src/aiconfig/editor/server/server_utils.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from enum import Enum
 from types import ModuleType
 from typing import Any, Callable, NewType, Optional, Type, TypeVar, cast
+from aiconfig.registry import ModelParserRegistry
+from aiconfig.schema import Prompt, PromptMetadata
 
 import lastmile_utils.lib.core.api as core_utils
 import result
@@ -217,6 +219,10 @@ def init_server_state(app: Flask, edit_config: EditServerConfig) -> Result[None,
                 return Err(f"Failed to load AIConfig from {edit_config.aiconfig_path}: {e}")
     else:
         aiconfig_runtime = AIConfigRuntime.create()  # type: ignore
+        model_ids = ModelParserRegistry.parser_ids()
+        if len(model_ids) > 0:
+            aiconfig_runtime.add_prompt("prompt_1", Prompt(name="prompt_1", input="", metadata=PromptMetadata(model=model_ids[0])))
+
         state.aiconfig = aiconfig_runtime
         LOGGER.info("Created new AIConfig")
         return Ok(None)

--- a/python/src/aiconfig/registry.py
+++ b/python/src/aiconfig/registry.py
@@ -12,34 +12,35 @@ if typing.TYPE_CHECKING:
 class ModelParserRegistry:
     """
     A dictionary to store registered model parsers by their IDs. It stores both:
-        1) model_name --> model_parser (ex: "mistralai/Mistral-7B-v0.1" --> 
+        1) model_name --> model_parser (ex: "mistralai/Mistral-7B-v0.1" -->
             HuggingFaceTextGenerationTransformer)
-        2) moder_parser.id() --> model_parser (ex: HuggingFaceTextGenerationTransformer 
-            works with many different Text Generation models) so is saved as 
-            HuggingFaceTextGenerationTransformer.id() (str) (usually it's classname) --> 
-            HuggingFaceTextGenerationTransformer (obj) 
-        
-    The reason we allow 2) above is so that you can define the relationship between a 
+        2) moder_parser.id() --> model_parser (ex: HuggingFaceTextGenerationTransformer
+            works with many different Text Generation models) so is saved as
+            HuggingFaceTextGenerationTransformer.id() (str) (usually it's classname) -->
+            HuggingFaceTextGenerationTransformer (obj)
+
+    The reason we allow 2) above is so that you can define the relationship between a
     model name and a model parser in the AIConfig instead of the model parser class (ex:
     https://github.com/lastmile-ai/aiconfig/blob/main/cookbooks/HuggingFace/Mistral-aiconfig.json#L16-L18).
-    This then gets updated into the desired format 1) by calling the 
+    This then gets updated into the desired format 1) by calling the
     `update_model_parser_registry_with_config_runtime()` command
-    
-    Each model_name is only allowed to map to a single model_parser for an 
+
+    Each model_name is only allowed to map to a single model_parser for an
     AIConfigRuntime.
     """
+
     _parsers: Dict[str, ModelParser] = {}
 
     @staticmethod
     def register_model_parser(model_parser: ModelParser, ids: Optional[List[str]] = None):
         """
-        Adds a model parser to the registry. This model parser is used to parse Prompts 
+        Adds a model parser to the registry. This model parser is used to parse Prompts
         in the AIConfig that use the given model.
 
         Args:
             model_parser (ModelParser): The model parser to add to the registry.
-            ids (list, optional): Optional list of IDs (typically model names) to 
-                register the model parser under. If unspecified, the model parser will 
+            ids (list, optional): Optional list of IDs (typically model names) to
+                register the model parser under. If unspecified, the model parser will
                 be resgistered under its own ID.
         """
         if ids:
@@ -93,7 +94,7 @@ class ModelParserRegistry:
         ModelParserRegistry._parsers.clear()
 
     @staticmethod
-    def parser_ids() -> list:
+    def parser_ids() -> list[str]:
         """
         Retrieves a list of model parser IDs from the ModelParserRegistry.
 
@@ -107,10 +108,7 @@ class ModelParserRegistry:
         """
         returns a dictionary of model names and their correspondings model parser ids
         """
-        return {
-            model_name: model_parser.id()
-            for model_name, model_parser in ModelParserRegistry._parsers.items()
-        }
+        return {model_name: model_parser.id() for model_name, model_parser in ModelParserRegistry._parsers.items()}
 
 
 def update_model_parser_registry_with_config_runtime(config_runtime: "AIConfigRuntime"):
@@ -123,9 +121,7 @@ def update_model_parser_registry_with_config_runtime(config_runtime: "AIConfigRu
     if not config_runtime.metadata.model_parsers:
         return
     for model_id, model_parser_id in config_runtime.metadata.model_parsers.items():
-        retrieved_model_parser = ModelParserRegistry.get_model_parser(
-            model_parser_id
-        )  # Fix
+        retrieved_model_parser = ModelParserRegistry.get_model_parser(model_parser_id)  # Fix
         if retrieved_model_parser is None:
             error_message = (
                 f"Unable to load AIConfig: It specifies {config_runtime.metadata.model_parsers}, "


### PR DESCRIPTION
[editor] Initialize Empty Config with a First Prompt

# [editor] Initialize Empty Config with a First Prompt

Currently, starting the editor without specifying a file path will result in an empty editor UI without any prompts.

This PR updates it to start the config with a prompt whose model is the first supported model in the registry.

![Screenshot 2023-12-29 at 4 59 03 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/b6aec33a-9425-457f-8726-866bbfa671de)
