### PR TITLE
Feat: Add method to add multiple outputs to a prompt in AIConfig

### DIFF
--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -696,6 +696,29 @@ AIConfig-level settings. If this is a mistake, please rerun the \
         else:
             prompt.outputs.append(output)
 
+    def add_outputs(self, prompt_name: str, outputs: List[Output], overwrite: bool = False):
+        """
+        Add multiple outputs to the prompt with the given name in the AIConfig
+
+        Args:
+            prompt_name (str): The name of the prompt to add the outputs to.
+            outputs (List[Output]): List of outputs to add.
+            overwrite (bool, optional): Overwrites the existing output if True. Otherwise appends the outputs to the prompt's output list. Defaults to False.
+        """
+        prompt = self.get_prompt(prompt_name)
+        if not prompt:
+            raise IndexError(
+                f"Cannot out output. Prompt '{prompt_name}' not found in config."
+            )
+        if not outputs:
+            raise IndexError(
+                f"Cannot add outputs. No outputs provided for prompt '{prompt_name}'."
+            )
+        if overwrite:
+            prompt.outputs = outputs
+        else:
+            prompt.outputs.extend(outputs)
+
     def delete_output(self, prompt_name: str):
         """
         Deletes the outputs for the prompt with the given prompt_name.

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -708,10 +708,10 @@ AIConfig-level settings. If this is a mistake, please rerun the \
         prompt = self.get_prompt(prompt_name)
         if not prompt:
             raise IndexError(
-                f"Cannot out output. Prompt '{prompt_name}' not found in config."
+                f"Cannot add outputs. Prompt '{prompt_name}' not found in config."
             )
         if not outputs:
-            raise IndexError(
+            raise ValueError(
                 f"Cannot add outputs. No outputs provided for prompt '{prompt_name}'."
             )
         if overwrite:

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -589,92 +589,104 @@ def test_add_output_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRunt
 
 def test_add_outputs_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRuntime):
     """Test adding outputs to an existing prompt without overwriting."""
-    base_result = ExecuteResult(
+    original_result = ExecuteResult(
         output_type="execute_result",
-        execution_count=0.0,
-        data={"role": "assistant", "content": "base output"},
-        metadata={"finish_reason": "stop"},)
-    prompt1 = Prompt(
+        execution_count=0,
+        data="original result",
+        metadata={
+            "raw_response": {"role": "assistant", "content": "original result"}
+        },
+    )
+    prompt = Prompt(
         name="GreetingPrompt",
         input="Hello, how are you?",
         metadata=PromptMetadata(model="fakemodel"),
-        outputs=[base_result],
+        outputs=[original_result],
     )
-    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    ai_config_runtime.add_prompt(prompt.name, prompt)
     
-    assert ai_config_runtime.get_latest_output("GreetingPrompt") == base_result
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == original_result
 
     test_result1 = ExecuteResult(
         output_type="execute_result",
-        execution_count=0.0,
-        data={"role": "assistant", "content": "test output 1"},
-        metadata={"finish_reason": "stop"},
+        execution_count=0,
+        data="test output 1",
+        metadata={
+            "raw_response": {"role": "assistant", "content": "test output 1"}
+        },
     )
-
     test_result2 = ExecuteResult(
         output_type="execute_result",
-        execution_count=0.0,
-        data={"role": "assistant", "content": "test output 2"},
-        metadata={"finish_reason": "stop"},
+        execution_count=0,
+        data="test output 2",
+        metadata={
+            "raw_response": {"role": "assistant", "content": "test output 2"}
+        },
     )
     ai_config_runtime.add_outputs("GreetingPrompt", [test_result1, test_result2])
 
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result2
-    assert prompt1.outputs == [base_result, test_result1, test_result2]
+    assert prompt.outputs == [original_result, test_result1, test_result2]
 
 def test_add_outputs_existing_prompt_with_overwrite(ai_config_runtime: AIConfigRuntime):
     """Test adding outputs to an existing prompt with overwriting."""
-    base_result = ExecuteResult(
+    original_result = ExecuteResult(
         output_type="execute_result",
-        execution_count=0.0,
-        data={"role": "assistant", "content": "base output"},
-        metadata={"finish_reason": "stop"},)
-    prompt1 = Prompt(
+        execution_count=0,
+        data="original result",
+        metadata={
+            "raw_response": {"role": "assistant", "content": "original result"}
+        },
+    )
+    prompt = Prompt(
         name="GreetingPrompt",
         input="Hello, how are you?",
         metadata=PromptMetadata(model="fakemodel"),
-        outputs=[base_result],
+        outputs=[original_result],
     )
-    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    ai_config_runtime.add_prompt(prompt.name, prompt)
     
-    assert ai_config_runtime.get_latest_output("GreetingPrompt") == base_result
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == original_result
 
     test_result1 = ExecuteResult(
         output_type="execute_result",
-        execution_count=0.0,
-        data={"role": "assistant", "content": "test output 1"},
-        metadata={"finish_reason": "stop"},
+        execution_count=0,
+        data="test output 1",
+        metadata={
+            "raw_response": {"role": "assistant", "content": "test output 1"}
+        },
     )
-
     test_result2 = ExecuteResult(
         output_type="execute_result",
-        execution_count=0.0,
-        data={"role": "assistant", "content": "test output 2"},
-        metadata={"finish_reason": "stop"},
+        execution_count=0,
+        data="test output 2",
+        metadata={
+            "raw_response": {"role": "assistant", "content": "test output 2"}
+        },
     )
     ai_config_runtime.add_outputs("GreetingPrompt", [test_result1, test_result2], True)
 
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result2
-    assert prompt1.outputs == [test_result1, test_result2]
+    assert prompt.outputs == [test_result1, test_result2]
 
-def test_add_empty_outputs_to_prompt(ai_config_runtime: AIConfigRuntime):
-    """Test for adding an empty output to an existing prompt with/without overwriting using add_ouputs."""
-    prompt1 = Prompt(
+def test_add_undefined_outputs_to_prompt(ai_config_runtime: AIConfigRuntime):
+    """Test for adding undefined outputs to an existing prompt with/without overwriting. Should result in an error."""
+    prompt = Prompt(
         name="GreetingPrompt",
         input="Hello, how are you?",
         metadata=PromptMetadata(model="fakemodel"),
     )
-    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    ai_config_runtime.add_prompt(prompt.name, prompt)
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == None
-    # Case 1: No outputs, no overwrite
+    # Case 1: No outputs, overwrite param not defined
     with pytest.raises(
-        Exception,
+        ValueError,
         match=r"Cannot add outputs. No outputs provided for prompt 'GreetingPrompt'.",
     ):
         ai_config_runtime.add_outputs("GreetingPrompt", [])
-    # Case 2: No outputs, with overwrite
+    # Case 2: No outputs, overwrite param set to True
     with pytest.raises(
-        Exception,
+        ValueError,
         match=r"Cannot add outputs. No outputs provided for prompt 'GreetingPrompt'.",
     ):
         ai_config_runtime.add_outputs("GreetingPrompt", [], True)

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -657,6 +657,28 @@ def test_add_outputs_existing_prompt_with_overwrite(ai_config_runtime: AIConfigR
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result2
     assert prompt1.outputs == [test_result1, test_result2]
 
+def test_add_empty_outputs_to_prompt(ai_config_runtime: AIConfigRuntime):
+    """Test for adding an empty output to an existing prompt with/without overwriting using add_ouputs."""
+    prompt1 = Prompt(
+        name="GreetingPrompt",
+        input="Hello, how are you?",
+        metadata=PromptMetadata(model="fakemodel"),
+    )
+    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == None
+    # Case 1: No outputs, no overwrite
+    with pytest.raises(
+        Exception,
+        match=r"Cannot add outputs. No outputs provided for prompt 'GreetingPrompt'.",
+    ):
+        ai_config_runtime.add_outputs("GreetingPrompt", [])
+    # Case 2: No outputs, with overwrite
+    with pytest.raises(
+        Exception,
+        match=r"Cannot add outputs. No outputs provided for prompt 'GreetingPrompt'.",
+    ):
+        ai_config_runtime.add_outputs("GreetingPrompt", [], True)
+
 def test_extract_override_settings(ai_config_runtime: AIConfigRuntime):
     initial_settings = {"topP": 0.9}
 

--- a/python/tests/test_programmatically_create_an_AIConfig.py
+++ b/python/tests/test_programmatically_create_an_AIConfig.py
@@ -587,6 +587,75 @@ def test_add_output_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRunt
 
     assert ai_config_runtime.get_latest_output("GreetingPrompt") == None
 
+def test_add_outputs_existing_prompt_no_overwrite(ai_config_runtime: AIConfigRuntime):
+    """Test adding outputs to an existing prompt without overwriting."""
+    base_result = ExecuteResult(
+        output_type="execute_result",
+        execution_count=0.0,
+        data={"role": "assistant", "content": "base output"},
+        metadata={"finish_reason": "stop"},)
+    prompt1 = Prompt(
+        name="GreetingPrompt",
+        input="Hello, how are you?",
+        metadata=PromptMetadata(model="fakemodel"),
+        outputs=[base_result],
+    )
+    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == base_result
+
+    test_result1 = ExecuteResult(
+        output_type="execute_result",
+        execution_count=0.0,
+        data={"role": "assistant", "content": "test output 1"},
+        metadata={"finish_reason": "stop"},
+    )
+
+    test_result2 = ExecuteResult(
+        output_type="execute_result",
+        execution_count=0.0,
+        data={"role": "assistant", "content": "test output 2"},
+        metadata={"finish_reason": "stop"},
+    )
+    ai_config_runtime.add_outputs("GreetingPrompt", [test_result1, test_result2])
+
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result2
+    assert prompt1.outputs == [base_result, test_result1, test_result2]
+
+def test_add_outputs_existing_prompt_with_overwrite(ai_config_runtime: AIConfigRuntime):
+    """Test adding outputs to an existing prompt with overwriting."""
+    base_result = ExecuteResult(
+        output_type="execute_result",
+        execution_count=0.0,
+        data={"role": "assistant", "content": "base output"},
+        metadata={"finish_reason": "stop"},)
+    prompt1 = Prompt(
+        name="GreetingPrompt",
+        input="Hello, how are you?",
+        metadata=PromptMetadata(model="fakemodel"),
+        outputs=[base_result],
+    )
+    ai_config_runtime.add_prompt(prompt1.name, prompt1)
+    
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == base_result
+
+    test_result1 = ExecuteResult(
+        output_type="execute_result",
+        execution_count=0.0,
+        data={"role": "assistant", "content": "test output 1"},
+        metadata={"finish_reason": "stop"},
+    )
+
+    test_result2 = ExecuteResult(
+        output_type="execute_result",
+        execution_count=0.0,
+        data={"role": "assistant", "content": "test output 2"},
+        metadata={"finish_reason": "stop"},
+    )
+    ai_config_runtime.add_outputs("GreetingPrompt", [test_result1, test_result2], True)
+
+    assert ai_config_runtime.get_latest_output("GreetingPrompt") == test_result2
+    assert prompt1.outputs == [test_result1, test_result2]
 
 def test_extract_override_settings(ai_config_runtime: AIConfigRuntime):
     initial_settings = {"topP": 0.9}


### PR DESCRIPTION
Summary:
This pull request adds ability to add multiple outputs to prompt for Python SDK.

Changes Made:
Added the add_outputs method to add multiple outputs to a prompt.

Related Issues:
Closes #153

Test Plan:
- [x] Test to check that multiple outputs can be added to prompt `test_add_outputs_existing_prompt_no_overwrite`.
- [x] Test to check that `add_outputs` support prompt output overwriting `test_add_outputs_existing_prompt_overwrite`.
- [x] Test to check that exception is raised if `add_outputs` is invoked with empty list or no outputs `test_add_empty_outputs_to_prompt`.