### PR TITLE
llama guard parser not working with local editor

### DIFF
--- a/testllama/llama_registry.py
+++ b/testllama/llama_registry.py
@@ -1,0 +1,8 @@
+from aiconfig import AIConfigRuntime
+from aiconfig_extension_llama_guard import LLamaGuardParser
+from aiconfig.registry import ModelParserRegistry
+
+
+def register_model_parsers() -> None:
+    llama_model_parser = LLamaGuardParser()
+    AIConfigRuntime.register_model_parser(llama_model_parser, llama_model_parser.id())


### PR DESCRIPTION
llama guard parser not working with local editor

This is how I invoked local editor:

> aiconfig edit --aiconfig-path=$aiconfig_path --server-port=8080 --server-mode=debug_servers --parsers-module-path="/Users/saqadri/lm/aiconfig/testllama/llama_registry.py"

To install llama-guard extension, I did:
> pip install aiconfig-extension-llama-guard

(need to have aiconfig installed as well)
