### PR TITLE
[editor] Handle CMD/CTRL + S to Save

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigContext.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigContext.tsx
@@ -8,7 +8,7 @@ import { ClientAIConfig } from "../shared/types";
 const AIConfigContext = createContext<{
   getState: () => ClientAIConfig;
 }>({
-  getState: () => ({ prompts: [] }),
+  getState: () => ({ prompts: [], _ui: { isDirty: false } }),
 });
 
 export default AIConfigContext;

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -644,6 +644,27 @@ export default function EditorContainer({
     return () => clearInterval(saveInterval);
   }, [isDirty, onSave]);
 
+  // Override CMD+s and CTRL+s to save
+  useEffect(() => {
+    const saveHandler = (e: KeyboardEvent) => {
+      // Note platform property to distinguish between CMD and CTRL for
+      // Mac/Windows/Linux is deprecated.
+      // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform
+      // Just handle both for now.
+      if (e.key === "s" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+
+        if (stateRef.current._ui.isDirty) {
+          onSave();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", saveHandler, false);
+
+    return () => window.removeEventListener("keydown", saveHandler);
+  }, [onSave]);
+
   return (
     <AIConfigContext.Provider value={contextValue}>
       <Notifications />

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -15,7 +15,14 @@ import {
   Prompt,
   PromptInput,
 } from "aiconfig";
-import { useCallback, useMemo, useReducer, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import aiconfigReducer, { AIConfigReducerAction } from "./aiconfigReducer";
 import {
   ClientPrompt,
@@ -33,7 +40,7 @@ import PromptMenuButton from "./prompt/PromptMenuButton";
 import GlobalParametersContainer from "./GlobalParametersContainer";
 import AIConfigContext from "./AIConfigContext";
 import ConfigNameDescription from "./ConfigNameDescription";
-import { DEBOUNCE_MS } from "../utils/constants";
+import { AUTOSAVE_INTERVAL_MS, DEBOUNCE_MS } from "../utils/constants";
 import { getPromptModelName } from "../utils/promptUtils";
 import { IconDeviceFloppy } from "@tabler/icons-react";
 
@@ -626,6 +633,16 @@ export default function EditorContainer({
   );
 
   const isDirty = aiconfigState._ui.isDirty !== false;
+  useEffect(() => {
+    if (!isDirty) {
+      return;
+    }
+
+    // Save every 15 seconds if there are unsaved changes
+    const saveInterval = setInterval(onSave, AUTOSAVE_INTERVAL_MS);
+
+    return () => clearInterval(saveInterval);
+  }, [isDirty, onSave]);
 
   return (
     <AIConfigContext.Provider value={contextValue}>

--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -1,5 +1,12 @@
 import PromptContainer from "./prompt/PromptContainer";
-import { Container, Button, createStyles, Stack, Flex } from "@mantine/core";
+import {
+  Container,
+  Button,
+  createStyles,
+  Stack,
+  Flex,
+  Tooltip,
+} from "@mantine/core";
 import { Notifications, showNotification } from "@mantine/notifications";
 import {
   AIConfig,
@@ -28,6 +35,7 @@ import AIConfigContext from "./AIConfigContext";
 import ConfigNameDescription from "./ConfigNameDescription";
 import { DEBOUNCE_MS } from "../utils/constants";
 import { getPromptModelName } from "../utils/promptUtils";
+import { IconDeviceFloppy } from "@tabler/icons-react";
 
 type Props = {
   aiconfig: AIConfig;
@@ -108,6 +116,9 @@ export default function EditorContainer({
     setIsSaving(true);
     try {
       await saveCallback(clientConfigToAIConfig(stateRef.current));
+      dispatch({
+        type: "SAVE_CONFIG_SUCCESS",
+      });
     } catch (err: unknown) {
       const message = (err as RequestCallbackError).message ?? null;
       showNotification({
@@ -614,14 +625,27 @@ export default function EditorContainer({
     [getState]
   );
 
+  const isDirty = aiconfigState._ui.isDirty !== false;
+
   return (
     <AIConfigContext.Provider value={contextValue}>
       <Notifications />
       <Container maw="80rem">
         <Flex justify="flex-end" mt="md" mb="xs">
-          <Button loading={isSaving} onClick={onSave}>
-            Save
-          </Button>
+          <Tooltip
+            label={isDirty ? "Save changes to config" : "No unsaved changes"}
+          >
+            <div>
+              <Button
+                leftIcon={<IconDeviceFloppy />}
+                loading={isSaving}
+                onClick={onSave}
+                disabled={!isDirty}
+              >
+                Save
+              </Button>
+            </div>
+          </Tooltip>
         </Flex>
         <ConfigNameDescription
           name={aiconfigState.name}

--- a/python/src/aiconfig/editor/client/src/shared/types.ts
+++ b/python/src/aiconfig/editor/client/src/shared/types.ts
@@ -18,6 +18,9 @@ export type ClientPrompt = Prompt & {
 
 export type ClientAIConfig = Omit<AIConfig, "prompts"> & {
   prompts: ClientPrompt[];
+  _ui: {
+    isDirty?: boolean;
+  };
 };
 
 export function clientPromptToAIConfigPrompt(prompt: ClientPrompt): Prompt {
@@ -30,12 +33,17 @@ export function clientPromptToAIConfigPrompt(prompt: ClientPrompt): Prompt {
 }
 
 export function clientConfigToAIConfig(clientConfig: ClientAIConfig): AIConfig {
-  // For some reason, TS thinks ClientAIConfig is missing properties from
-  // AIConfig, so we have to cast it
-  return {
+  const config = {
     ...clientConfig,
     prompts: clientConfig.prompts.map(clientPromptToAIConfigPrompt),
-  } as unknown as AIConfig;
+    _ui: undefined,
+  };
+
+  delete config._ui;
+
+  // For some reason, TS thinks ClientAIConfig is missing properties from
+  // AIConfig, so we have to cast it
+  return config as unknown as AIConfig;
 }
 
 export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
@@ -47,5 +55,8 @@ export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
         id: uniqueId(),
       },
     })),
+    _ui: {
+      isDirty: false,
+    },
   };
 }

--- a/python/src/aiconfig/editor/client/src/utils/constants.ts
+++ b/python/src/aiconfig/editor/client/src/utils/constants.ts
@@ -1,1 +1,2 @@
 export const DEBOUNCE_MS = 300;
+export const AUTOSAVE_INTERVAL_MS = 15 * 1000; // 15 seconds

--- a/python/src/aiconfig/editor/travel.aiconfig.json
+++ b/python/src/aiconfig/editor/travel.aiconfig.json
@@ -22,6 +22,9 @@
     {
       "name": "get_activities",
       "input": "Tell me 10 fun attractions to do in NYC.",
+      "metadata": {
+        "parameters": {}
+      },
       "outputs": [
         {
           "output_type": "execute_result",


### PR DESCRIPTION
# [editor] Handle CMD/CTRL + S to Save

A common action when using an editor UI is to hit CMD+s or CTRL+s to save. In browsers, this will by default open up the browser save window to save the web page itself. In this PR, we override this default behaviour and instead call the /save endpoint for the config if it's dirty


https://github.com/lastmile-ai/aiconfig/assets/5060851/a2bf656b-2209-49e0-a404-31b23b836abd



---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/735).
* __->__ #735
* #734
* #733