### PR TITLE
[editor][easy] Remove Confusing 'No Settings Available' Text for Missing Settings Property Renderer

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/SettingsPropertyRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/SettingsPropertyRenderer.tsx
@@ -419,5 +419,5 @@ export default function SettingsPropertyRenderer({
   }
 
   // TODO: Support toggling to monaco JSON editor at top level
-  return propertyControl ?? <Text>No settings available</Text>;
+  return propertyControl ?? null;
 }


### PR DESCRIPTION
# [editor][easy] Remove Confusing 'No Settings Available' Text for Missing Settings Property Renderer

It's confusing to have the 'No settings available' text when there's no renderer available for the type. Instead, just skip renderer for the property for now. We'll add a JSON editor toggle to the settings drawer to allow editing any settings, though it won't benefit from a schema since the prompt schema is not direct 1:1 with JSON schema.

## Before:
![Screenshot 2024-01-02 at 3 13 36 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/59fb39da-4561-4064-856f-0f346cedf8e4)


## After:
![Screenshot 2024-01-02 at 3 13 20 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/144c4a96-b009-4f53-84eb-1a9c72805eee)

