### PR TITLE
[AIC-py][editor] test+prod CLI packaging

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = {file = ["requirements.txt"]}
 "Homepage" = "https://github.com/lastmile-ai/aiconfig"
 "Bug Tracker" = "https://github.com/lastmile-ai/aiconfig/issues"
 
+[project.scripts]
+aiconfig = "aiconfig.scripts.aiconfig_cli:main"
+
 # Black formatting
 [tool.black]
 line-length = 99

--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, Dict, Type, Union
+import webbrowser
 
 import lastmile_utils.lib.core.api as core_utils
 import result
@@ -51,6 +52,11 @@ def run_backend_server(edit_config: EditServerConfig) -> Result[str, str]:
     LOGGER.setLevel(edit_config.log_level)
     LOGGER.info("Edit config: %s", edit_config.model_dump_json())
     LOGGER.info(f"Starting server on http://localhost:{edit_config.server_port}")
+    try:
+        LOGGER.info(f"Opening browser at http://localhost:{edit_config.server_port}")
+        webbrowser.open(f"http://localhost:{edit_config.server_port}")
+    except Exception as e:
+        LOGGER.warning(f"Failed to open browser: {e}. Please open http://localhost:{port} manually.")
 
     app.server_state = ServerState()  # type: ignore
     res_server_state_init = init_server_state(app, edit_config)
@@ -59,7 +65,7 @@ def run_backend_server(edit_config: EditServerConfig) -> Result[str, str]:
             LOGGER.info("Initialized server state")
             debug = edit_config.server_mode in [ServerMode.DEBUG_BACKEND, ServerMode.DEBUG_SERVERS]
             LOGGER.info(f"Running in {edit_config.server_mode} mode")
-            app.run(port=edit_config.server_port, debug=debug, use_reloader=True)
+            app.run(port=edit_config.server_port, debug=debug, use_reloader=debug)
             return Ok("Done")
         case Err(e):
             LOGGER.error(f"Failed to initialize server state: {e}")

--- a/python/src/aiconfig/editor/server/server_utils.py
+++ b/python/src/aiconfig/editor/server/server_utils.py
@@ -59,7 +59,7 @@ class EditServerConfig(core_utils.Record):
     server_port: int = 8080
     aiconfig_path: str = "my_aiconfig.aiconfig.json"
     log_level: str | int = "INFO"
-    server_mode: ServerMode
+    server_mode: ServerMode = ServerMode.PROD
     parsers_module_path: str = "aiconfig_model_registry.py"
 
     @field_validator("server_mode", mode="before")

--- a/python/src/aiconfig/scripts/aiconfig_cli.py
+++ b/python/src/aiconfig/scripts/aiconfig_cli.py
@@ -21,7 +21,7 @@ logging.basicConfig(format=core_utils.LOGGER_FMT)
 LOGGER = logging.getLogger(__name__)
 
 
-async def main(argv: list[str]) -> int:
+async def main_with_args(argv: list[str]) -> int:
     final_result = run_subcommand(argv)
     match final_result:
         case Ok(msg):
@@ -142,6 +142,12 @@ def _run_frontend_server_background() -> Result[list[subprocess.Popen[bytes]], s
     return Ok([p1, p2])
 
 
+def main() -> int:
+    print("Running main")
+    argv = sys.argv
+    return asyncio.run(main_with_args(argv))
+
+
 if __name__ == "__main__":
-    retcode: int = asyncio.run(main(sys.argv))
+    retcode: int = main()
     sys.exit(retcode)


### PR DESCRIPTION
[AIC-py][editor] test+prod CLI packaging

This bundles a few simple changes to make CLI installation and usage easier.
The main thing is adding the aiconfig script to the build config, which is tested
using a test pypi package.

- test publish script
- add script to build file that runs cli main
  - had to refactor main slightly to enable this
- open in browser on server start
- only reload server in debug mode
- default prod server mode so you dont have to give it at cli

I built python-aiconfig-test 1.1.22. Install:

`pip3 install --index-url https://test.pypi.org/simple --extra-index-url https://pypi.org/simple python-aiconfig-test==1.1.22 --force`

Run:

`aiconfig edit`

Editor opens in browser
