### PR TITLE
[editor] Fix Error Message Handling

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -1,6 +1,6 @@
 import PromptContainer from "./prompt/PromptContainer";
 import { Container, Button, createStyles, Stack, Flex } from "@mantine/core";
-import { showNotification } from "@mantine/notifications";
+import { Notifications, showNotification } from "@mantine/notifications";
 import {
   AIConfig,
   InferenceSettings,
@@ -460,9 +460,19 @@ export default function EditorContainer({
           config: serverConfigRes.aiconfig,
         });
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as { message?: string }).message ?? null;
+
+        // TODO: Add ErrorOutput component to show error instead of notification
+        dispatch({
+          type: "RUN_PROMPT_ERROR",
+          id: promptId,
+          message: message ?? undefined,
+        });
+
+        const promptName = getPrompt(stateRef.current, promptId)?.name;
+
         showNotification({
-          title: "Error running prompt",
+          title: `Error running prompt${promptName ? ` ${promptName}` : ""}`,
           message,
           color: "red",
         });
@@ -540,6 +550,7 @@ export default function EditorContainer({
 
   return (
     <AIConfigContext.Provider value={contextValue}>
+      <Notifications />
       <Container maw="80rem">
         <Flex justify="flex-end" mt="md" mb="xs">
           <Button loading={isSaving} onClick={onSave}>

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -122,8 +122,19 @@ export default function EditorContainer({
   const debouncedUpdatePrompt = useMemo(
     () =>
       debounce(
-        (promptName: string, newPrompt: Prompt) =>
-          updatePromptCallback(promptName, newPrompt),
+        async (
+          promptName: string,
+          newPrompt: Prompt,
+          onSuccess?: (aiconfigRes: AIConfig) => void
+        ) => {
+          const serverConfigRes = await updatePromptCallback(
+            promptName,
+            newPrompt
+          );
+          if (serverConfigRes && onSuccess) {
+            onSuccess(serverConfigRes.aiconfig);
+          }
+        },
         DEBOUNCE_MS
       ),
     [updatePromptCallback]
@@ -146,22 +157,23 @@ export default function EditorContainer({
         }
         const prompt = clientPromptToAIConfigPrompt(statePrompt);
 
-        const serverConfigRes = await debouncedUpdatePrompt(prompt.name, {
-          ...prompt,
-          input: newPromptInput,
-        });
-
-        if (serverConfigRes) {
-          dispatch({
-            type: "CONSOLIDATE_AICONFIG",
-            action,
-            config: serverConfigRes.aiconfig,
-          });
-        }
+        await debouncedUpdatePrompt(
+          prompt.name,
+          {
+            ...prompt,
+            input: newPromptInput,
+          },
+          (serverConfigRes) =>
+            dispatch({
+              type: "CONSOLIDATE_AICONFIG",
+              action,
+              config: serverConfigRes.aiconfig,
+            })
+        );
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : null;
         showNotification({
-          title: "Error adding prompt to config",
+          title: "Error updating prompt input",
           message,
           color: "red",
         });
@@ -172,15 +184,39 @@ export default function EditorContainer({
 
   const onChangePromptName = useCallback(
     async (promptId: string, newName: string) => {
-      const action: AIConfigReducerAction = {
-        type: "UPDATE_PROMPT_NAME",
-        id: promptId,
-        name: newName,
-      };
+      try {
+        const statePrompt = getPrompt(stateRef.current, promptId);
+        if (!statePrompt) {
+          throw new Error(`Could not find prompt with id ${promptId}`);
+        }
+        const prompt = clientPromptToAIConfigPrompt(statePrompt);
 
-      dispatch(action);
+        await debouncedUpdatePrompt(
+          prompt.name,
+          {
+            ...prompt,
+            name: newName,
+          },
+          // PromptName component maintains local state for the name to show in the UI
+          // We cannot update client config state until the name is successfully set server-side
+          // or else we could end up referencing a prompt name that is not set server-side
+          () =>
+            dispatch({
+              type: "UPDATE_PROMPT_NAME",
+              id: promptId,
+              name: newName,
+            })
+        );
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : null;
+        showNotification({
+          title: "Error updating prompt name",
+          message,
+          color: "red",
+        });
+      }
     },
-    [dispatch]
+    [debouncedUpdatePrompt]
   );
 
   const updateModelCallback = callbacks.updateModel;

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -58,6 +58,8 @@ export type AIConfigCallbacks = {
   ) => Promise<{ aiconfig: AIConfig }>;
 };
 
+type RequestCallbackError = { message?: string };
+
 const useStyles = createStyles((theme) => ({
   addPromptRow: {
     borderRadius: "4px",
@@ -107,7 +109,7 @@ export default function EditorContainer({
     try {
       await saveCallback(clientConfigToAIConfig(stateRef.current));
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : null;
+      const message = (err as RequestCallbackError).message ?? null;
       showNotification({
         title: "Error saving",
         message,
@@ -171,7 +173,7 @@ export default function EditorContainer({
             })
         );
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error updating prompt input",
           message,
@@ -256,7 +258,7 @@ export default function EditorContainer({
           promptName: statePrompt.name,
         });
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error updating prompt model settings",
           message,
@@ -285,10 +287,8 @@ export default function EditorContainer({
           modelName: newModel,
           promptName: statePrompt.name,
         });
-
-        // TODO: Consolidate
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error updating prompt model",
           message,
@@ -320,7 +320,7 @@ export default function EditorContainer({
       try {
         await debouncedSetParameters(newParameters);
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error setting global parameters",
           message: message,
@@ -346,7 +346,7 @@ export default function EditorContainer({
         }
         await debouncedSetParameters(newParameters, statePrompt.name);
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as RequestCallbackError).message ?? null;
         const promptIdentifier =
           getPrompt(stateRef.current, promptId)?.name ?? promptId;
         showNotification({
@@ -399,7 +399,7 @@ export default function EditorContainer({
           config: serverConfigRes.aiconfig,
         });
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error adding prompt to config",
           message: message,
@@ -425,7 +425,7 @@ export default function EditorContainer({
         }
         await deletePromptCallback(prompt.name);
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error deleting prompt",
           message,
@@ -460,7 +460,7 @@ export default function EditorContainer({
           config: serverConfigRes.aiconfig,
         });
       } catch (err: unknown) {
-        const message = (err as { message?: string }).message ?? null;
+        const message = (err as RequestCallbackError).message ?? null;
 
         // TODO: Add ErrorOutput component to show error instead of notification
         dispatch({
@@ -496,7 +496,7 @@ export default function EditorContainer({
       try {
         await debouncedSetName(name);
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error setting config name",
           message,
@@ -527,7 +527,7 @@ export default function EditorContainer({
       try {
         await debouncedSetDescription(description);
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error setting config description",
           message,

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -4,7 +4,8 @@ import { AIConfig, JSONObject, PromptInput } from "aiconfig";
 
 export type AIConfigReducerAction =
   | MutateAIConfigAction
-  | ConsolidateAIConfigAction;
+  | ConsolidateAIConfigAction
+  | RunPromptErrorAction;
 
 export type MutateAIConfigAction =
   | AddPromptAction
@@ -39,6 +40,12 @@ export type DeletePromptAction = {
 export type RunPromptAction = {
   type: "RUN_PROMPT";
   id: string;
+};
+
+export type RunPromptErrorAction = {
+  type: "RUN_PROMPT_ERROR";
+  id: string;
+  message?: string;
 };
 
 export type SetDescriptionAction = {
@@ -201,6 +208,15 @@ export default function aiconfigReducer(
         _ui: {
           ...prompt._ui,
           isRunning: true,
+        },
+      }));
+    }
+    case "RUN_PROMPT_ERROR": {
+      return reduceReplacePrompt(state, action.id, (prompt) => ({
+        ...prompt,
+        _ui: {
+          ...prompt._ui,
+          isRunning: false,
         },
       }));
     }

--- a/python/src/aiconfig/editor/client/src/utils/constants.ts
+++ b/python/src/aiconfig/editor/client/src/utils/constants.ts
@@ -1,1 +1,1 @@
-export const DEBOUNCE_MS = 250;
+export const DEBOUNCE_MS = 300;


### PR DESCRIPTION
[editor] Fix Error Message Handling

# [editor] Fix Error Message Handling

Just update the error type to not rely on being an instance of `Error`, and just to use the {message?: string} type

## Testing:
- Intentionally raise error in /save `return HttpResponseWithAIConfig(message="ERROR", code=500, aiconfig=None).to_flask_format()` then attempt to save & see correct error notification

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/716).
* __->__ #716
* #715
* #710