### PR TITLE
[editor] Connect Prompt Name to /update_prompt

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -122,8 +122,19 @@ export default function EditorContainer({
   const debouncedUpdatePrompt = useMemo(
     () =>
       debounce(
-        (promptName: string, newPrompt: Prompt) =>
-          updatePromptCallback(promptName, newPrompt),
+        async (
+          promptName: string,
+          newPrompt: Prompt,
+          onSuccess?: (aiconfigRes: AIConfig) => void
+        ) => {
+          const serverConfigRes = await updatePromptCallback(
+            promptName,
+            newPrompt
+          );
+          if (serverConfigRes && onSuccess) {
+            onSuccess(serverConfigRes.aiconfig);
+          }
+        },
         DEBOUNCE_MS
       ),
     [updatePromptCallback]
@@ -146,22 +157,23 @@ export default function EditorContainer({
         }
         const prompt = clientPromptToAIConfigPrompt(statePrompt);
 
-        const serverConfigRes = await debouncedUpdatePrompt(prompt.name, {
-          ...prompt,
-          input: newPromptInput,
-        });
-
-        if (serverConfigRes) {
-          dispatch({
-            type: "CONSOLIDATE_AICONFIG",
-            action,
-            config: serverConfigRes.aiconfig,
-          });
-        }
+        await debouncedUpdatePrompt(
+          prompt.name,
+          {
+            ...prompt,
+            input: newPromptInput,
+          },
+          (serverConfigRes) =>
+            dispatch({
+              type: "CONSOLIDATE_AICONFIG",
+              action,
+              config: serverConfigRes.aiconfig,
+            })
+        );
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : null;
         showNotification({
-          title: "Error adding prompt to config",
+          title: "Error updating prompt input",
           message,
           color: "red",
         });
@@ -172,15 +184,39 @@ export default function EditorContainer({
 
   const onChangePromptName = useCallback(
     async (promptId: string, newName: string) => {
-      const action: AIConfigReducerAction = {
-        type: "UPDATE_PROMPT_NAME",
-        id: promptId,
-        name: newName,
-      };
+      try {
+        const statePrompt = getPrompt(stateRef.current, promptId);
+        if (!statePrompt) {
+          throw new Error(`Could not find prompt with id ${promptId}`);
+        }
+        const prompt = clientPromptToAIConfigPrompt(statePrompt);
 
-      dispatch(action);
+        await debouncedUpdatePrompt(
+          prompt.name,
+          {
+            ...prompt,
+            name: newName,
+          },
+          // PromptName component maintains local state for the name to show in the UI
+          // We cannot update client config state until the name is successfully set server-side
+          // or else we could end up referencing a prompt name that is not set server-side
+          () =>
+            dispatch({
+              type: "UPDATE_PROMPT_NAME",
+              id: promptId,
+              name: newName,
+            })
+        );
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : null;
+        showNotification({
+          title: "Error updating prompt name",
+          message,
+          color: "red",
+        });
+      }
     },
-    [dispatch]
+    [debouncedUpdatePrompt]
   );
 
   const updateModelCallback = callbacks.updateModel;

--- a/python/src/aiconfig/editor/client/src/utils/constants.ts
+++ b/python/src/aiconfig/editor/client/src/utils/constants.ts
@@ -1,1 +1,1 @@
-export const DEBOUNCE_MS = 250;
+export const DEBOUNCE_MS = 300;


### PR DESCRIPTION
[editor] Connect Prompt Name to /update_prompt

# [editor] Connect Prompt Name to /update_prompt

Connect the onChangePromptName callback to the server with /update_prompt request. Note the special handling here:
Since most AIConfig API methods depend on unique prompt names, we can't update the prompt name in the config on every change (or else we could end up using a not-yet-existing prompt name for other actions). Instead, we maintain the prompt name input in the client side prompt name component state and then update the client AIConfig state after the response has returned successfully.

Note: Realized as part of this that the debounce value returns the prev debounce result, so we actually need to handle the async response dispatch event with a callback to the debounce function.

## Testing:
Make sure updating prompt name works now

https://github.com/lastmile-ai/aiconfig/assets/5060851/55da5642-9b36-44f4-aab1-0c461efab7a8

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/710).
* #716
* #715
* __->__ #710