### PR TITLE
[editor] Autosave at 15s Interval

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigContext.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigContext.tsx
@@ -8,7 +8,7 @@ import { ClientAIConfig } from "../shared/types";
 const AIConfigContext = createContext<{
   getState: () => ClientAIConfig;
 }>({
-  getState: () => ({ prompts: [] }),
+  getState: () => ({ prompts: [], _ui: { isDirty: false } }),
 });
 
 export default AIConfigContext;

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -15,7 +15,14 @@ import {
   Prompt,
   PromptInput,
 } from "aiconfig";
-import { useCallback, useMemo, useReducer, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import aiconfigReducer, { AIConfigReducerAction } from "./aiconfigReducer";
 import {
   ClientPrompt,
@@ -33,7 +40,7 @@ import PromptMenuButton from "./prompt/PromptMenuButton";
 import GlobalParametersContainer from "./GlobalParametersContainer";
 import AIConfigContext from "./AIConfigContext";
 import ConfigNameDescription from "./ConfigNameDescription";
-import { DEBOUNCE_MS } from "../utils/constants";
+import { AUTOSAVE_INTERVAL_MS, DEBOUNCE_MS } from "../utils/constants";
 import { getPromptModelName } from "../utils/promptUtils";
 import { IconDeviceFloppy } from "@tabler/icons-react";
 
@@ -626,6 +633,16 @@ export default function EditorContainer({
   );
 
   const isDirty = aiconfigState._ui.isDirty !== false;
+  useEffect(() => {
+    if (!isDirty) {
+      return;
+    }
+
+    // Save every 15 seconds if there are unsaved changes
+    const saveInterval = setInterval(onSave, AUTOSAVE_INTERVAL_MS);
+
+    return () => clearInterval(saveInterval);
+  }, [isDirty, onSave]);
 
   return (
     <AIConfigContext.Provider value={contextValue}>

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -1,5 +1,12 @@
 import PromptContainer from "./prompt/PromptContainer";
-import { Container, Button, createStyles, Stack, Flex } from "@mantine/core";
+import {
+  Container,
+  Button,
+  createStyles,
+  Stack,
+  Flex,
+  Tooltip,
+} from "@mantine/core";
 import { Notifications, showNotification } from "@mantine/notifications";
 import {
   AIConfig,
@@ -28,6 +35,7 @@ import AIConfigContext from "./AIConfigContext";
 import ConfigNameDescription from "./ConfigNameDescription";
 import { DEBOUNCE_MS } from "../utils/constants";
 import { getPromptModelName } from "../utils/promptUtils";
+import { IconDeviceFloppy } from "@tabler/icons-react";
 
 type Props = {
   aiconfig: AIConfig;
@@ -108,6 +116,9 @@ export default function EditorContainer({
     setIsSaving(true);
     try {
       await saveCallback(clientConfigToAIConfig(stateRef.current));
+      dispatch({
+        type: "SAVE_CONFIG_SUCCESS",
+      });
     } catch (err: unknown) {
       const message = (err as RequestCallbackError).message ?? null;
       showNotification({
@@ -614,14 +625,27 @@ export default function EditorContainer({
     [getState]
   );
 
+  const isDirty = aiconfigState._ui.isDirty !== false;
+
   return (
     <AIConfigContext.Provider value={contextValue}>
       <Notifications />
       <Container maw="80rem">
         <Flex justify="flex-end" mt="md" mb="xs">
-          <Button loading={isSaving} onClick={onSave}>
-            Save
-          </Button>
+          <Tooltip
+            label={isDirty ? "Save changes to config" : "No unsaved changes"}
+          >
+            <div>
+              <Button
+                leftIcon={<IconDeviceFloppy />}
+                loading={isSaving}
+                onClick={onSave}
+                disabled={!isDirty}
+              >
+                Save
+              </Button>
+            </div>
+          </Tooltip>
         </Flex>
         <ConfigNameDescription
           name={aiconfigState.name}

--- a/python/src/aiconfig/editor/client/src/shared/types.ts
+++ b/python/src/aiconfig/editor/client/src/shared/types.ts
@@ -18,6 +18,9 @@ export type ClientPrompt = Prompt & {
 
 export type ClientAIConfig = Omit<AIConfig, "prompts"> & {
   prompts: ClientPrompt[];
+  _ui: {
+    isDirty?: boolean;
+  };
 };
 
 export function clientPromptToAIConfigPrompt(prompt: ClientPrompt): Prompt {
@@ -30,12 +33,17 @@ export function clientPromptToAIConfigPrompt(prompt: ClientPrompt): Prompt {
 }
 
 export function clientConfigToAIConfig(clientConfig: ClientAIConfig): AIConfig {
-  // For some reason, TS thinks ClientAIConfig is missing properties from
-  // AIConfig, so we have to cast it
-  return {
+  const config = {
     ...clientConfig,
     prompts: clientConfig.prompts.map(clientPromptToAIConfigPrompt),
-  } as unknown as AIConfig;
+    _ui: undefined,
+  };
+
+  delete config._ui;
+
+  // For some reason, TS thinks ClientAIConfig is missing properties from
+  // AIConfig, so we have to cast it
+  return config as unknown as AIConfig;
 }
 
 export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
@@ -47,5 +55,8 @@ export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
         id: uniqueId(),
       },
     })),
+    _ui: {
+      isDirty: false,
+    },
   };
 }

--- a/python/src/aiconfig/editor/client/src/utils/constants.ts
+++ b/python/src/aiconfig/editor/client/src/utils/constants.ts
@@ -1,1 +1,2 @@
 export const DEBOUNCE_MS = 300;
+export const AUTOSAVE_INTERVAL_MS = 15 * 1000; // 15 seconds


### PR DESCRIPTION
[editor] Autosave at 15s Interval

# [editor] Autosave at 15s Interval

Set up an interval to autosave the config every 15s from the client. Note that the interval is technically cleared & recreated each time the `isDirty` state changes, but that's fine because this will also handle the case where changes are made right when a successful save response comes back, or if a save fails (doesn't clear dirty state) another attempt will be made automatically after 15s.

https://github.com/lastmile-ai/aiconfig/assets/5060851/dfcb57bd-282d-4622-bd10-ec4a281c213c

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/734).
* #735
* __->__ #734
* #733