### PR TITLE
[editor][easy] Remove gpt4-v example prompt

### DIFF
--- a/python/src/aiconfig/editor/travel.aiconfig.json
+++ b/python/src/aiconfig/editor/travel.aiconfig.json
@@ -91,30 +91,6 @@
           }
         }
       ]
-    },
-    {
-      "name": "image_prompt",
-      "input": {
-        "attachments": [
-          {
-            "data": "https://s3.amazonaws.com/files.uploads.lastmileai.com/uploads/cldxsqbel0000qs8owp8mkd0z/2023_12_1_21_23_24/942/Screenshot 2023-11-28 at 11.11.25 AM.png",
-            "mime_type": "image/png"
-          },
-          {
-            "data": "https://s3.amazonaws.com/files.uploads.lastmileai.com/uploads/cldxsqbel0000qs8owp8mkd0z/2023_12_1_21_23_24/8325/Screenshot 2023-11-28 at 1.51.52 PM.png",
-            "mime_type": "image/png"
-          }
-        ],
-        "data": "What do these images show?"
-      },
-      "metadata": {
-        "model": {
-          "name": "gpt-4-vision-preview",
-          "settings": {}
-        },
-        "parameters": {}
-      },
-      "outputs": []
     }
   ],
   "$schema": "https://json.schemastore.org/aiconfig-1.0"


### PR DESCRIPTION
# [editor][easy] Remove gpt4-v example prompt

This prompt was just being used for getting the PromptSchema rendering figured out and is no longer needed since we don't actually support gpt4-v as a default model yet. It just added confusion due to errors when running
