### PR TITLE
[editor] JSON Renderer for Prompt Input

### DIFF
--- a/python/src/aiconfig/editor/client/package.json
+++ b/python/src/aiconfig/editor/client/package.json
@@ -33,6 +33,7 @@
     "@mantine/modals": "^6.0.7",
     "@mantine/notifications": "^6.0.7",
     "@mantine/prism": "^6.0.7",
+    "@monaco-editor/react": "^4.6.0",
     "@tabler/icons-react": "^2.44.0",
     "aiconfig": "../../../../../typescript",
     "lodash": "^4.17.21",

--- a/python/src/aiconfig/editor/client/src/Editor.tsx
+++ b/python/src/aiconfig/editor/client/src/Editor.tsx
@@ -82,6 +82,18 @@ export default function Editor() {
     []
   );
 
+  const setConfigName = useCallback(async (name: string) => {
+    return await ufetch.post(ROUTE_TABLE.SET_NAME, {
+      name,
+    });
+  }, []);
+
+  const setConfigDescription = useCallback(async (description: string) => {
+    return await ufetch.post(ROUTE_TABLE.SET_DESCRIPTION, {
+      description,
+    });
+  }, []);
+
   const callbacks: AIConfigCallbacks = useMemo(
     () => ({
       addPrompt,
@@ -89,6 +101,8 @@ export default function Editor() {
       getModels,
       runPrompt,
       save,
+      setConfigDescription,
+      setConfigName,
       updateModel,
       updatePrompt,
     }),
@@ -98,6 +112,8 @@ export default function Editor() {
       getModels,
       runPrompt,
       save,
+      setConfigDescription,
+      setConfigName,
       updateModel,
       updatePrompt,
     ]

--- a/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
@@ -1,0 +1,137 @@
+import {
+  createStyles,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+} from "@mantine/core";
+import { useClickOutside } from "@mantine/hooks";
+import { memo, useCallback, useRef, useState } from "react";
+
+type Props = {
+  name?: string;
+  description?: string | null;
+  setDescription: (description: string) => void;
+  setName: (name: string) => void;
+};
+
+const useStyles = createStyles((theme) => ({
+  // Match name input style to corresponding Title element styles
+  // See https://github.com/mantinedev/mantine/blob/master/src/mantine-core/src/Title/Title.styles.ts
+  nameInput: {
+    ...theme.fn.fontStyles(),
+    fontFamily: theme.headings.fontFamily,
+    fontWeight: theme.headings.fontWeight as number,
+    fontSize: theme.headings.sizes.h1.fontSize,
+    lineHeight: theme.headings.sizes.h1.lineHeight,
+    width: "-webkit-fill-available",
+    letterSpacing: "-1px",
+    height: "44px",
+  },
+  hoverContainer: {
+    "&:hover": {
+      backgroundColor:
+        theme.colorScheme === "dark"
+          ? "rgba(255, 255, 255, 0.1)"
+          : theme.colors.gray[1],
+    },
+    borderRadius: theme.radius.sm,
+    width: "-webkit-fill-available",
+  },
+}));
+
+export default memo(function ConfigNameDescription({
+  name,
+  description,
+  setDescription,
+  setName,
+}: Props) {
+  const { classes } = useStyles();
+
+  const [isEditing, setIsEditing] = useState(!name);
+  const [initialFocus, setInitialFocus] = useState<
+    "name" | "description" | null
+  >("name");
+
+  const nameDisplayRef = useRef<HTMLHeadingElement | null>(null);
+  const descriptionDisplayRef = useRef<HTMLDivElement | null>(null);
+
+  const inputSectionRef = useClickOutside(() => {
+    if (name) {
+      setIsEditing(false);
+    }
+  });
+
+  const onHandleEnter = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (event.key === "Enter") {
+        event.stopPropagation();
+        setIsEditing(false);
+      }
+    },
+    []
+  );
+
+  const onClickEdit = useCallback(
+    (event: React.MouseEvent<HTMLHeadingElement | HTMLDivElement>) => {
+      setIsEditing(true);
+      if (event.target === nameDisplayRef.current) {
+        setInitialFocus("name");
+      } else if (event.target === descriptionDisplayRef.current) {
+        setInitialFocus("description");
+      }
+    },
+    []
+  );
+
+  return (
+    <Stack
+      ref={isEditing ? inputSectionRef : undefined}
+      spacing="xs"
+      w="100%"
+      ml="1em"
+      mr="0.5em"
+    >
+      {isEditing ? (
+        <>
+          <TextInput
+            classNames={{ input: classes.nameInput }}
+            placeholder={"Config name"}
+            value={name}
+            onKeyDown={onHandleEnter}
+            autoFocus={initialFocus === "name"}
+            onChange={(e) => setName(e.currentTarget.value)}
+          />
+          <Textarea
+            placeholder="Config description"
+            value={description ?? undefined}
+            onKeyDown={onHandleEnter}
+            autoFocus={initialFocus === "description"}
+            onChange={(e) => setDescription(e.currentTarget.value)}
+            autosize
+            minRows={2}
+          />
+        </>
+      ) : (
+        <div>
+          <Title
+            ref={nameDisplayRef}
+            onClick={onClickEdit}
+            className={classes.hoverContainer}
+          >
+            {name}
+          </Title>
+          <Text
+            ref={descriptionDisplayRef}
+            onClick={onClickEdit}
+            style={{ whiteSpace: "pre-wrap" }}
+            className={classes.hoverContainer}
+          >
+            {description}
+          </Text>
+        </div>
+      )}
+    </Stack>
+  );
+});

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -444,6 +444,12 @@ export default function EditorContainer({
         onUpdateParameters={onUpdateGlobalParameters}
       />
       <Container maw="80rem" className={classes.promptsContainer}>
+        <div className={classes.addPromptRow}>
+          <AddPromptButton
+            getModels={callbacks.getModels}
+            addPrompt={(model: string) => onAddPrompt(0, model)}
+          />
+        </div>
         {aiconfigState.prompts.map((prompt: ClientPrompt, i: number) => {
           return (
             <Stack key={prompt._ui.id}>

--- a/python/src/aiconfig/editor/client/src/components/JSONEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/JSONEditor.tsx
@@ -1,0 +1,78 @@
+import { createStyles, useMantineTheme } from "@mantine/core";
+import { Editor, Monaco } from "@monaco-editor/react";
+import { JSONObject, JSONValue } from "aiconfig";
+import { memo } from "react";
+
+type Props = {
+  content: JSONValue;
+  onChangeContent: (value: JSONValue) => void;
+  schema?: JSONObject;
+};
+
+const useStyles = createStyles(() => ({
+  monacoEditor: {
+    minHeight: "300px",
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function configureEditor(
+  _editor: Monaco["editor"]["IStandaloneCodeEditor"],
+  monaco: Monaco,
+  schema?: JSONObject
+) {
+  // Validate the text against PromptInput schema
+  monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+    validate: true,
+    schemas: [
+      {
+        uri: "https://json.schemastore.org/aiconfig-1.0",
+        fileMatch: ["*"],
+        // schema: {
+        //     $ref: "#/definitions/PromptInput",
+        // }
+        // TODO: Figure out how to reference PromptInput definition from the uri schema
+        // Getting the following error:
+        // $ref '/definitions/PromptInput' in 'https://json.schemastore.org/aiconfig-1.0' can not be resolved.(768)
+
+        schema,
+      },
+    ],
+    enableSchemaRequest: true,
+  });
+}
+
+export default memo(function JSONEditor({
+  content,
+  onChangeContent,
+  schema,
+}: Props) {
+  const theme = useMantineTheme();
+  const { classes } = useStyles();
+
+  return (
+    <Editor
+      defaultLanguage="json"
+      value={JSON.stringify(content, null, 2)}
+      onChange={(value) => {
+        if (!value) {
+          return;
+        }
+        try {
+          const updatedContent = JSON.parse(value);
+          onChangeContent(updatedContent);
+        } catch (e) {
+          return;
+        }
+      }}
+      theme={theme.colorScheme === "dark" ? "vs-dark" : undefined}
+      className={classes.monacoEditor}
+      options={{
+        lineNumbers: false,
+        minimap: { enabled: false },
+        wordWrap: "on",
+      }}
+      onMount={(editor, monaco) => configureEditor(editor, monaco, schema)}
+    />
+  );
+});

--- a/python/src/aiconfig/editor/client/src/components/JSONRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/JSONRenderer.tsx
@@ -1,0 +1,24 @@
+import { Prism } from "@mantine/prism";
+import { JSONObject, JSONValue } from "aiconfig";
+import { memo } from "react";
+import JSONEditor from "./JSONEditor";
+
+type Props = {
+  content: JSONValue;
+  onChange?: (value: JSONValue) => void;
+  schema?: JSONObject;
+};
+
+export default memo(function JSONRenderer({
+  content,
+  onChange,
+  schema,
+}: Props) {
+  return !onChange ? (
+    <Prism language="json" styles={{ code: { textWrap: "pretty" } }}>
+      {JSON.stringify(content, null, 2)}
+    </Prism>
+  ) : (
+    <JSONEditor content={content} onChangeContent={onChange} schema={schema} />
+  );
+});

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -10,6 +10,8 @@ export type MutateAIConfigAction =
   | AddPromptAction
   | DeletePromptAction
   | RunPromptAction
+  | SetDescriptionAction
+  | SetNameAction
   | UpdatePromptInputAction
   | UpdatePromptNameAction
   | UpdatePromptModelAction
@@ -37,6 +39,16 @@ export type DeletePromptAction = {
 export type RunPromptAction = {
   type: "RUN_PROMPT";
   id: string;
+};
+
+export type SetDescriptionAction = {
+  type: "SET_DESCRIPTION";
+  description: string;
+};
+
+export type SetNameAction = {
+  type: "SET_NAME";
+  name: string;
 };
 
 export type UpdatePromptInputAction = {
@@ -191,6 +203,18 @@ export default function aiconfigReducer(
           isRunning: true,
         },
       }));
+    }
+    case "SET_DESCRIPTION": {
+      return {
+        ...state,
+        description: action.description,
+      };
+    }
+    case "SET_NAME": {
+      return {
+        ...state,
+        name: action.name,
+      };
     }
     case "UPDATE_PROMPT_INPUT": {
       return reduceReplaceInput(state, action.id, () => action.input);

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/PromptInputJSONRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/PromptInputJSONRenderer.tsx
@@ -1,0 +1,76 @@
+import { JSONValue, PromptInput } from "aiconfig";
+import { memo, useCallback } from "react";
+import JSONRenderer from "../../JSONRenderer";
+
+type Props = {
+  input: PromptInput;
+  onChangeInput: (value: PromptInput) => void;
+};
+
+const PROMPT_INPUT_SCHEMA = {
+  anyOf: [
+    {
+      type: "object",
+      additionalProperties: {},
+      properties: {
+        data: {
+          description:
+            "Input to the model. This can represent a single input, or multiple inputs.\nThe structure of the data object is up to the ModelParser. Attachments field should be leveraged for non-text inputs (e.g. image, audio).",
+        },
+        attachments: {
+          description:
+            "Used to include non-text inputs (e.g. image, audio) of specified MIME types in the prompt",
+          type: "array",
+          items: {
+            $ref: "#/definitions/Attachment",
+          },
+        },
+      },
+    },
+    {
+      type: "string",
+    },
+  ],
+  definitions: {
+    Attachment: {
+      description: "Data of specified MIME type to attach to a prompt",
+      type: "object",
+      required: ["data"],
+      properties: {
+        mime_type: {
+          description:
+            "MIME type of the attachment. If not specified, the MIME type will be assumed to be text/plain.",
+          type: "string",
+        },
+        data: {
+          description: "Data representing the attachment",
+        },
+        metadata: {
+          description: "Attachment metadata.",
+          type: "object",
+          additionalProperties: {},
+        },
+      },
+    },
+  },
+};
+
+export default memo(function PromptInputJSONRenderer({
+  input,
+  onChangeInput,
+}: Props) {
+  const onChange = useCallback(
+    (value: JSONValue) => {
+      onChangeInput(value as PromptInput);
+    },
+    [onChangeInput]
+  );
+
+  return (
+    <JSONRenderer
+      content={input}
+      onChange={onChange}
+      schema={PROMPT_INPUT_SCHEMA}
+    />
+  );
+});

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/PromptInputRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/PromptInputRenderer.tsx
@@ -1,8 +1,11 @@
 import { PromptInput } from "aiconfig";
-import { memo } from "react";
+import { memo, useState } from "react";
 import { PromptInputSchema } from "../../../utils/promptUtils";
 import PromptInputSchemaRenderer from "./schema_renderer/PromptInputSchemaRenderer";
 import PromptInputConfigRenderer from "./PromptInputConfigRenderer";
+import { ActionIcon, Flex, Tooltip } from "@mantine/core";
+import { IconBraces, IconBracesOff } from "@tabler/icons-react";
+import PromptInputJSONRenderer from "./PromptInputJSONRenderer";
 
 type Props = {
   input: PromptInput;
@@ -15,13 +18,34 @@ export default memo(function PromptInputRenderer({
   schema,
   onChangeInput,
 }: Props) {
-  return schema ? (
-    <PromptInputSchemaRenderer
-      input={input}
-      schema={schema}
-      onChangeInput={onChangeInput}
-    />
-  ) : (
-    <PromptInputConfigRenderer input={input} onChangeInput={onChangeInput} />
+  const [isRawJSON, setIsRawJSON] = useState(false);
+  return (
+    <>
+      <Flex justify="flex-end">
+        <Tooltip label="Toggle JSON editor" withArrow>
+          <ActionIcon onClick={() => setIsRawJSON((curr) => !curr)}>
+            {isRawJSON ? (
+              <IconBracesOff size="1rem" />
+            ) : (
+              <IconBraces size="1rem" />
+            )}
+          </ActionIcon>
+        </Tooltip>
+      </Flex>
+      {isRawJSON ? (
+        <PromptInputJSONRenderer input={input} onChangeInput={onChangeInput} />
+      ) : schema ? (
+        <PromptInputSchemaRenderer
+          input={input}
+          schema={schema}
+          onChangeInput={onChangeInput}
+        />
+      ) : (
+        <PromptInputConfigRenderer
+          input={input}
+          onChangeInput={onChangeInput}
+        />
+      )}
+    </>
   );
 });

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputDataSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputDataSchemaRenderer.tsx
@@ -20,6 +20,7 @@ export default memo(function PromptInputDataSchemaRenderer({
         <Textarea
           value={data ? (data as string) : ""}
           onChange={(e) => onChangeData(e.target.value)}
+          placeholder="Type a prompt"
         />
       );
     default:

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
@@ -4,9 +4,10 @@ import {
 } from "../../../../utils/promptUtils";
 import DataRenderer from "./PromptInputDataSchemaRenderer";
 import AttachmentsRenderer from "./PromptInputAttachmentsSchemaRenderer";
-import { Flex, Textarea } from "@mantine/core";
+import { Flex, Text, Textarea } from "@mantine/core";
 import { Attachment, JSONValue, PromptInput } from "aiconfig";
 import { memo } from "react";
+import JSONRenderer from "../../../JSONRenderer";
 
 type Props = {
   input: PromptInput;
@@ -61,15 +62,17 @@ function SchemaRenderer({ input, schema, onChangeInput }: SchemaRendererProps) {
 
 export default memo(function PromptInputSchemaRenderer(props: Props) {
   if (props.schema.type === "string") {
-    // TODO: Add ErrorBoundary handling
-    // if (props.input && typeof props.input !== "string") {
-    //   throw new Error(
-    //     `Expected input to be a string, but got ${typeof props.input}`
-    //   );
-    // }
+    if (props.input && typeof props.input !== "string") {
+      return (
+        <>
+          <Text color="red">Expected input type string</Text>
+          <JSONRenderer content={props.input} />
+        </>
+      );
+    }
     return (
       <Textarea
-        value={props.input as string}
+        value={props.input}
         onChange={(e) => props.onChangeInput(e.target.value)}
         placeholder="Type a prompt"
       />

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
@@ -71,6 +71,7 @@ export default memo(function PromptInputSchemaRenderer(props: Props) {
       <Textarea
         value={props.input as string}
         onChange={(e) => props.onChangeInput(e.target.value)}
+        placeholder="Type a prompt"
       />
     );
   } else {

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_outputs/JSONOutput.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_outputs/JSONOutput.tsx
@@ -1,11 +1,7 @@
-import { Prism } from "@mantine/prism";
 import { JSONValue } from "aiconfig";
 import { memo } from "react";
+import JSONRenderer from "../../JSONRenderer";
 
 export default memo(function JSONOutput({ content }: { content: JSONValue }) {
-  return (
-    <Prism language="json" styles={{ code: { textWrap: "pretty" } }}>
-      {JSON.stringify(content, null, 2)}
-    </Prism>
-  );
+  return <JSONRenderer content={content} />;
 });

--- a/python/src/aiconfig/editor/client/src/utils/api.ts
+++ b/python/src/aiconfig/editor/client/src/utils/api.ts
@@ -12,6 +12,8 @@ export const ROUTE_TABLE = {
   ADD_PROMPT: urlJoin(API_ENDPOINT, "/add_prompt"),
   DELETE_PROMPT: urlJoin(API_ENDPOINT, "/delete_prompt"),
   SAVE: urlJoin(API_ENDPOINT, "/save"),
+  SET_DESCRIPTION: urlJoin(API_ENDPOINT, "/set_description"),
+  SET_NAME: urlJoin(API_ENDPOINT, "/set_name"),
   LOAD: urlJoin(API_ENDPOINT, "/load"),
   LIST_MODELS: urlJoin(API_ENDPOINT, "/list_models"),
   RUN_PROMPT: urlJoin(API_ENDPOINT, "/run"),

--- a/python/src/aiconfig/editor/client/src/utils/constants.ts
+++ b/python/src/aiconfig/editor/client/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const DEBOUNCE_MS = 250;

--- a/python/src/aiconfig/editor/client/yarn.lock
+++ b/python/src/aiconfig/editor/client/yarn.lock
@@ -1856,6 +1856,20 @@
   resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.21.tgz#6185506e91cba3e308aaa8ea9ababc8e767995d6"
   integrity sha512-33RVDRop5jiWFao3HKd3Yp7A9mEq4HAJxJPTuYm1NkdqX6aTKOQK7wT8v8itVodBp+sb4cJK6ZVdD1UurK/txQ==
 
+"@monaco-editor/loader@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.4.0.tgz#f08227057331ec890fa1e903912a5b711a2ad558"
+  integrity sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==
+  dependencies:
+    state-local "^1.0.6"
+
+"@monaco-editor/react@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.6.0.tgz#bcc68671e358a21c3814566b865a54b191e24119"
+  integrity sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==
+  dependencies:
+    "@monaco-editor/loader" "^1.4.0"
+
 "@next/eslint-plugin-next@14.0.2":
   version "14.0.2"
   resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-14.0.2.tgz#421799f46116d8032f1739ce5ce89822453c8f03"
@@ -10416,6 +10430,11 @@ stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
   integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
+
+state-local@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
+  integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
 
 static-eval@2.0.2:
   version "2.0.2"


### PR DESCRIPTION
[editor] JSON Renderer for Prompt Input

# [editor] JSON Renderer for Prompt Input

Add a toggle-able JSON editor for prompt inputs so that users can see/modify the input JSON directly. This sets up the JSONEditor component which can be reused in other places (e.g. prompt model settings). This component takes in a schema object to provide validation of the input -- we should investigate and update the implementation to just take a reference to a definition in our config schema instead of needing to duplicate the schema definition for PromptInput but I wasn't able to get that working within a reasonable time box.


https://github.com/lastmile-ai/aiconfig/assets/5060851/c5e14ac0-0771-41f5-adea-4369b886ef00

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/686).
* __->__ #686
* #682
* #681
* #680