### PR TITLE
[editor] Starting Point for Remaining Prompt Schemas

### DIFF
--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -44,9 +44,46 @@ export function getPromptModelName(
 //   - we can focus on the important 3 params defined above, instead of requiring re-definining the full JSON schema
 // Should we define a JSON schema for PromptSchema type so we can safely serialize/deserialize them?
 export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
-  "gpt-3.5-turbo": OpenAIChatModelParserPromptSchema,
+  // OpenAIChatModelParser
   "gpt-4": OpenAIChatModelParserPromptSchema,
+  "gpt-4-0314": OpenAIChatModelParserPromptSchema,
+  "gpt-4-0613": OpenAIChatModelParserPromptSchema,
+  "gpt-4-32k": OpenAIChatModelParserPromptSchema,
+  "gpt-4-32k-0314": OpenAIChatModelParserPromptSchema,
+  "gpt-4-32k-0613": OpenAIChatModelParserPromptSchema,
+  "gpt-3.5-turbo": OpenAIChatModelParserPromptSchema,
+  "gpt-3.5-turbo-16k": OpenAIChatModelParserPromptSchema,
+  "gpt-3.5-turbo-0301": OpenAIChatModelParserPromptSchema,
+  "gpt-3.5-turbo-0613": OpenAIChatModelParserPromptSchema,
+  "gpt-3.5-turbo-16k-0613": OpenAIChatModelParserPromptSchema,
+
+  // TODO: Add GPT4-V parser in AIConfig
   "gpt-4-vision-preview": OpenAIChatVisionModelParserPromptSchema,
+
+  // OpenAIModelParser
+  // "babbage-002":
+  // "davinci-002":
+  // "gpt-3.5-turbo-instruct":
+  // "text-davinci-003":
+  // "text-davinci-002":
+  // "text-davinci-001":
+  // "code-davinci-002":
+  // "text-curie-001":
+  // "text-babbage-001":
+  // "text-ada-001":
+
+  // DalleImageGenerationParser
+  // "dalle-e-2":
+  // "dall-e-3":
+
+  // HuggingFaceTextGenerationParser
+  // "HuggingFaceTextGenerationParser":
+
+  // PaLMTextParser
+  // "models/text-bison-001":
+
+  // PaLMChatParser
+  // "models/chat-bison-001":
 };
 
 export type PromptInputSchema =


### PR DESCRIPTION
# [editor] Starting Point for Remaining Prompt Schemas

Copy over all the default models to the temporary mapping of models to prompt schemas and apply the existing `OpenAIChatModelParserPromptSchema` to all models supported by the `OpenAIChatModelParser`. Subsequent PRs should implement the prompt schemas for the remaining parsers and uncomment the models to add the mapping.

Fast-following after MVP:
- define these schemas in python as static reference on the relevant model parser classes
- implement an endpoint get_prompt_schemas for the client to call and get a list of static prompt schemas (to be JSON parsed into objects on the client) and the mapping of model->schema to use for referencing

## Testing:
- Create a new prompt with gpt-4-0613 and ensure correct settings UI
- Toggle to some other gpt chat variants and ensure correct settings UI
