### PR TITLE
[editor] Add DalleImageGenerationParserPromptSchema

### DIFF
--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/DalleImageGenerationParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/DalleImageGenerationParserPromptSchema.ts
@@ -1,0 +1,36 @@
+import { PromptSchema } from "../../utils/promptUtils";
+
+export const DalleImageGenerationParserPromptSchema: PromptSchema = {
+  // See /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/openai/resources/images.py
+  // for supported settings
+
+  input: {
+    type: "string",
+  },
+  model_settings: {
+    type: "object",
+    properties: {
+      n: {
+        type: "integer",
+        minimum: 1,
+        maximum: 10,
+      },
+      quality: {
+        type: "string",
+        enum: ["standard", "hd"],
+      },
+      response_format: {
+        type: "string",
+        enum: ["url", "b64_json"],
+      },
+      size: {
+        type: "string",
+        enum: ["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"],
+      },
+      style: {
+        type: "string",
+        enum: ["vivid", "natural"],
+      },
+    },
+  },
+};

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -1,6 +1,7 @@
 import { JSONObject, JSONValue, Prompt } from "aiconfig";
 import { OpenAIChatModelParserPromptSchema } from "../shared/prompt_schemas/OpenAIChatModelParserPromptSchema";
 import { OpenAIChatVisionModelParserPromptSchema } from "../shared/prompt_schemas/OpenAIChatVisionModelParserPromptSchema";
+import { DalleImageGenerationParserPromptSchema } from "../shared/prompt_schemas/DalleImageGenerationParserPromptSchema";
 
 /**
  * Get the name of the model for the specified prompt. The name will either be specified in the prompt's
@@ -60,21 +61,9 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   // TODO: Add GPT4-V parser in AIConfig
   "gpt-4-vision-preview": OpenAIChatVisionModelParserPromptSchema,
 
-  // OpenAIModelParser
-  // "babbage-002":
-  // "davinci-002":
-  // "gpt-3.5-turbo-instruct":
-  // "text-davinci-003":
-  // "text-davinci-002":
-  // "text-davinci-001":
-  // "code-davinci-002":
-  // "text-curie-001":
-  // "text-babbage-001":
-  // "text-ada-001":
-
   // DalleImageGenerationParser
-  // "dalle-e-2":
-  // "dall-e-3":
+  "dall-e-2": DalleImageGenerationParserPromptSchema,
+  "dall-e-3": DalleImageGenerationParserPromptSchema,
 
   // HuggingFaceTextGenerationParser
   // "HuggingFaceTextGenerationParser":


### PR DESCRIPTION
[editor] Add DalleImageGenerationParserPromptSchema

# [editor] Add DalleImageGenerationParserPromptSchema

Add the prompt schema for dall-e-2 to match `/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/openai/resources/images.py`:

```
 def generate(
        self,
        *,
        prompt: str,
        model: Union[str, Literal["dall-e-2", "dall-e-3"], None] | NotGiven = NOT_GIVEN,
        n: Optional[int] | NotGiven = NOT_GIVEN,
        quality: Literal["standard", "hd"] | NotGiven = NOT_GIVEN,
        response_format: Optional[Literal["url", "b64_json"]] | NotGiven = NOT_GIVEN,
        size: Optional[Literal["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]] | NotGiven = NOT_GIVEN,
        style: Optional[Literal["vivid", "natural"]] | NotGiven = NOT_GIVEN,
        user: str | NotGiven = NOT_GIVEN,
        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
        # The extra values given here take precedence over values defined on the client or passed to this method.
        extra_headers: Headers | None = None,
        extra_query: Query | None = None,
        extra_body: Body | None = None,
        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
    ) -> ImagesResponse:
```

And supported keys specified in dalle.py:
```
supported_keys = {"model", "n", "quality", "response_format", "size", "style"}
```


<img width="1235" alt="Screenshot 2024-01-02 at 7 20 29 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/bf92287b-a56d-4711-8339-d9b59d4c3564">
