### PR TITLE
[editor] Persist Setting Params

### DIFF
--- a/python/src/aiconfig/editor/client/src/Editor.tsx
+++ b/python/src/aiconfig/editor/client/src/Editor.tsx
@@ -2,7 +2,7 @@ import EditorContainer, {
   AIConfigCallbacks,
 } from "./components/EditorContainer";
 import { Flex, Loader, MantineProvider } from "@mantine/core";
-import { AIConfig, InferenceSettings, Prompt } from "aiconfig";
+import { AIConfig, InferenceSettings, JSONObject, Prompt } from "aiconfig";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ufetch } from "ufetch";
 import { ROUTE_TABLE } from "./utils/api";
@@ -99,6 +99,16 @@ export default function Editor() {
     });
   }, []);
 
+  const setParameters = useCallback(
+    async (parameters: JSONObject, promptName?: string) => {
+      return await ufetch.post(ROUTE_TABLE.SET_PARAMETERS, {
+        parameters,
+        prompt_name: promptName,
+      });
+    },
+    []
+  );
+
   const callbacks: AIConfigCallbacks = useMemo(
     () => ({
       addPrompt,
@@ -108,6 +118,7 @@ export default function Editor() {
       save,
       setConfigDescription,
       setConfigName,
+      setParameters,
       updateModel,
       updatePrompt,
     }),
@@ -119,6 +130,7 @@ export default function Editor() {
       save,
       setConfigDescription,
       setConfigName,
+      setParameters,
       updateModel,
       updatePrompt,
     ]

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -46,6 +46,7 @@ export type AIConfigCallbacks = {
   save: (aiconfig: AIConfig) => Promise<void>;
   setConfigDescription: (description: string) => Promise<void>;
   setConfigName: (name: string) => Promise<void>;
+  setParameters: (parameters: JSONObject, promptName?: string) => Promise<void>;
   updateModel: (value: {
     modelName?: string;
     settings?: InferenceSettings;
@@ -262,15 +263,36 @@ export default function EditorContainer({
     [dispatch, debouncedUpdateModel]
   );
 
+  const setParametersCallback = callbacks.setParameters;
+  const debouncedSetParameters = useMemo(
+    () =>
+      debounce(
+        (parameters: JSONObject, promptName?: string) =>
+          setParametersCallback(parameters, promptName),
+        DEBOUNCE_MS
+      ),
+    [setParametersCallback]
+  );
+
   const onUpdateGlobalParameters = useCallback(
     async (newParameters: JSONObject) => {
       dispatch({
         type: "UPDATE_GLOBAL_PARAMETERS",
         parameters: newParameters,
       });
-      // TODO: Call server-side endpoint to update global parameters
+
+      try {
+        await debouncedSetParameters(newParameters);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : null;
+        showNotification({
+          title: "Error setting global parameters",
+          message: message,
+          color: "red",
+        });
+      }
     },
-    [dispatch]
+    [debouncedSetParameters, dispatch]
   );
 
   const onUpdatePromptParameters = useCallback(
@@ -280,9 +302,25 @@ export default function EditorContainer({
         id: promptId,
         parameters: newParameters,
       });
-      // TODO: Call server-side endpoint to update prompt parameters
+
+      try {
+        const statePrompt = getPrompt(stateRef.current, promptId);
+        if (!statePrompt) {
+          throw new Error(`Could not find prompt with id ${promptId}`);
+        }
+        await debouncedSetParameters(newParameters, statePrompt.name);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : null;
+        const promptIdentifier =
+          getPrompt(stateRef.current, promptId)?.name ?? promptId;
+        showNotification({
+          title: `Error setting parameters for prompt ${promptIdentifier}`,
+          message: message,
+          color: "red",
+        });
+      }
     },
-    [dispatch]
+    [debouncedSetParameters, dispatch]
   );
 
   const addPromptCallback = callbacks.addPrompt;

--- a/python/src/aiconfig/editor/client/src/utils/api.ts
+++ b/python/src/aiconfig/editor/client/src/utils/api.ts
@@ -14,6 +14,7 @@ export const ROUTE_TABLE = {
   SAVE: urlJoin(API_ENDPOINT, "/save"),
   SET_DESCRIPTION: urlJoin(API_ENDPOINT, "/set_description"),
   SET_NAME: urlJoin(API_ENDPOINT, "/set_name"),
+  SET_PARAMETERS: urlJoin(API_ENDPOINT, "/set_parameters"),
   LOAD: urlJoin(API_ENDPOINT, "/load"),
   LIST_MODELS: urlJoin(API_ENDPOINT, "/list_models"),
   RUN_PROMPT: urlJoin(API_ENDPOINT, "/run"),

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -484,6 +484,17 @@ class AIConfig(BaseModel):
                 parameters dict to. If none is provided, we update the
                 AIConfig-level parameters instead
         """
+        # Clear all existing parameters before setting new ones
+        parameter_names_to_delete = []
+        if prompt_name:
+            prompt = self.get_prompt(prompt_name)
+            parameter_names_to_delete = list(self.get_prompt_parameters(prompt).keys())
+        else:
+            parameter_names_to_delete = list(self.get_global_parameters().keys())
+
+        for parameter_name in parameter_names_to_delete:
+            self.delete_parameter(parameter_name, prompt_name)
+
         for parameter_name, parameter_value in parameters.items():
             self.set_parameter(parameter_name, parameter_value, prompt_name)
 


### PR DESCRIPTION
[editor] Persist Setting Params

[editor] Persist Setting Params

Update the set_parameters implementation to clear existing parameters before setting the new ones (otherwise, we end up with a ton of duplicates). Then, connect the parameters callbacks to the endpoint.

## Testing:
- Set and update global and prompt-level parameters, reload to ensure persisted values server-side:


https://github.com/lastmile-ai/aiconfig/assets/5060851/19b061a3-1cff-4e66-a2fb-43bfe662fd5b
