### PR TITLE
Add error handling for `add_ouput` in Python SDK

### DIFF
--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -681,7 +681,7 @@ AIConfig-level settings. If this is a mistake, please rerun the \
 
     def add_output(self, prompt_name: str, output: Output, overwrite: bool = False):
         """
-        Add an output to the [rompt with the given name in the AIConfig
+        Add an output to the prompt with the given name in the AIConfig
 
         Args:
             prompt_name (str): The name of the prompt to add the output to.
@@ -691,7 +691,9 @@ AIConfig-level settings. If this is a mistake, please rerun the \
         prompt = self.get_prompt(prompt_name)
         if not prompt:
             raise IndexError(f"Cannot out output. Prompt '{prompt_name}' not found in config.")
-        if overwrite or not output:
+        if not output:
+            raise Exception(f"Cannot add output to prompt '{prompt_name}'. Output is empty")
+        if overwrite:
             prompt.outputs = [output]
         else:
             prompt.outputs.append(output)

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -692,7 +692,7 @@ AIConfig-level settings. If this is a mistake, please rerun the \
         if not prompt:
             raise IndexError(f"Cannot out output. Prompt '{prompt_name}' not found in config.")
         if not output:
-            raise Exception(f"Cannot add output to prompt '{prompt_name}'. Output is empty")
+            raise Exception(f"Cannot add output to prompt '{prompt_name}'. Output is empty.")
         if overwrite:
             prompt.outputs = [output]
         else:

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -690,9 +690,9 @@ AIConfig-level settings. If this is a mistake, please rerun the \
         """
         prompt = self.get_prompt(prompt_name)
         if not prompt:
-            raise IndexError(f"Cannot out output. Prompt '{prompt_name}' not found in config.")
+            raise IndexError(f"Cannot add output. Prompt '{prompt_name}' not found in config.")
         if not output:
-            raise Exception(f"Cannot add output to prompt '{prompt_name}'. Output is empty.")
+            raise ValueError(f"Cannot add output to prompt '{prompt_name}'. Output is not defined.")
         if overwrite:
             prompt.outputs = [output]
         else:

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -592,9 +592,9 @@ def test_add_output_existing_prompt_overwrite(ai_config_runtime: AIConfigRuntime
     original_output = ExecuteResult(
         output_type="execute_result",
         execution_count=0,
-        data={"role": "assistant", "content": "original output"},
+        data="original output",
         metadata={
-            "rawResponse": {"role": "assistant", "content": "original output"}
+            "raw_response": {"role": "assistant", "content": "original output"}
         },
     )
     prompt = Prompt(
@@ -609,8 +609,10 @@ def test_add_output_existing_prompt_overwrite(ai_config_runtime: AIConfigRuntime
     expected_output = ExecuteResult(
         output_type="execute_result",
         execution_count=0,
-        data={"role": "assistant", "content": "test output"},
-        metadata={"finish_reason": "stop"},
+        data="original output",
+        metadata={
+            "raw_response": {"role": "assistant", "content": "original output"}
+        },
     )
     # overwrite the original_output
     ai_config_runtime.add_output("GreetingPrompt", expected_output, True)

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -536,12 +536,12 @@ def test_set_and_delete_metadata_ai_config(ai_config_runtime: AIConfigRuntime):
 
 def test_set_and_delete_metadata_ai_config_prompt(ai_config_runtime: AIConfigRuntime):
     """Test deleting a non-existent metadata key at the AIConfig level."""
-    prompt1 = Prompt(
+    prompt = Prompt(
         name="GreetingPrompt",
         input="Hello, how are you?",
         metadata=PromptMetadata(model="fakemodel"),
     )
-    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    ai_config_runtime.add_prompt(prompt.name, prompt)
     ai_config_runtime.set_metadata("testkey", "testvalue", "GreetingPrompt")
 
     assert (
@@ -558,17 +558,19 @@ def test_set_and_delete_metadata_ai_config_prompt(ai_config_runtime: AIConfigRun
 
 def test_add_output_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRuntime):
     """Test adding an output to an existing prompt without overwriting."""
-    prompt1 = Prompt(
+    prompt = Prompt(
         name="GreetingPrompt",
         input="Hello, how are you?",
         metadata=PromptMetadata(model="fakemodel"),
     )
-    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    ai_config_runtime.add_prompt(prompt.name, prompt)
     test_result = ExecuteResult(
         output_type="execute_result",
         execution_count=0,
-        data={"role": "assistant", "content": "test output"},
-        metadata={"finish_reason": "stop"},
+        data="test output",
+        metadata={
+            "raw_response": {"role": "assistant", "content": "test output"}
+        },
     )
     ai_config_runtime.add_output("GreetingPrompt", test_result)
 
@@ -577,9 +579,11 @@ def test_add_output_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRunt
     test_result2 = ExecuteResult(
         output_type="execute_result",
         execution_count=0,
-        data={"role": "assistant", "content": "test output for second time"},
-        metadata={"finish_reason": "stop"},
-    )
+        data="test output",
+        metadata={
+            "raw_response": {"role": "assistant", "content": "test output for second time"}
+        }, 
+    
     ai_config_runtime.add_output("GreetingPrompt", test_result2)
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result2
 

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -604,7 +604,7 @@ def test_add_output_existing_prompt_overwrite(ai_config_runtime: AIConfigRuntime
         outputs=[original_output],
     )
     ai_config_runtime.add_prompt(prompt.name, prompt)
-    # check that the base result is there
+    # check that the original_output is there
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == original_output
     expected_output = ExecuteResult(
         output_type="execute_result",
@@ -612,25 +612,25 @@ def test_add_output_existing_prompt_overwrite(ai_config_runtime: AIConfigRuntime
         data={"role": "assistant", "content": "test output"},
         metadata={"finish_reason": "stop"},
     )
-    # overwrite the base result
+    # overwrite the original_output
     ai_config_runtime.add_output("GreetingPrompt", expected_output, True)
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == expected_output
 
 def test_add_undefined_output_to_prompt(ai_config_runtime: AIConfigRuntime):
     """Test for adding an undefined output to a prompt with/without overwriting. Should result in an error."""
-    prompt1 = Prompt(
+    prompt = Prompt(
         name="GreetingPrompt",
         input="Hello, how are you?",
         metadata=PromptMetadata(model="fakemodel"),
     )
-    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    ai_config_runtime.add_prompt(prompt.name, prompt)
     # Case 1: No output, overwrite param not defined
     with pytest.raises(
         ValueError,
         match=r"Cannot add output to prompt 'GreetingPrompt'. Output is not defined.",
     ):
         ai_config_runtime.add_output("GreetingPrompt", None)
-    # Case 2: No output, woverwrite param set to True
+    # Case 2: No output, overwrite param set to True
     with pytest.raises(
         ValueError,
         match=r"Cannot add output to prompt 'GreetingPrompt'. Output is not defined.",

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -612,6 +612,27 @@ def test_add_output_existing_prompt_overwrite(ai_config_runtime: AIConfigRuntime
     ai_config_runtime.add_output("GreetingPrompt", test_result, True)
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result
 
+def test_add_empty_output_to_prompt(ai_config_runtime: AIConfigRuntime):
+    """Test for adding an empty output to an existing prompt with/without overwriting."""
+    prompt1 = Prompt(
+        name="GreetingPrompt",
+        input="Hello, how are you?",
+        metadata=PromptMetadata(model="fakemodel"),
+    )
+    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    # Case 1: No output, no overwrite
+    with pytest.raises(
+        Exception,
+        match=r"Cannot add output to prompt 'GreetingPrompt'. Output is empty.",
+    ):
+        ai_config_runtime.add_output("GreetingPrompt", None)
+    # Case 2: No output, with overwrite
+    with pytest.raises(
+        Exception,
+        match=r"Cannot add output to prompt 'GreetingPrompt'. Output is empty.",
+    ):
+        ai_config_runtime.add_output("GreetingPrompt", None, True)
+    
 def test_extract_override_settings(ai_config_runtime: AIConfigRuntime):
     initial_settings = {"topP": 0.9}
 

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -577,16 +577,40 @@ def test_add_output_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRunt
     test_result2 = ExecuteResult(
         output_type="execute_result",
         execution_count=0.0,
-        data={"role": "assistant", "content": "test output"},
+        data={"role": "assistant", "content": "test output for second time"},
         metadata={"finish_reason": "stop"},
     )
     ai_config_runtime.add_output("GreetingPrompt", test_result2)
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result2
 
     ai_config_runtime.delete_output("GreetingPrompt")
-
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == None
 
+def test_add_output_existing_prompt_overwrite(ai_config_runtime: AIConfigRuntime):
+    """Test adding an output to an existing prompt with overwriting."""
+    base_result = ExecuteResult(
+        output_type="execute_result",
+        execution_count=0.0,
+        data={"role": "assistant", "content": "base output"},
+        metadata={"finish_reason": "stop"},)
+    prompt1 = Prompt(
+        name="GreetingPrompt",
+        input="Hello, how are you?",
+        metadata=PromptMetadata(model="fakemodel"),
+        outputs=[base_result],
+    )
+    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    # check that the base result is there
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == base_result
+    test_result = ExecuteResult(
+        output_type="execute_result",
+        execution_count=0.0,
+        data={"role": "assistant", "content": "test output"},
+        metadata={"finish_reason": "stop"},
+    )
+    # overwrite the base result
+    ai_config_runtime.add_output("GreetingPrompt", test_result, True)
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result
 
 def test_extract_override_settings(ai_config_runtime: AIConfigRuntime):
     initial_settings = {"topP": 0.9}

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -582,7 +582,8 @@ def test_add_output_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRunt
         data="test output",
         metadata={
             "raw_response": {"role": "assistant", "content": "test output for second time"}
-        }, 
+        },
+    ) 
     
     ai_config_runtime.add_output("GreetingPrompt", test_result2)
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result2

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -616,24 +616,24 @@ def test_add_output_existing_prompt_overwrite(ai_config_runtime: AIConfigRuntime
     ai_config_runtime.add_output("GreetingPrompt", expected_output, True)
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == expected_output
 
-def test_add_empty_output_to_prompt(ai_config_runtime: AIConfigRuntime):
-    """Test for adding an empty output to an existing prompt with/without overwriting."""
+def test_add_undefined_output_to_prompt(ai_config_runtime: AIConfigRuntime):
+    """Test for adding an undefined output to a prompt with/without overwriting. Should result in an error."""
     prompt1 = Prompt(
         name="GreetingPrompt",
         input="Hello, how are you?",
         metadata=PromptMetadata(model="fakemodel"),
     )
     ai_config_runtime.add_prompt(prompt1.name, prompt1)
-    # Case 1: No output, no overwrite
+    # Case 1: No output, overwrite param not defined
     with pytest.raises(
-        Exception,
-        match=r"Cannot add output to prompt 'GreetingPrompt'. Output is empty.",
+        ValueError,
+        match=r"Cannot add output to prompt 'GreetingPrompt'. Output is not defined.",
     ):
         ai_config_runtime.add_output("GreetingPrompt", None)
-    # Case 2: No output, with overwrite
+    # Case 2: No output, woverwrite param set to True
     with pytest.raises(
-        Exception,
-        match=r"Cannot add output to prompt 'GreetingPrompt'. Output is empty.",
+        ValueError,
+        match=r"Cannot add output to prompt 'GreetingPrompt'. Output is not defined.",
     ):
         ai_config_runtime.add_output("GreetingPrompt", None, True)
     

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -566,7 +566,7 @@ def test_add_output_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRunt
     ai_config_runtime.add_prompt(prompt1.name, prompt1)
     test_result = ExecuteResult(
         output_type="execute_result",
-        execution_count=0.0,
+        execution_count=0,
         data={"role": "assistant", "content": "test output"},
         metadata={"finish_reason": "stop"},
     )
@@ -576,7 +576,7 @@ def test_add_output_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRunt
 
     test_result2 = ExecuteResult(
         output_type="execute_result",
-        execution_count=0.0,
+        execution_count=0,
         data={"role": "assistant", "content": "test output for second time"},
         metadata={"finish_reason": "stop"},
     )
@@ -586,31 +586,35 @@ def test_add_output_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRunt
     ai_config_runtime.delete_output("GreetingPrompt")
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == None
 
+
 def test_add_output_existing_prompt_overwrite(ai_config_runtime: AIConfigRuntime):
     """Test adding an output to an existing prompt with overwriting."""
-    base_result = ExecuteResult(
+    original_output = ExecuteResult(
         output_type="execute_result",
-        execution_count=0.0,
-        data={"role": "assistant", "content": "base output"},
-        metadata={"finish_reason": "stop"},)
-    prompt1 = Prompt(
+        execution_count=0,
+        data={"role": "assistant", "content": "original output"},
+        metadata={
+            "rawResponse": {"role": "assistant", "content": "original output"}
+        },
+    )
+    prompt = Prompt(
         name="GreetingPrompt",
         input="Hello, how are you?",
         metadata=PromptMetadata(model="fakemodel"),
-        outputs=[base_result],
+        outputs=[original_output],
     )
-    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    ai_config_runtime.add_prompt(prompt.name, prompt)
     # check that the base result is there
-    assert ai_config_runtime.get_latest_output("GreetingPrompt") == base_result
-    test_result = ExecuteResult(
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == original_output
+    expected_output = ExecuteResult(
         output_type="execute_result",
-        execution_count=0.0,
+        execution_count=0,
         data={"role": "assistant", "content": "test output"},
         metadata={"finish_reason": "stop"},
     )
     # overwrite the base result
-    ai_config_runtime.add_output("GreetingPrompt", test_result, True)
-    assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result
+    ai_config_runtime.add_output("GreetingPrompt", expected_output, True)
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == expected_output
 
 def test_add_empty_output_to_prompt(ai_config_runtime: AIConfigRuntime):
     """Test for adding an empty output to an existing prompt with/without overwriting."""


### PR DESCRIPTION
Summary:
This pull request addresses a critical flaw in the add_output method within the Python SDK. Currently, the method incorrectly adds None to the output list when the Output parameter is None, which contradicts the intended behavior. The expected functionality is for the method to reject None as an invalid output or, alternatively, raise an exception.

Changes Made:
- Modified the add_output method to raise an exception when the Output parameter is None.

Context:
This change ensures that the add_output method behaves as expected, providing more robust and predictable behavior when handling output parameters.

Related Issues:
Closes #529 

Test Plan:
New test similar to `test_add_output_existing_prompt_no_overwrite` but with overwrite needs to be added.

Things left to complete:
- [x] Add test for `add_output` with overwrite enabled