### PR TITLE
[editor] Set isRunning on RunPromptButton in Settings Drawer

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
@@ -88,7 +88,11 @@ export default memo(function PromptActionBar({
               )}
             </Tabs>
           </Container>
-          <RunPromptButton runPrompt={onRunPrompt} size="full" />
+          <RunPromptButton
+            isRunning={prompt._ui.isRunning}
+            runPrompt={onRunPrompt}
+            size="full"
+          />
         </>
       ) : (
         <Flex direction="column" justify="space-between" h="100%">
@@ -98,8 +102,8 @@ export default memo(function PromptActionBar({
             </ActionIcon>
           </Flex>
           <RunPromptButton
-            runPrompt={onRunPrompt}
             isRunning={prompt._ui.isRunning}
+            runPrompt={onRunPrompt}
             size="compact"
           />
         </Flex>


### PR DESCRIPTION
[editor] Set isRunning on RunPromptButton in Settings Drawer

# [editor] Set isRunning on RunPromptButton in Settings Drawer

Previously, the RunPromptButton within the expanded action bar was clickable when running the prompt, so just pass the isRunning prop to fix:

https://github.com/lastmile-ai/aiconfig/assets/5060851/408ac180-d3ef-4fe7-bd10-b476081a11a0

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/709).
* #710
* __->__ #709