### PR TITLE
[editor] PaLMTextParserPromptSchema

### DIFF
--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMTextParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMTextParserPromptSchema.ts
@@ -1,0 +1,43 @@
+import { PromptSchema } from "../../utils/promptUtils";
+
+export const PaLMTextParserPromptSchema: PromptSchema = {
+  // See https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text for settings
+  // and defaults. The settings below are supported settings specified in the PaLMTextParser
+  // refine_completion_params implementation.
+  input: {
+    type: "string",
+  },
+  model_settings: {
+    type: "object",
+    properties: {
+      candidate_count: {
+        type: "integer",
+        minimum: 1,
+        maximum: 4,
+      },
+      temperature: {
+        type: "number",
+        minimum: 0,
+        maximum: 1,
+      },
+      top_p: {
+        type: "number",
+        minimum: 0,
+        maximum: 1,
+      },
+      top_k: {
+        type: "integer",
+        minimum: 1,
+        maximum: 40,
+      },
+    },
+  },
+  prompt_metadata: {
+    type: "object",
+    properties: {
+      remember_chat_context: {
+        type: "boolean",
+      },
+    },
+  },
+};

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -2,6 +2,7 @@ import { JSONObject, JSONValue, Prompt } from "aiconfig";
 import { OpenAIChatModelParserPromptSchema } from "../shared/prompt_schemas/OpenAIChatModelParserPromptSchema";
 import { OpenAIChatVisionModelParserPromptSchema } from "../shared/prompt_schemas/OpenAIChatVisionModelParserPromptSchema";
 import { DalleImageGenerationParserPromptSchema } from "../shared/prompt_schemas/DalleImageGenerationParserPromptSchema";
+import { PaLMTextParserPromptSchema } from "../shared/prompt_schemas/PaLMTextParserPromptSchema";
 
 /**
  * Get the name of the model for the specified prompt. The name will either be specified in the prompt's
@@ -69,7 +70,7 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   // "HuggingFaceTextGenerationParser":
 
   // PaLMTextParser
-  // "models/text-bison-001":
+  "models/text-bison-001": PaLMTextParserPromptSchema,
 
   // PaLMChatParser
   // "models/chat-bison-001":


### PR DESCRIPTION
# [editor] PaLMTextParserPromptSchema

Add the prompt schema for PaLM text models (text-bison). Note that our PaLMTextParser implementation is currently not using fully valid completion params (created https://github.com/lastmile-ai/aiconfig/issues/736 for that), so just selected the valid ones in accordance with https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text

<img width="1311" alt="Screenshot 2024-01-03 at 3 14 00 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/fac04b95-7c3b-4824-9c53-0327c3dd1a81">

