### PR TITLE
Create set_parameters endpoint

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Any, Dict, Type, Union
 
@@ -258,6 +259,20 @@ def set_parameter() -> FlaskResponse:
         OpArgs({"parameter_name": parameter_name, "parameter_value": parameter_value, "prompt_name": prompt_name})
     )
     return run_aiconfig_operation_with_op_args(aiconfig, "set_parameter", operation, operation_args)
+
+
+@app.route("/api/set_parameters", methods=["POST"])
+def set_parameters() -> FlaskResponse:
+    state = get_server_state(app)
+    aiconfig = state.aiconfig
+    request_json = request.get_json()
+
+    parameters: Dict[str, Any] = request_json.get("parameters")
+    prompt_name: str | None = request_json.get("prompt_name")
+
+    operation = make_op_run_method(MethodName("set_parameters"))
+    operation_args: Result[OpArgs, str] = result.Ok(OpArgs({"parameters": parameters, "prompt_name": prompt_name}))
+    return run_aiconfig_operation_with_op_args(aiconfig, "set_parameters", operation, operation_args)
 
 
 @app.route("/api/delete_parameter", methods=["POST"])


### PR DESCRIPTION
Create set_parameters endpoint

Created a new method in SDK called `set_parameters` that iterates through a hash table and calls `set_parameter` on each parameter key-value pair

## Test Plan

```
curl http://localhost:8080/api/set_parameters -d '{"prompt_name":"get_activities", "parameters": {"city":"New York", "sort_by":"geographical_location"}}' -X POST -H 'Content-Type: application/json'
```


https://github.com/lastmile-ai/aiconfig/assets/151060367/979f1e5c-437b-4a33-80cc-cb6fcda13c02


