### PR TITLE
[editor] Add placeholder to empty text prompt input

### DIFF
--- a/python/src/aiconfig/editor/client/src/Editor.tsx
+++ b/python/src/aiconfig/editor/client/src/Editor.tsx
@@ -82,6 +82,18 @@ export default function Editor() {
     []
   );
 
+  const setConfigName = useCallback(async (name: string) => {
+    return await ufetch.post(ROUTE_TABLE.SET_NAME, {
+      name,
+    });
+  }, []);
+
+  const setConfigDescription = useCallback(async (description: string) => {
+    return await ufetch.post(ROUTE_TABLE.SET_DESCRIPTION, {
+      description,
+    });
+  }, []);
+
   const callbacks: AIConfigCallbacks = useMemo(
     () => ({
       addPrompt,
@@ -89,6 +101,8 @@ export default function Editor() {
       getModels,
       runPrompt,
       save,
+      setConfigDescription,
+      setConfigName,
       updateModel,
       updatePrompt,
     }),
@@ -98,6 +112,8 @@ export default function Editor() {
       getModels,
       runPrompt,
       save,
+      setConfigDescription,
+      setConfigName,
       updateModel,
       updatePrompt,
     ]

--- a/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
@@ -1,0 +1,137 @@
+import {
+  createStyles,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+} from "@mantine/core";
+import { useClickOutside } from "@mantine/hooks";
+import { memo, useCallback, useRef, useState } from "react";
+
+type Props = {
+  name?: string;
+  description?: string | null;
+  setDescription: (description: string) => void;
+  setName: (name: string) => void;
+};
+
+const useStyles = createStyles((theme) => ({
+  // Match name input style to corresponding Title element styles
+  // See https://github.com/mantinedev/mantine/blob/master/src/mantine-core/src/Title/Title.styles.ts
+  nameInput: {
+    ...theme.fn.fontStyles(),
+    fontFamily: theme.headings.fontFamily,
+    fontWeight: theme.headings.fontWeight as number,
+    fontSize: theme.headings.sizes.h1.fontSize,
+    lineHeight: theme.headings.sizes.h1.lineHeight,
+    width: "-webkit-fill-available",
+    letterSpacing: "-1px",
+    height: "44px",
+  },
+  hoverContainer: {
+    "&:hover": {
+      backgroundColor:
+        theme.colorScheme === "dark"
+          ? "rgba(255, 255, 255, 0.1)"
+          : theme.colors.gray[1],
+    },
+    borderRadius: theme.radius.sm,
+    width: "-webkit-fill-available",
+  },
+}));
+
+export default memo(function ConfigNameDescription({
+  name,
+  description,
+  setDescription,
+  setName,
+}: Props) {
+  const { classes } = useStyles();
+
+  const [isEditing, setIsEditing] = useState(!name);
+  const [initialFocus, setInitialFocus] = useState<
+    "name" | "description" | null
+  >("name");
+
+  const nameDisplayRef = useRef<HTMLHeadingElement | null>(null);
+  const descriptionDisplayRef = useRef<HTMLDivElement | null>(null);
+
+  const inputSectionRef = useClickOutside(() => {
+    if (name) {
+      setIsEditing(false);
+    }
+  });
+
+  const onHandleEnter = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (event.key === "Enter") {
+        event.stopPropagation();
+        setIsEditing(false);
+      }
+    },
+    []
+  );
+
+  const onClickEdit = useCallback(
+    (event: React.MouseEvent<HTMLHeadingElement | HTMLDivElement>) => {
+      setIsEditing(true);
+      if (event.target === nameDisplayRef.current) {
+        setInitialFocus("name");
+      } else if (event.target === descriptionDisplayRef.current) {
+        setInitialFocus("description");
+      }
+    },
+    []
+  );
+
+  return (
+    <Stack
+      ref={isEditing ? inputSectionRef : undefined}
+      spacing="xs"
+      w="100%"
+      ml="1em"
+      mr="0.5em"
+    >
+      {isEditing ? (
+        <>
+          <TextInput
+            classNames={{ input: classes.nameInput }}
+            placeholder={"Config name"}
+            value={name}
+            onKeyDown={onHandleEnter}
+            autoFocus={initialFocus === "name"}
+            onChange={(e) => setName(e.currentTarget.value)}
+          />
+          <Textarea
+            placeholder="Config description"
+            value={description ?? undefined}
+            onKeyDown={onHandleEnter}
+            autoFocus={initialFocus === "description"}
+            onChange={(e) => setDescription(e.currentTarget.value)}
+            autosize
+            minRows={2}
+          />
+        </>
+      ) : (
+        <div>
+          <Title
+            ref={nameDisplayRef}
+            onClick={onClickEdit}
+            className={classes.hoverContainer}
+          >
+            {name}
+          </Title>
+          <Text
+            ref={descriptionDisplayRef}
+            onClick={onClickEdit}
+            style={{ whiteSpace: "pre-wrap" }}
+            className={classes.hoverContainer}
+          >
+            {description}
+          </Text>
+        </div>
+      )}
+    </Stack>
+  );
+});

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -10,6 +10,8 @@ export type MutateAIConfigAction =
   | AddPromptAction
   | DeletePromptAction
   | RunPromptAction
+  | SetDescriptionAction
+  | SetNameAction
   | UpdatePromptInputAction
   | UpdatePromptNameAction
   | UpdatePromptModelAction
@@ -37,6 +39,16 @@ export type DeletePromptAction = {
 export type RunPromptAction = {
   type: "RUN_PROMPT";
   id: string;
+};
+
+export type SetDescriptionAction = {
+  type: "SET_DESCRIPTION";
+  description: string;
+};
+
+export type SetNameAction = {
+  type: "SET_NAME";
+  name: string;
 };
 
 export type UpdatePromptInputAction = {
@@ -191,6 +203,18 @@ export default function aiconfigReducer(
           isRunning: true,
         },
       }));
+    }
+    case "SET_DESCRIPTION": {
+      return {
+        ...state,
+        description: action.description,
+      };
+    }
+    case "SET_NAME": {
+      return {
+        ...state,
+        name: action.name,
+      };
     }
     case "UPDATE_PROMPT_INPUT": {
       return reduceReplaceInput(state, action.id, () => action.input);

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputDataSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputDataSchemaRenderer.tsx
@@ -20,6 +20,7 @@ export default memo(function PromptInputDataSchemaRenderer({
         <Textarea
           value={data ? (data as string) : ""}
           onChange={(e) => onChangeData(e.target.value)}
+          placeholder="Type a prompt"
         />
       );
     default:

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
@@ -71,6 +71,7 @@ export default memo(function PromptInputSchemaRenderer(props: Props) {
       <Textarea
         value={props.input as string}
         onChange={(e) => props.onChangeInput(e.target.value)}
+        placeholder="Type a prompt"
       />
     );
   } else {

--- a/python/src/aiconfig/editor/client/src/utils/api.ts
+++ b/python/src/aiconfig/editor/client/src/utils/api.ts
@@ -12,6 +12,8 @@ export const ROUTE_TABLE = {
   ADD_PROMPT: urlJoin(API_ENDPOINT, "/add_prompt"),
   DELETE_PROMPT: urlJoin(API_ENDPOINT, "/delete_prompt"),
   SAVE: urlJoin(API_ENDPOINT, "/save"),
+  SET_DESCRIPTION: urlJoin(API_ENDPOINT, "/set_description"),
+  SET_NAME: urlJoin(API_ENDPOINT, "/set_name"),
   LOAD: urlJoin(API_ENDPOINT, "/load"),
   LIST_MODELS: urlJoin(API_ENDPOINT, "/list_models"),
   RUN_PROMPT: urlJoin(API_ENDPOINT, "/run"),

--- a/python/src/aiconfig/editor/client/src/utils/constants.ts
+++ b/python/src/aiconfig/editor/client/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const DEBOUNCE_MS = 250;


### PR DESCRIPTION
[editor] Add placeholder to empty text prompt input

# [editor] Add placeholder to empty text prompt input

Note the figma has the text "Type a prompt. (e.g. show me an astronaut riding a horse on the moon)", however that could be confusing for any model that doesn't have an image output. So, let's just use 'Type a prompt' for now

<img width="1360" alt="Screenshot 2023-12-29 at 8 14 38 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/a84d6ebb-77ae-4304-8689-0cdfa7236360">

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/681).
* #686
* #682
* __->__ #681
* #680