### PR TITLE
[editor] Temporarily Remove 'Add New Model' Option in AddPromptButton

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
@@ -79,8 +79,9 @@ export default memo(function AddPromptButton({ addPrompt, getModels }: Props) {
           collapseLimit={5}
           onSelectModel={onAddPrompt}
         />
+        {/* TODO: Add back once we have custom model parsers fully supported
         <Menu.Divider />
-        <Menu.Item icon={<IconPlus size="16" />}>Add New Model</Menu.Item>
+        <Menu.Item icon={<IconPlus size="16" />}>Add New Model</Menu.Item> */}
       </Menu.Dropdown>
     </Menu>
   );


### PR DESCRIPTION
# [editor] Temporarily Remove 'Add New Model' Option in AddPromptButton

Custom model support is a fast-follow post-MVP so remove the button that will eventually show the info modal for adding custom model parsers

## Before:
<img width="468" alt="Screenshot 2024-01-04 at 10 45 12 AM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/a148e6c5-0756-4b49-b4c0-7a320e67da92">


## After:
<img width="425" alt="Screenshot 2024-01-04 at 10 40 21 AM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/a74f65f8-f2ea-46d5-89e8-f52aa26668b9">

