### PR TITLE
[editor] Debounced Error Handling for Config Name and Description

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -542,7 +542,14 @@ export default function EditorContainer({
 
   const setNameCallback = callbacks.setConfigName;
   const debouncedSetName = useMemo(
-    () => debounce((name: string) => setNameCallback(name), DEBOUNCE_MS),
+    () =>
+      debounce(async (name: string, onError: (err: unknown) => void) => {
+        try {
+          await setNameCallback(name);
+        } catch (err: unknown) {
+          onError(err);
+        }
+      }, DEBOUNCE_MS),
     [setNameCallback]
   );
 
@@ -552,16 +559,15 @@ export default function EditorContainer({
         type: "SET_NAME",
         name,
       });
-      try {
-        await debouncedSetName(name);
-      } catch (err: unknown) {
+
+      await debouncedSetName(name, (err: unknown) => {
         const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error setting config name",
           message,
           color: "red",
         });
-      }
+      });
     },
     [debouncedSetName]
   );
@@ -569,10 +575,13 @@ export default function EditorContainer({
   const setDescriptionCallback = callbacks.setConfigDescription;
   const debouncedSetDescription = useMemo(
     () =>
-      debounce(
-        (description: string) => setDescriptionCallback(description),
-        DEBOUNCE_MS
-      ),
+      debounce(async (description: string, onError: (err: unknown) => void) => {
+        try {
+          await setDescriptionCallback(description);
+        } catch (err: unknown) {
+          onError(err);
+        }
+      }, DEBOUNCE_MS),
     [setDescriptionCallback]
   );
 
@@ -583,16 +592,14 @@ export default function EditorContainer({
         description,
       });
 
-      try {
-        await debouncedSetDescription(description);
-      } catch (err: unknown) {
+      await debouncedSetDescription(description, (err: unknown) => {
         const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error setting config description",
           message,
           color: "red",
         });
-      }
+      });
     },
     [debouncedSetDescription]
   );

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -197,7 +197,7 @@ export default function EditorContainer({
   const onChangePromptName = useCallback(
     async (promptId: string, newName: string) => {
       const onError = (err: unknown) => {
-        const message = err instanceof Error ? err.message : null;
+        const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error updating prompt name",
           message,

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -341,8 +341,17 @@ export default function EditorContainer({
   const debouncedSetParameters = useMemo(
     () =>
       debounce(
-        (parameters: JSONObject, promptName?: string) =>
-          setParametersCallback(parameters, promptName),
+        async (
+          parameters: JSONObject,
+          promptName?: string,
+          onError?: (err: unknown) => void
+        ) => {
+          try {
+            await setParametersCallback(parameters, promptName);
+          } catch (err: unknown) {
+            onError?.(err);
+          }
+        },
         DEBOUNCE_MS
       ),
     [setParametersCallback]
@@ -355,15 +364,23 @@ export default function EditorContainer({
         parameters: newParameters,
       });
 
-      try {
-        await debouncedSetParameters(newParameters);
-      } catch (err: unknown) {
+      const onError = (err: unknown) => {
         const message = (err as RequestCallbackError).message ?? null;
         showNotification({
           title: "Error setting global parameters",
           message: message,
           color: "red",
         });
+      };
+
+      try {
+        await debouncedSetParameters(
+          newParameters,
+          undefined /* promptName */,
+          onError
+        );
+      } catch (err: unknown) {
+        onError(err);
       }
     },
     [debouncedSetParameters, dispatch]
@@ -377,13 +394,7 @@ export default function EditorContainer({
         parameters: newParameters,
       });
 
-      try {
-        const statePrompt = getPrompt(stateRef.current, promptId);
-        if (!statePrompt) {
-          throw new Error(`Could not find prompt with id ${promptId}`);
-        }
-        await debouncedSetParameters(newParameters, statePrompt.name);
-      } catch (err: unknown) {
+      const onError = (err: unknown) => {
         const message = (err as RequestCallbackError).message ?? null;
         const promptIdentifier =
           getPrompt(stateRef.current, promptId)?.name ?? promptId;
@@ -392,6 +403,16 @@ export default function EditorContainer({
           message: message,
           color: "red",
         });
+      };
+
+      try {
+        const statePrompt = getPrompt(stateRef.current, promptId);
+        if (!statePrompt) {
+          throw new Error(`Could not find prompt with id ${promptId}`);
+        }
+        await debouncedSetParameters(newParameters, statePrompt.name, onError);
+      } catch (err: unknown) {
+        onError(err);
       }
     },
     [debouncedSetParameters, dispatch]


### PR DESCRIPTION
# [editor] Debounced Error Handling for Config Name and Description

`debounced` callbacks won't propagate thrown errors so we should use an `onError` callback to handle those. This PR handles them for updating config name and description.

## Testing:
- Update /set_name endpoint to return error:
```
return HttpResponseWithAIConfig(
        #
        message=f"Failed to set name (TEST)",
        code=500,
        aiconfig=None,
    ).to_flask_format()
```
- Update /set_description endpoint to return error:
```
return HttpResponseWithAIConfig(
        #
        message=f"Failed to set description (TEST)",
        code=500,
        aiconfig=None,
    ).to_flask_format()
```

See notifications:

https://github.com/lastmile-ai/aiconfig/assets/5060851/b1299566-ad16-4d8a-ad91-702d0b163393


---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/728).
* __->__ #728
* #727
* #726
* #725