### PR TITLE
[editor] Add 'dirty' Config State

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigContext.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigContext.tsx
@@ -8,7 +8,7 @@ import { ClientAIConfig } from "../shared/types";
 const AIConfigContext = createContext<{
   getState: () => ClientAIConfig;
 }>({
-  getState: () => ({ prompts: [] }),
+  getState: () => ({ prompts: [], _ui: { isDirty: false } }),
 });
 
 export default AIConfigContext;

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -1,5 +1,12 @@
 import PromptContainer from "./prompt/PromptContainer";
-import { Container, Button, createStyles, Stack, Flex } from "@mantine/core";
+import {
+  Container,
+  Button,
+  createStyles,
+  Stack,
+  Flex,
+  Tooltip,
+} from "@mantine/core";
 import { Notifications, showNotification } from "@mantine/notifications";
 import {
   AIConfig,
@@ -28,6 +35,7 @@ import AIConfigContext from "./AIConfigContext";
 import ConfigNameDescription from "./ConfigNameDescription";
 import { DEBOUNCE_MS } from "../utils/constants";
 import { getPromptModelName } from "../utils/promptUtils";
+import { IconDeviceFloppy } from "@tabler/icons-react";
 
 type Props = {
   aiconfig: AIConfig;
@@ -108,6 +116,9 @@ export default function EditorContainer({
     setIsSaving(true);
     try {
       await saveCallback(clientConfigToAIConfig(stateRef.current));
+      dispatch({
+        type: "SAVE_CONFIG_SUCCESS",
+      });
     } catch (err: unknown) {
       const message = (err as RequestCallbackError).message ?? null;
       showNotification({
@@ -614,14 +625,27 @@ export default function EditorContainer({
     [getState]
   );
 
+  const isDirty = aiconfigState._ui.isDirty !== false;
+
   return (
     <AIConfigContext.Provider value={contextValue}>
       <Notifications />
       <Container maw="80rem">
         <Flex justify="flex-end" mt="md" mb="xs">
-          <Button loading={isSaving} onClick={onSave}>
-            Save
-          </Button>
+          <Tooltip
+            label={isDirty ? "Save changes to config" : "No unsaved changes"}
+          >
+            <div>
+              <Button
+                leftIcon={<IconDeviceFloppy />}
+                loading={isSaving}
+                onClick={onSave}
+                disabled={!isDirty}
+              >
+                Save
+              </Button>
+            </div>
+          </Tooltip>
         </Flex>
         <ConfigNameDescription
           name={aiconfigState.name}

--- a/python/src/aiconfig/editor/client/src/shared/types.ts
+++ b/python/src/aiconfig/editor/client/src/shared/types.ts
@@ -18,6 +18,9 @@ export type ClientPrompt = Prompt & {
 
 export type ClientAIConfig = Omit<AIConfig, "prompts"> & {
   prompts: ClientPrompt[];
+  _ui: {
+    isDirty?: boolean;
+  };
 };
 
 export function clientPromptToAIConfigPrompt(prompt: ClientPrompt): Prompt {
@@ -30,12 +33,17 @@ export function clientPromptToAIConfigPrompt(prompt: ClientPrompt): Prompt {
 }
 
 export function clientConfigToAIConfig(clientConfig: ClientAIConfig): AIConfig {
-  // For some reason, TS thinks ClientAIConfig is missing properties from
-  // AIConfig, so we have to cast it
-  return {
+  const config = {
     ...clientConfig,
     prompts: clientConfig.prompts.map(clientPromptToAIConfigPrompt),
-  } as unknown as AIConfig;
+    _ui: undefined,
+  };
+
+  delete config._ui;
+
+  // For some reason, TS thinks ClientAIConfig is missing properties from
+  // AIConfig, so we have to cast it
+  return config as unknown as AIConfig;
 }
 
 export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
@@ -47,5 +55,8 @@ export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
         id: uniqueId(),
       },
     })),
+    _ui: {
+      isDirty: false,
+    },
   };
 }


### PR DESCRIPTION
[editor] Add 'dirty' Config State

# [editor] Add 'dirty' Config State

Update the client-side config _ui state to maintain `isDirty` state, which is set to true whenever a client-side config mutation happens and then set to false whenever a successful config save happens. Use this value to disable the button and show appropriate tooltip


https://github.com/lastmile-ai/aiconfig/assets/5060851/dfcb57bd-282d-4622-bd10-ec4a281c213c

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/733).
* #735
* #734
* __->__ #733