### PR TITLE
[editor][hotfix] Fix Debounced Update Prompt Callback

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -169,7 +169,7 @@ export default function EditorContainer({
             dispatch({
               type: "CONSOLIDATE_AICONFIG",
               action,
-              config: serverConfigRes.aiconfig,
+              config: serverConfigRes,
             })
         );
       } catch (err: unknown) {


### PR DESCRIPTION
# [editor][hotfix] Fix Debounced Update Prompt Callback

Was incorrectly indexing .aiconfig from the resulting aiconfig (which types fine since AIConfig is completely open)
