### PR TITLE
[bug] Ensure that Output is constructed consistently across streaming and non-streaming

### DIFF
--- a/cookbooks/Anyscale/Function_Calling_with_Mixtral.ipynb
+++ b/cookbooks/Anyscale/Function_Calling_with_Mixtral.ipynb
@@ -1,0 +1,485 @@
+{
+  "cells": [
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_KIVLBz840Bi"
+      },
+      "source": [
+        "# Function Calling with Anyscale Endpoints & AIConfig\n",
+        "\n",
+        "This notebook serves as a practical guide for leveraging AIConfig and function calling with Anyscale Endpoints. We start with a mock database of books and functions to list, search, and retrieve books. Function calling is enabled so the LLM can interpret a user's question, determine the appropriate function to call, and execute the function. \n",
+        "\n",
+        "This guide shows how to achieve the [OpenAI function calling demo](https://github.com/openai/openai-node/blob/v4/examples/function-call-stream.ts) using Anyscale Endpoints instead (and using Mixtral-8x7B instead of GPT-4).\n",
+        "\n",
+        "Read more about [Function Calling with Anyscale Endpoints](https://docs.endpoints.anyscale.com/guides/function-calling) and [AIConfig for prompt and model management](https://github.com/lastmile-ai/aiconfig)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Install AIConfig package\n",
+        "%pip install python-aiconfig"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Obtaining file:///Users/saqadri/lm/aiconfig/python\n",
+            "  Installing build dependencies ... \u001b[?25ldone\n",
+            "\u001b[?25h  Checking if build backend supports build_editable ... \u001b[?25ldone\n",
+            "\u001b[?25h  Getting requirements to build editable ... \u001b[?25ldone\n",
+            "\u001b[?25h  Preparing editable metadata (pyproject.toml) ... \u001b[?25ldone\n",
+            "\u001b[?25hRequirement already satisfied: black in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (23.11.0)\n",
+            "Requirement already satisfied: flake8 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (6.1.0)\n",
+            "Requirement already satisfied: flask-cors in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (4.0.0)\n",
+            "Requirement already satisfied: flask[async] in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (3.0.0)\n",
+            "Requirement already satisfied: google-generativeai in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.3.2)\n",
+            "Requirement already satisfied: huggingface-hub in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.20.1)\n",
+            "Requirement already satisfied: hypothesis==6.91.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (6.91.0)\n",
+            "Requirement already satisfied: lastmile-utils==0.0.14 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.0.14)\n",
+            "Requirement already satisfied: mock in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (5.1.0)\n",
+            "Requirement already satisfied: nest-asyncio in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (1.5.8)\n",
+            "Requirement already satisfied: nltk in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (3.8.1)\n",
+            "Requirement already satisfied: openai<1.5,>=1.0.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (1.4.0)\n",
+            "Requirement already satisfied: prompt-toolkit in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (3.0.42)\n",
+            "Requirement already satisfied: pybars3 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.9.7)\n",
+            "Requirement already satisfied: pydantic>=2.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (2.4.2)\n",
+            "Requirement already satisfied: pylint in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (3.0.2)\n",
+            "Requirement already satisfied: pytest in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (7.4.3)\n",
+            "Requirement already satisfied: pytest-asyncio in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.23.3)\n",
+            "Requirement already satisfied: python-dotenv in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (1.0.0)\n",
+            "Requirement already satisfied: pyyaml in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (6.0.1)\n",
+            "Requirement already satisfied: requests in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (2.31.0)\n",
+            "Requirement already satisfied: result in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.15.0)\n",
+            "Requirement already satisfied: attrs>=19.2.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from hypothesis==6.91.0->python-aiconfig==1.1.8) (23.2.0)\n",
+            "Requirement already satisfied: sortedcontainers<3.0.0,>=2.1.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from hypothesis==6.91.0->python-aiconfig==1.1.8) (2.4.0)\n",
+            "Requirement already satisfied: chardet==5.2.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (5.2.0)\n",
+            "Requirement already satisfied: isort==5.12.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (5.12.0)\n",
+            "Requirement already satisfied: jsoncomment==0.4.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (0.4.2)\n",
+            "Requirement already satisfied: pandas==2.1.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (2.1.2)\n",
+            "Requirement already satisfied: pyright==1.1.335 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (1.1.335)\n",
+            "Requirement already satisfied: autoflake==2.2.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (2.2.1)\n",
+            "Requirement already satisfied: click>=8.0.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from black->python-aiconfig==1.1.8) (8.1.7)\n",
+            "Requirement already satisfied: mypy-extensions>=0.4.3 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from black->python-aiconfig==1.1.8) (1.0.0)\n",
+            "Requirement already satisfied: packaging>=22.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from black->python-aiconfig==1.1.8) (23.2)\n",
+            "Requirement already satisfied: pathspec>=0.9.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from black->python-aiconfig==1.1.8) (0.12.1)\n",
+            "Requirement already satisfied: platformdirs>=2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from black->python-aiconfig==1.1.8) (4.1.0)\n",
+            "Requirement already satisfied: mccabe<0.8.0,>=0.7.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flake8->python-aiconfig==1.1.8) (0.7.0)\n",
+            "Requirement already satisfied: pycodestyle<2.12.0,>=2.11.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flake8->python-aiconfig==1.1.8) (2.11.1)\n",
+            "Requirement already satisfied: pyflakes<3.2.0,>=3.1.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flake8->python-aiconfig==1.1.8) (3.1.0)\n",
+            "Requirement already satisfied: annotated-types>=0.4.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pydantic>=2.1->python-aiconfig==1.1.8) (0.6.0)\n",
+            "Requirement already satisfied: pydantic-core==2.10.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pydantic>=2.1->python-aiconfig==1.1.8) (2.10.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.6.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pydantic>=2.1->python-aiconfig==1.1.8) (4.9.0)\n",
+            "Requirement already satisfied: astroid<=3.1.0-dev0,>=3.0.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pylint->python-aiconfig==1.1.8) (3.0.2)\n",
+            "Requirement already satisfied: tomlkit>=0.10.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pylint->python-aiconfig==1.1.8) (0.12.3)\n",
+            "Requirement already satisfied: dill>=0.3.6 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pylint->python-aiconfig==1.1.8) (0.3.7)\n",
+            "Requirement already satisfied: iniconfig in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pytest->python-aiconfig==1.1.8) (2.0.0)\n",
+            "Requirement already satisfied: pluggy<2.0,>=0.12 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pytest->python-aiconfig==1.1.8) (1.3.0)\n",
+            "Requirement already satisfied: json-spec in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from jsoncomment==0.4.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (0.11.0)\n",
+            "Requirement already satisfied: numpy<2,>=1.26.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pandas==2.1.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (1.26.3)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pandas==2.1.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pandas==2.1.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (2023.3.post1)\n",
+            "Requirement already satisfied: tzdata>=2022.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pandas==2.1.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (2023.4)\n",
+            "Requirement already satisfied: nodeenv>=1.6.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pyright==1.1.335->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (1.8.0)\n",
+            "Requirement already satisfied: anyio<5,>=3.5.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (4.2.0)\n",
+            "Requirement already satisfied: distro<2,>=1.7.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (1.9.0)\n",
+            "Requirement already satisfied: httpx<1,>=0.23.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (0.26.0)\n",
+            "Requirement already satisfied: sniffio in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (1.3.0)\n",
+            "Requirement already satisfied: tqdm>4 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (4.66.1)\n",
+            "Requirement already satisfied: Werkzeug>=3.0.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flask[async]->python-aiconfig==1.1.8) (3.0.1)\n",
+            "Requirement already satisfied: Jinja2>=3.1.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flask[async]->python-aiconfig==1.1.8) (3.1.2)\n",
+            "Requirement already satisfied: itsdangerous>=2.1.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flask[async]->python-aiconfig==1.1.8) (2.1.2)\n",
+            "Requirement already satisfied: blinker>=1.6.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flask[async]->python-aiconfig==1.1.8) (1.7.0)\n",
+            "Requirement already satisfied: asgiref>=3.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flask[async]->python-aiconfig==1.1.8) (3.7.2)\n",
+            "Requirement already satisfied: google-ai-generativelanguage==0.4.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-generativeai->python-aiconfig==1.1.8) (0.4.0)\n",
+            "Requirement already satisfied: google-auth in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-generativeai->python-aiconfig==1.1.8) (2.26.0)\n",
+            "Requirement already satisfied: google-api-core in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-generativeai->python-aiconfig==1.1.8) (2.15.0)\n",
+            "Requirement already satisfied: protobuf in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-generativeai->python-aiconfig==1.1.8) (4.25.1)\n",
+            "Requirement already satisfied: proto-plus<2.0.0dev,>=1.22.3 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-ai-generativelanguage==0.4.0->google-generativeai->python-aiconfig==1.1.8) (1.23.0)\n",
+            "Requirement already satisfied: filelock in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from huggingface-hub->python-aiconfig==1.1.8) (3.13.1)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from huggingface-hub->python-aiconfig==1.1.8) (2023.12.2)\n",
+            "Requirement already satisfied: joblib in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from nltk->python-aiconfig==1.1.8) (1.3.2)\n",
+            "Requirement already satisfied: regex>=2021.8.3 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from nltk->python-aiconfig==1.1.8) (2023.12.25)\n",
+            "Requirement already satisfied: wcwidth in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from prompt-toolkit->python-aiconfig==1.1.8) (0.2.12)\n",
+            "Requirement already satisfied: PyMeta3>=0.5.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pybars3->python-aiconfig==1.1.8) (0.5.1)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from requests->python-aiconfig==1.1.8) (3.3.2)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from requests->python-aiconfig==1.1.8) (3.6)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from requests->python-aiconfig==1.1.8) (2.1.0)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from requests->python-aiconfig==1.1.8) (2023.11.17)\n",
+            "Requirement already satisfied: googleapis-common-protos<2.0.dev0,>=1.56.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-api-core->google-generativeai->python-aiconfig==1.1.8) (1.62.0)\n",
+            "Requirement already satisfied: cachetools<6.0,>=2.0.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-auth->google-generativeai->python-aiconfig==1.1.8) (5.3.2)\n",
+            "Requirement already satisfied: pyasn1-modules>=0.2.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-auth->google-generativeai->python-aiconfig==1.1.8) (0.3.0)\n",
+            "Requirement already satisfied: rsa<5,>=3.1.4 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-auth->google-generativeai->python-aiconfig==1.1.8) (4.9)\n",
+            "Requirement already satisfied: httpcore==1.* in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from httpx<1,>=0.23.0->openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (1.0.2)\n",
+            "Requirement already satisfied: h11<0.15,>=0.13 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (0.14.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from Jinja2>=3.1.2->flask[async]->python-aiconfig==1.1.8) (2.1.3)\n",
+            "Requirement already satisfied: grpcio<2.0dev,>=1.33.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0->google-ai-generativelanguage==0.4.0->google-generativeai->python-aiconfig==1.1.8) (1.60.0)\n",
+            "Requirement already satisfied: grpcio-status<2.0.dev0,>=1.33.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0->google-ai-generativelanguage==0.4.0->google-generativeai->python-aiconfig==1.1.8) (1.60.0)\n",
+            "Requirement already satisfied: setuptools in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from nodeenv>=1.6.0->pyright==1.1.335->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (69.0.3)\n",
+            "Requirement already satisfied: pyasn1<0.6.0,>=0.4.6 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pyasn1-modules>=0.2.1->google-auth->google-generativeai->python-aiconfig==1.1.8) (0.5.1)\n",
+            "Requirement already satisfied: six>=1.5 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-dateutil>=2.8.2->pandas==2.1.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (1.16.0)\n",
+            "Requirement already satisfied: importlib-metadata<6.0.0,>=5.0.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from json-spec->jsoncomment==0.4.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (5.2.0)\n",
+            "Requirement already satisfied: zipp>=0.5 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from importlib-metadata<6.0.0,>=5.0.0->json-spec->jsoncomment==0.4.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (3.17.0)\n",
+            "Building wheels for collected packages: python-aiconfig\n",
+            "  Building editable for python-aiconfig (pyproject.toml) ... \u001b[?25ldone\n",
+            "\u001b[?25h  Created wheel for python-aiconfig: filename=python_aiconfig-1.1.8-0.editable-py3-none-any.whl size=9971 sha256=18699068804b023ee12eb07d94efe96e40c05e54dfa9e4d971e6fbcf933645da\n",
+            "  Stored in directory: /private/var/folders/mk/5l10lyqs1c73_pj2grj9f9vw0000gn/T/pip-ephem-wheel-cache-8467usz2/wheels/e7/fd/a2/adfd3d754fa5bcf2040054afef13bbf40a8e091249b821d62d\n",
+            "Successfully built python-aiconfig\n",
+            "Installing collected packages: python-aiconfig\n",
+            "  Attempting uninstall: python-aiconfig\n",
+            "    Found existing installation: python-aiconfig 1.1.8\n",
+            "    Uninstalling python-aiconfig-1.1.8:\n",
+            "      Successfully uninstalled python-aiconfig-1.1.8\n",
+            "Successfully installed python-aiconfig-1.1.8\n",
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
+      "source": [
+        "%pip install -e /Users/saqadri/lm/aiconfig/python"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "51w-3OZC_Z97"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "execution_count": 1,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Create .env file at aiconfig/.env containing the following line: \n",
+        "# ANYSCALE_ENDPOINT_API_KEY=<your key here>\n",
+        "# You can get your key from https://app.endpoints.anyscale.com/credentials\n",
+        "import dotenv\n",
+        "dotenv.load_dotenv()"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rXJJiDO6gbOK"
+      },
+      "source": [
+        "## Set up the books DB"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "KP-CTNZBKN_J"
+      },
+      "outputs": [],
+      "source": [
+        "# Define db of books\n",
+        "db = [\n",
+        "    {\n",
+        "        'id': 'a1',\n",
+        "        'name': 'To Kill a Mockingbird',\n",
+        "        'genre': 'historical',\n",
+        "        'description': ('Compassionate, dramatic, and deeply moving, \"To Kill A Mockingbird\" takes readers to the roots of human behavior - to innocence and experience, kindness and cruelty, love and hatred, humor and pathos. Now with over 18 million copies in print and translated into forty languages, this regional story by a young Alabama woman claims universal appeal. Harper Lee always considered her book to be a simple love story. Today it is regarded as a masterpiece of American literature.'),\n",
+        "    },\n",
+        "    {\n",
+        "        'id': 'a2',\n",
+        "        'name': 'All the Light We Cannot See',\n",
+        "        'genre': 'historical',\n",
+        "        'description': ('In a mining town in Germany, Werner Pfennig, an orphan, grows up with his younger sister, enchanted by a crude radio they find that brings them news and stories from places they have never seen or imagined. Werner becomes an expert at building and fixing these crucial new instruments and is enlisted to use his talent to track down the resistance. Deftly interweaving the lives of Marie-Laure and Werner, Doerr illuminates the ways, against all odds, people try to be good to one another.'),\n",
+        "    },\n",
+        "    {\n",
+        "        'id': 'a3',\n",
+        "        'name': 'Where the Crawdads Sing',\n",
+        "        'genre': 'historical',\n",
+        "        'description': ('For years, rumors of the “Marsh Girl” haunted Barkley Cove, a quiet fishing village. Kya Clark is barefoot and wild; unfit for polite society. So in late 1969, when the popular Chase Andrews is found dead, locals immediately suspect her.\\n\\n'\n",
+        "                        'But Kya is not what they say. A born naturalist with just one day of school, she takes life\\'s lessons from the land, learning the real ways of the world from the dishonest signals of fireflies. But while she has the skills to live in solitude forever, the time comes when she yearns to be touched and loved. Drawn to two young men from town, who are each intrigued by her wild beauty, Kya opens herself to a new and startling world—until the unthinkable happens.'),\n",
+        "    },\n",
+        "]"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dCiJurzKgnqB"
+      },
+      "source": [
+        "## Define functions (to interact with DB)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "nbolW2mVDeZD"
+      },
+      "outputs": [],
+      "source": [
+        "# Define the functions: list, search, get\n",
+        "\n",
+        "# The 'list' function returns a list of books in a specified genre.\n",
+        "def list(genre):\n",
+        "    return [item for item in db if item['genre'] == genre]\n",
+        "\n",
+        "# The 'search' function returns a list of books that match the provided name.\n",
+        "def search(name):\n",
+        "    return [item for item in db if name in item['name']]\n",
+        "\n",
+        "# The 'get' function returns detailed information about a book based on its ID.\n",
+        "# Note: This function accepts only IDs, not names. Use the 'search' function to find a book's ID.\n",
+        "def get(id):\n",
+        "    for item in db:\n",
+        "        if item['id'] == id:\n",
+        "            return item\n",
+        "    return None"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ni_umLSdjAAT"
+      },
+      "source": [
+        "## Get recommendations using function calls"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "o7eJfimvLa3X"
+      },
+      "outputs": [],
+      "source": [
+        "# Use helper function to executes the function specified by the LLM's output for 'function_call'.\n",
+        "# It handles 'list', 'search', or 'get' functions, and raises a ValueError for unknown functions.\n",
+        "import json\n",
+        "\n",
+        "def call_function(function_call):\n",
+        "    args = json.loads(function_call.arguments)\n",
+        "    name = function_call.name\n",
+        "\n",
+        "    if name == 'list':\n",
+        "        print(f\"genre={args['genre']}, args={args}\")\n",
+        "        return list(args['genre'])\n",
+        "    elif name == 'search':\n",
+        "        return search(args['name'])\n",
+        "    elif name == 'get':\n",
+        "        return get(args['id'])\n",
+        "    else:\n",
+        "        raise ValueError('No function found')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/pydantic/_internal/_fields.py:128: UserWarning: Field \"model_parsers\" has conflict with protected namespace \"model_\".\n",
+            "\n",
+            "You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.\n",
+            "  warnings.warn(\n",
+            "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+            "  from .autonotebook import tqdm as notebook_tqdm\n"
+          ]
+        }
+      ],
+      "source": [
+        "from aiconfig import AIConfigRuntime, InferenceOptions\n",
+        "\n",
+        "config = AIConfigRuntime.load(\"recommender.aiconfig.json\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "id": "jD9S3q5mMtqd"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[ExecuteResult(output_type='execute_result', execution_count=0, data=OutputDataWithToolCallsValue(kind='tool_calls', value=[ToolCallData(id='call_2f1aca9308454db1bf39030212fe3c4f', function=FunctionCallData(arguments='{\"name\": \"Where the Crawdads Sing\"}', name='search'), type='function')]), mime_type=None, metadata={'raw_response': {'role': 'assistant', 'tool_calls': [{'id': 'call_2f1aca9308454db1bf39030212fe3c4f', 'function': {'arguments': '{\"name\": \"Where the Crawdads Sing\"}', 'name': 'search'}, 'type': 'function'}]}, 'id': 'mistralai/Mixtral-8x7B-Instruct-v0.1-UL3yG8uqvO7QFPsRp1dUMfNDVL3vo27sZPxqrbECoKc', 'created': 1704329124, 'model': 'mistralai/Mixtral-8x7B-Instruct-v0.1', 'object': 'text_completion', 'usage': {'completion_tokens': 62, 'prompt_tokens': 651, 'total_tokens': 713}, 'finish_reason': 'tool_calls', 'role': 'assistant'})]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Run recommendBook prompt with gpt-3.5 and determine right function to call based on user question\n",
+        "params = {\"book\":\"Where the Crawdads Sing\"}\n",
+        "inference_options = InferenceOptions(stream=False)\n",
+        "\n",
+        "completion = await config.run(\"recommend_book\", params, options=inference_options)\n",
+        "print(completion)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "kind='tool_calls' value=[ToolCallData(id='call_2f1aca9308454db1bf39030212fe3c4f', function=FunctionCallData(arguments='{\"name\": \"Where the Crawdads Sing\"}', name='search'), type='function')]\n"
+          ]
+        }
+      ],
+      "source": [
+        "output_data = completion[0].data\n",
+        "print(output_data)\n",
+        "\n",
+        "assert output_data.kind == \"tool_calls\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "id": "CZ_NhrvrTCu8"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "id='call_2f1aca9308454db1bf39030212fe3c4f' function=FunctionCallData(arguments='{\"name\": \"Where the Crawdads Sing\"}', name='search') type='function'\n",
+            "[\n",
+            "    {\n",
+            "        \"id\": \"a3\",\n",
+            "        \"name\": \"Where the Crawdads Sing\",\n",
+            "        \"genre\": \"historical\",\n",
+            "        \"description\": \"For years, rumors of the \\u201cMarsh Girl\\u201d haunted Barkley Cove, a quiet fishing village. Kya Clark is barefoot and wild; unfit for polite society. So in late 1969, when the popular Chase Andrews is found dead, locals immediately suspect her.\\n\\nBut Kya is not what they say. A born naturalist with just one day of school, she takes life's lessons from the land, learning the real ways of the world from the dishonest signals of fireflies. But while she has the skills to live in solitude forever, the time comes when she yearns to be touched and loved. Drawn to two young men from town, who are each intrigued by her wild beauty, Kya opens herself to a new and startling world\\u2014until the unthinkable happens.\"\n",
+            "    }\n",
+            "]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Run call_function to execute the LLM-specified function (list, search, get)\n",
+        "\n",
+        "result = None\n",
+        "for func_call in output_data.value:\n",
+        "    print(func_call)\n",
+        "    function = func_call.function\n",
+        "    result = call_function(function)\n",
+        "    print(json.dumps(result, indent=4))\n"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MKEf1idOjkvk"
+      },
+      "source": [
+        "## Using LLaMA-7B to generate a user-friendly response"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "id": "0QZHtalIVGQB"
+      },
+      "outputs": [],
+      "source": [
+        "model=\"mistralai/Mistral-7B-Instruct-v0.1\"\n",
+        "data = {\n",
+        "    \"model\": model,\n",
+        "    \"messages\": [\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": \"Here is some data about a book from a books DB - please write a short description about the book as if you're a librarian. Data: {{book_info}}\"\n",
+        "        }\n",
+        "    ]\n",
+        "}\n",
+        "\n",
+        "new_prompts = await config.serialize(model, data, prompt_name=\"gen_summary\")\n",
+        "config.add_prompt(prompt_name=\"gen_summary\", prompt_data=new_prompts[0])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "id": "Xd-4rg5lj8lp"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            " \"Where the Crawdads Sing\" is a captivating historical novel by Delia Owens that explores the life of Kya Clark, a self-sufficient naturalist who lives in the marshes of North Carolina. With vivid descriptions of the natural world and Kya's relationship with it, the novel highlights the resilience of the human spirit and the power of love and community. It is a poignant story that explores complex themes such as isolation, grief and the search for connection while also examining the prejudices and biases of society. With its stunning prose and compelling plot, \"Where the Crawdads Sing\" is a must-read for anyone interested in a beautifully written, thought-provoking novel."
+          ]
+        }
+      ],
+      "source": [
+        "inference_options = InferenceOptions(stream=True)\n",
+        "completion = await config.run(\"gen_summary\", params={\"book_info\": result}, options=inference_options)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "4l-buJXglaLw"
+      },
+      "outputs": [],
+      "source": [
+        "config.save(\"recommender.aiconfig.json\", include_outputs=True)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.1"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/cookbooks/Anyscale/README.md
+++ b/cookbooks/Anyscale/README.md
@@ -10,6 +10,7 @@ We cover:
 
 - Inference using Anyscale Endpoints
 - Prompt chains with multiple models
+- Function calling with Anyscale Endpoints & AIConfig
 
 Read more about [AIConfig for prompt and model management](https://github.com/lastmile-ai/aiconfig).
 

--- a/cookbooks/Anyscale/README.md
+++ b/cookbooks/Anyscale/README.md
@@ -1,0 +1,29 @@
+# Anyscale Endpoints with AIConfig
+
+[![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1JgGjJ2YglyaT5GHQNswkPOyB5oHGbOcv?usp=sharing)
+
+[Anyscale Endpoints](https://www.anyscale.com/endpoints) support optimized inference for many open source models, including the LLaMA2 family of models (7B, 13B, 70B, CodeLLaMA, LLaMA Guard) and Mistral (7B, Mixtral 8x7B).
+
+This cookbook shows how to use any [Anyscale Endpoints](https://www.anyscale.com/endpoints) model with AIConfig using the same simple API.
+
+We cover:
+
+- Inference using Anyscale Endpoints
+- Prompt chains with multiple models
+
+Read more about [AIConfig for prompt and model management](https://github.com/lastmile-ai/aiconfig).
+
+## Models supported with Anyscale Endpoints
+
+For the complete list, please see https://app.endpoints.anyscale.com/docs
+
+- LLaMA-7B: meta-llama/Llama-2-7b-chat-hf
+- LLaMA-13B: meta-llama/Llama-2-13b-chat-hf
+- LLaMA-70B: meta-llama/Llama-2-70b-chat-hf
+- LLaMA Guard: Meta-Llama/Llama-Guard-7b
+- CodeLLaMA: codellama/CodeLlama-34b-Instruct-hf
+- Mistral-7B (OpenOrca): Open-Orca/Mistral-7B-OpenOrca
+- Mistral-7B: mistralai/Mistral-7B-Instruct-v0.1
+- Mixtral-8x7B: mistralai/Mixtral-8x7B-Instruct-v0.1
+- Zephyr: HuggingFaceH4/zephyr-7b-beta
+- GTE: thenlper/gte-large

--- a/cookbooks/Anyscale/getting_started.ipynb
+++ b/cookbooks/Anyscale/getting_started.ipynb
@@ -1,0 +1,542 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Anyscale Endpoints with AIConfig\n",
+        "\n",
+        "[Anyscale Endpoints](https://www.anyscale.com/endpoints) support optimized inference for many open source models, including the LLaMA2 family of models (7B, 13B, 70B, CodeLLaMA, LLaMA Guard) and Mistral (7B, Mixtral 8x7B).\n",
+        "\n",
+        "This cookbook shows how to use any [Anyscale Endpoints](https://www.anyscale.com/endpoints) model with AIConfig using the same simple API.\n",
+        "\n",
+        "In this notebook we show how to build a travel itinerary using inference from multiple models (LLaMA-7B and Mixtral-8x7B) using Anyscale Endpoints\n",
+        "\n",
+        "Read more about [AIConfig for prompt and model management](https://github.com/lastmile-ai/aiconfig).\n",
+        "\n",
+        "## Models supported with Anyscale Endpoints\n",
+        "For the complete list, please see https://app.endpoints.anyscale.com/docs\n",
+        "* LLaMA-7B: meta-llama/Llama-2-7b-chat-hf\n",
+        "* LLaMA-13B: meta-llama/Llama-2-13b-chat-hf\n",
+        "* LLaMA-70B: meta-llama/Llama-2-70b-chat-hf\n",
+        "* LLaMA Guard: Meta-Llama/Llama-Guard-7b\n",
+        "* CodeLLaMA: codellama/CodeLlama-34b-Instruct-hf\n",
+        "* Mistral-7B (OpenOrca): Open-Orca/Mistral-7B-OpenOrca\n",
+        "* Mistral-7B: mistralai/Mistral-7B-Instruct-v0.1\n",
+        "* Mixtral-8x7B: mistralai/Mixtral-8x7B-Instruct-v0.1\n",
+        "* Zephyr: HuggingFaceH4/zephyr-7b-beta\n",
+        "* GTE: thenlper/gte-large"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kNmnUZnUFzt3"
+      },
+      "source": [
+        "# Installation and Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Obtaining file:///Users/saqadri/lm/aiconfig/python\n",
+            "  Installing build dependencies ... \u001b[?25ldone\n",
+            "\u001b[?25h  Checking if build backend supports build_editable ... \u001b[?25ldone\n",
+            "\u001b[?25h  Getting requirements to build editable ... \u001b[?25ldone\n",
+            "\u001b[?25h  Preparing editable metadata (pyproject.toml) ... \u001b[?25ldone\n",
+            "\u001b[?25hRequirement already satisfied: black in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (23.11.0)\n",
+            "Requirement already satisfied: flake8 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (6.1.0)\n",
+            "Requirement already satisfied: flask-cors in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (4.0.0)\n",
+            "Requirement already satisfied: flask[async] in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (3.0.0)\n",
+            "Requirement already satisfied: google-generativeai in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.3.2)\n",
+            "Requirement already satisfied: huggingface-hub in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.20.1)\n",
+            "Requirement already satisfied: hypothesis==6.91.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (6.91.0)\n",
+            "Requirement already satisfied: lastmile-utils==0.0.14 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.0.14)\n",
+            "Requirement already satisfied: mock in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (5.1.0)\n",
+            "Requirement already satisfied: nest-asyncio in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (1.5.8)\n",
+            "Requirement already satisfied: nltk in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (3.8.1)\n",
+            "Requirement already satisfied: openai<1.5,>=1.0.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (1.4.0)\n",
+            "Requirement already satisfied: prompt-toolkit in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (3.0.42)\n",
+            "Requirement already satisfied: pybars3 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.9.7)\n",
+            "Requirement already satisfied: pydantic>=2.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (2.4.2)\n",
+            "Requirement already satisfied: pylint in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (3.0.2)\n",
+            "Requirement already satisfied: pytest in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (7.4.3)\n",
+            "Requirement already satisfied: pytest-asyncio in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.23.3)\n",
+            "Requirement already satisfied: python-dotenv in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (1.0.0)\n",
+            "Requirement already satisfied: pyyaml in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (6.0.1)\n",
+            "Requirement already satisfied: requests in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (2.31.0)\n",
+            "Requirement already satisfied: result in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-aiconfig==1.1.8) (0.15.0)\n",
+            "Requirement already satisfied: attrs>=19.2.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from hypothesis==6.91.0->python-aiconfig==1.1.8) (23.2.0)\n",
+            "Requirement already satisfied: sortedcontainers<3.0.0,>=2.1.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from hypothesis==6.91.0->python-aiconfig==1.1.8) (2.4.0)\n",
+            "Requirement already satisfied: chardet==5.2.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (5.2.0)\n",
+            "Requirement already satisfied: isort==5.12.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (5.12.0)\n",
+            "Requirement already satisfied: jsoncomment==0.4.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (0.4.2)\n",
+            "Requirement already satisfied: pandas==2.1.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (2.1.2)\n",
+            "Requirement already satisfied: pyright==1.1.335 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (1.1.335)\n",
+            "Requirement already satisfied: autoflake==2.2.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from lastmile-utils==0.0.14->python-aiconfig==1.1.8) (2.2.1)\n",
+            "Requirement already satisfied: click>=8.0.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from black->python-aiconfig==1.1.8) (8.1.7)\n",
+            "Requirement already satisfied: mypy-extensions>=0.4.3 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from black->python-aiconfig==1.1.8) (1.0.0)\n",
+            "Requirement already satisfied: packaging>=22.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from black->python-aiconfig==1.1.8) (23.2)\n",
+            "Requirement already satisfied: pathspec>=0.9.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from black->python-aiconfig==1.1.8) (0.12.1)\n",
+            "Requirement already satisfied: platformdirs>=2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from black->python-aiconfig==1.1.8) (4.1.0)\n",
+            "Requirement already satisfied: mccabe<0.8.0,>=0.7.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flake8->python-aiconfig==1.1.8) (0.7.0)\n",
+            "Requirement already satisfied: pycodestyle<2.12.0,>=2.11.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flake8->python-aiconfig==1.1.8) (2.11.1)\n",
+            "Requirement already satisfied: pyflakes<3.2.0,>=3.1.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flake8->python-aiconfig==1.1.8) (3.1.0)\n",
+            "Requirement already satisfied: annotated-types>=0.4.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pydantic>=2.1->python-aiconfig==1.1.8) (0.6.0)\n",
+            "Requirement already satisfied: pydantic-core==2.10.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pydantic>=2.1->python-aiconfig==1.1.8) (2.10.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.6.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pydantic>=2.1->python-aiconfig==1.1.8) (4.9.0)\n",
+            "Requirement already satisfied: astroid<=3.1.0-dev0,>=3.0.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pylint->python-aiconfig==1.1.8) (3.0.2)\n",
+            "Requirement already satisfied: tomlkit>=0.10.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pylint->python-aiconfig==1.1.8) (0.12.3)\n",
+            "Requirement already satisfied: dill>=0.3.6 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pylint->python-aiconfig==1.1.8) (0.3.7)\n",
+            "Requirement already satisfied: iniconfig in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pytest->python-aiconfig==1.1.8) (2.0.0)\n",
+            "Requirement already satisfied: pluggy<2.0,>=0.12 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pytest->python-aiconfig==1.1.8) (1.3.0)\n",
+            "Requirement already satisfied: json-spec in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from jsoncomment==0.4.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (0.11.0)\n",
+            "Requirement already satisfied: numpy<2,>=1.26.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pandas==2.1.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (1.26.3)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pandas==2.1.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pandas==2.1.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (2023.3.post1)\n",
+            "Requirement already satisfied: tzdata>=2022.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pandas==2.1.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (2023.4)\n",
+            "Requirement already satisfied: nodeenv>=1.6.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pyright==1.1.335->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (1.8.0)\n",
+            "Requirement already satisfied: anyio<5,>=3.5.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (4.2.0)\n",
+            "Requirement already satisfied: distro<2,>=1.7.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (1.9.0)\n",
+            "Requirement already satisfied: httpx<1,>=0.23.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (0.26.0)\n",
+            "Requirement already satisfied: sniffio in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (1.3.0)\n",
+            "Requirement already satisfied: tqdm>4 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (4.66.1)\n",
+            "Requirement already satisfied: Werkzeug>=3.0.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flask[async]->python-aiconfig==1.1.8) (3.0.1)\n",
+            "Requirement already satisfied: Jinja2>=3.1.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flask[async]->python-aiconfig==1.1.8) (3.1.2)\n",
+            "Requirement already satisfied: itsdangerous>=2.1.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flask[async]->python-aiconfig==1.1.8) (2.1.2)\n",
+            "Requirement already satisfied: blinker>=1.6.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flask[async]->python-aiconfig==1.1.8) (1.7.0)\n",
+            "Requirement already satisfied: asgiref>=3.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from flask[async]->python-aiconfig==1.1.8) (3.7.2)\n",
+            "Requirement already satisfied: google-ai-generativelanguage==0.4.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-generativeai->python-aiconfig==1.1.8) (0.4.0)\n",
+            "Requirement already satisfied: google-auth in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-generativeai->python-aiconfig==1.1.8) (2.26.0)\n",
+            "Requirement already satisfied: google-api-core in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-generativeai->python-aiconfig==1.1.8) (2.15.0)\n",
+            "Requirement already satisfied: protobuf in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-generativeai->python-aiconfig==1.1.8) (4.25.1)\n",
+            "Requirement already satisfied: proto-plus<2.0.0dev,>=1.22.3 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-ai-generativelanguage==0.4.0->google-generativeai->python-aiconfig==1.1.8) (1.23.0)\n",
+            "Requirement already satisfied: filelock in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from huggingface-hub->python-aiconfig==1.1.8) (3.13.1)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from huggingface-hub->python-aiconfig==1.1.8) (2023.12.2)\n",
+            "Requirement already satisfied: joblib in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from nltk->python-aiconfig==1.1.8) (1.3.2)\n",
+            "Requirement already satisfied: regex>=2021.8.3 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from nltk->python-aiconfig==1.1.8) (2023.12.25)\n",
+            "Requirement already satisfied: wcwidth in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from prompt-toolkit->python-aiconfig==1.1.8) (0.2.12)\n",
+            "Requirement already satisfied: PyMeta3>=0.5.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pybars3->python-aiconfig==1.1.8) (0.5.1)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from requests->python-aiconfig==1.1.8) (3.3.2)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from requests->python-aiconfig==1.1.8) (3.6)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from requests->python-aiconfig==1.1.8) (2.1.0)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from requests->python-aiconfig==1.1.8) (2023.11.17)\n",
+            "Requirement already satisfied: googleapis-common-protos<2.0.dev0,>=1.56.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-api-core->google-generativeai->python-aiconfig==1.1.8) (1.62.0)\n",
+            "Requirement already satisfied: cachetools<6.0,>=2.0.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-auth->google-generativeai->python-aiconfig==1.1.8) (5.3.2)\n",
+            "Requirement already satisfied: pyasn1-modules>=0.2.1 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-auth->google-generativeai->python-aiconfig==1.1.8) (0.3.0)\n",
+            "Requirement already satisfied: rsa<5,>=3.1.4 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-auth->google-generativeai->python-aiconfig==1.1.8) (4.9)\n",
+            "Requirement already satisfied: httpcore==1.* in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from httpx<1,>=0.23.0->openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (1.0.2)\n",
+            "Requirement already satisfied: h11<0.15,>=0.13 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai<1.5,>=1.0.0->python-aiconfig==1.1.8) (0.14.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from Jinja2>=3.1.2->flask[async]->python-aiconfig==1.1.8) (2.1.3)\n",
+            "Requirement already satisfied: grpcio<2.0dev,>=1.33.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0->google-ai-generativelanguage==0.4.0->google-generativeai->python-aiconfig==1.1.8) (1.60.0)\n",
+            "Requirement already satisfied: grpcio-status<2.0.dev0,>=1.33.2 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0->google-ai-generativelanguage==0.4.0->google-generativeai->python-aiconfig==1.1.8) (1.60.0)\n",
+            "Requirement already satisfied: setuptools in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from nodeenv>=1.6.0->pyright==1.1.335->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (69.0.3)\n",
+            "Requirement already satisfied: pyasn1<0.6.0,>=0.4.6 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from pyasn1-modules>=0.2.1->google-auth->google-generativeai->python-aiconfig==1.1.8) (0.5.1)\n",
+            "Requirement already satisfied: six>=1.5 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from python-dateutil>=2.8.2->pandas==2.1.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (1.16.0)\n",
+            "Requirement already satisfied: importlib-metadata<6.0.0,>=5.0.0 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from json-spec->jsoncomment==0.4.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (5.2.0)\n",
+            "Requirement already satisfied: zipp>=0.5 in /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages (from importlib-metadata<6.0.0,>=5.0.0->json-spec->jsoncomment==0.4.2->lastmile-utils==0.0.14->python-aiconfig==1.1.8) (3.17.0)\n",
+            "Building wheels for collected packages: python-aiconfig\n",
+            "  Building editable for python-aiconfig (pyproject.toml) ... \u001b[?25ldone\n",
+            "\u001b[?25h  Created wheel for python-aiconfig: filename=python_aiconfig-1.1.8-0.editable-py3-none-any.whl size=9971 sha256=fbca0ed6d950008e262466231d7c55fab845a22af39eb637e26a284722253ad7\n",
+            "  Stored in directory: /private/var/folders/mk/5l10lyqs1c73_pj2grj9f9vw0000gn/T/pip-ephem-wheel-cache-1j_z2ajl/wheels/e7/fd/a2/adfd3d754fa5bcf2040054afef13bbf40a8e091249b821d62d\n",
+            "Successfully built python-aiconfig\n",
+            "Installing collected packages: python-aiconfig\n",
+            "  Attempting uninstall: python-aiconfig\n",
+            "    Found existing installation: python-aiconfig 1.1.8\n",
+            "    Uninstalling python-aiconfig-1.1.8:\n",
+            "      Successfully uninstalled python-aiconfig-1.1.8\n",
+            "Successfully installed python-aiconfig-1.1.8\n",
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
+      "source": [
+        "#%pip install -e /Users/saqadri/lm/aiconfig/python\n",
+        "%pip install python-aiconfig"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "sq9uM4ENFStR"
+      },
+      "outputs": [],
+      "source": [
+        "# Create .env file containing the following line:\n",
+        "# ANYSCALE_ENDPOINT_API_KEY=<your key here>\n",
+        "# You can get your key from https://app.endpoints.anyscale.com/docs (https://app.endpoints.anyscale.com/credentials)\n",
+        "\n",
+        "import dotenv\n",
+        "dotenv.load_dotenv()"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-FMlVH2bF4iN"
+      },
+      "source": [
+        "## Load AI Config `travel.aiconfig.json`\n",
+        "Download file [from here](https://github.com/lastmile-ai/aiconfig/blob/main/cookbooks/Anyscale/travel.aiconfig.json). If you're using Colab, upload to 'Files' in your colab notebook and load (shown below).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "go9T1xivF4S2"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/pydantic/_internal/_fields.py:128: UserWarning: Field \"model_parsers\" has conflict with protected namespace \"model_\".\n",
+            "\n",
+            "You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.\n",
+            "  warnings.warn(\n",
+            "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+            "  from .autonotebook import tqdm as notebook_tqdm\n"
+          ]
+        }
+      ],
+      "source": [
+        "from aiconfig import AIConfigRuntime, InferenceOptions, CallbackManager\n",
+        "\n",
+        "# Load the aiconfig.\n",
+        "config = AIConfigRuntime.load('travel.aiconfig.json')\n",
+        "config.callback_manager = CallbackManager([])"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zqCchve9GINL"
+      },
+      "source": [
+        "# Run `get_activities` prompt with streaming (llama-7b)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Kd6BFPGiHPJe",
+        "outputId": "f221e835-0d96-4cdc-dc3e-0908c0943955"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  Sure! Here are 10 fun attractions to do in New York City:\n",
+            "\n",
+            "1. Take a walk across the Brooklyn Bridge: This iconic bridge offers stunning views of the Manhattan skyline, the East River, and the Brooklyn shore. It's a must-do activity for anyone visiting NYC.\n",
+            "2. Explore the Metropolitan Museum of Art: With over 2 million works of art spanning 5,000 years of human history, the Met is one of the world's greatest museums. Be sure to spend at least a whole day here to see everything.\n",
+            "3. Visit Central Park: This 843-acre green oasis in the middle of Manhattan offers a peaceful escape from the hustle and bustle of the city. Take a stroll through the park, rent a bike, or have a picnic on the Great Lawn.\n",
+            "4. Go to a Broadway show: NYC is home to some of the world's most iconic theaters and productions. Catch a musical or play on Broadway for an unforgettable experience.\n",
+            "5. Visit the 9/11 Memorial & Museum: This moving tribute to the victims of the 9/11 attacks features two large reflecting pools surrounded by the names of those who were killed, as well as a museum with artifacts and stories from that day.\n",
+            "6. Take a food tour: NYC is known for its diverse culinary scene, and there are countless food tours available to explore the city's many cuisines. From pizza to bagels to dumplings, you'll find it all in NYC.\n",
+            "7. Visit the Guggenheim Museum: Designed by Frank Lloyd Wright, this museum is home to a world-class collection of modern and contemporary art. Be sure to check out the iconic spiral staircase.\n",
+            "8. Go shopping on Fifth Avenue: This iconic street is home to some of the world's most high-end retailers, including Saks Fifth Avenue, Bergdorf Goodman, and Tiffany & Co. Even if you're not planning to buy anything, window shopping is a fun and indulgent activity.\n",
+            "9. Take a ride on the Staten Island Ferry: This free ferry takes you across the harbor to Staten Island and offers stunning views of the Manhattan skyline and the Statue of Liberty. It's a great way to see the city from a different perspective.\n",
+            "10. Visit the Rockefeller Center: This complex of buildings in Midtown Manhattan is home to NBC studios, a skating rink, and the famous Christmas tree lighting ceremony. It's a fun place to explore and take photos.\n",
+            "\n",
+            "These are just a few of the many fun attractions that NYC has to offer. There's something for everyone in this vibrant and exciting city!"
+          ]
+        }
+      ],
+      "source": [
+        "# Run a single prompt (with streaming). inference_options = InferenceOptions(stream=True)\n",
+        "\n",
+        "inference_options = InferenceOptions(stream=True)\n",
+        "activities = await config.run(\"get_activities\", options=inference_options)"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5Fgj5w85Sbch"
+      },
+      "source": [
+        "# Run `gen_itinerary` prompt chain (mixtral-8x7b)\n",
+        "\n",
+        "**Note**: In `travel.aiconfig.json`, `gen_itinerary` is defined as:\n",
+        "\n",
+        "```json\n",
+        "{\n",
+        "    \"name\": \"gen_itinerary\",\n",
+        "    \"input\": \"Generate an itinerary ordered by {{order_by}} for these activities: {{get_activities.output}}.\",\n",
+        "    \"metadata\": {\n",
+        "        \"model\": {\n",
+        "            \"name\": \"AnyscaleEndpoint\",\n",
+        "            \"settings\": {\n",
+        "            \"model\": \"mistralai/Mixtral-8x7B-Instruct-v0.1\",\n",
+        "            \"max_tokens\": 3000,\n",
+        "            \"system_prompt\": \"You are an expert travel coordinator with exquisite taste.\"\n",
+        "            }\n",
+        "        },\n",
+        "        \"parameters\": {\n",
+        "            \"order_by\": \"geographic location\"\n",
+        "        }\n",
+        "    }\n",
+        "}\n",
+        "```\n",
+        "\n",
+        "This means it depends on the output of the `get_activities` prompt, and uses that to run inference with mixtral-8x7B. Let's run this prompt chain with AIConfig"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "49xN8OiqSeMX",
+        "outputId": "624b046a-2812-45b4-f875-e7cc12249845"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  Sure! Here are 10 fun attractions to do in New York City:\n",
+            "\n",
+            "1. Visit the Statue of Liberty and Ellis Island: Take a ferry to Liberty Island to see the iconic Statue of Liberty up close and learn about its history at the nearby Ellis Island Immigration Museum.\n",
+            "2. Explore the Metropolitan Museum of Art: With over 2 million works of art spanning 5,000 years of history, the Met is one of the world's largest and most comprehensive art museums.\n",
+            "3. Walk across the Brooklyn Bridge: Take a stroll across this iconic bridge for spectacular views of the Manhattan skyline, the East River, and Brooklyn.\n",
+            "4. See a Broadway show: New York City is home to dozens of world-class theaters and performances, including Tony-award winning shows like Hamilton, Wicked, and The Lion King.\n",
+            "5. Visit Central Park: This 843-acre green oasis in the middle of Manhattan offers a peaceful escape from the hustle and bustle of the city, with plenty of walking paths, lakes, and monuments to explore.\n",
+            "6. Go shopping on Fifth Avenue: From high-end designer boutiques to exclusive department stores, Fifth Avenue is the ultimate shopping destination in NYC.\n",
+            "7. Visit the 9/11 Memorial & Museum: A poignant tribute to the victims of the 9/11 attacks, the memorial features two reflecting pools surrounded by the names of those who were killed, as well as a museum with artifacts and stories from that fateful day.\n",
+            "8. Take a food tour: New York City is a food lover's paradise, with a diverse array of cuisines and dining options. Take a guided tour to sample some of the city's best foods, from classic pizza to artisanal doughnuts.\n",
+            "9. Visit the Museum of Modern Art (MoMA): With a collection of over 200,000 works of art, MoMA is one of the world's premier modern art museums, featuring pieces by artists like Picasso, Warhol, and Pollock.\n",
+            "10. Take a helicopter tour of NYC: For a unique perspective on the city, take a helicopter tour of New York City's iconic skyline and landmarks. You'll soar over the Hudson River and get a bird's-eye view of Manhattan's towering skyscrapers, bridges, and parks.\n",
+            "\n",
+            "These are just a few of the many fun attractions to explore in New York City. Depending on your interests, there are countless other activities and experiences to enjoy in the city that never sleeps! 1. Private guided tour of the Louvre Museum (2-3 hours)\n",
+            "Begin your journey with a private guided tour of the Louvre Museum, the world's largest art museum and a historic monument in Paris. This tour will allow you to explore the museum's most famous works, including the Mona Lisa, the Winged Victory of Samothrace, and the Venus de Milo, with a knowledgeable guide who can provide context and insight into the artwork.\n",
+            "\n",
+            "2. Champagne tasting at a prestigious champagne house in Reims (2 hours)\n",
+            "Next, head to Reims, a city in the Champagne region of France, for a private champagne tasting at a prestigious champagne house such as Taittinger, Veuve Clicquot, or Ruinart. You'll learn about the history and production methods of champagne, as well as have the opportunity to taste a selection of their finest bubbly.\n",
+            "\n",
+            "3. Lunch at a Michelin-starred restaurant in Reims (1.5-2 hours)\n",
+            "Treat yourself to lunch at one of Reims' Michelin-starred restaurants, such as Le Foch, where you can sample local specialties such as Jambon de Reims, or Reims ham, and indulge in expertly prepared dishes made with fresh, seasonal ingredients.\n",
+            "\n",
+            "4. Private guided tour of the Palace of Versailles (3-4 hours)\n",
+            "No trip to France would be complete without a visit to the Palace of Versailles, the opulent palace and gardens of the French monarchy. A private guided tour will allow you to explore the palace's grand halls, ornate apartments, and incomparable art collections, as well as stroll through the meticulously manicured gardens and fountains.\n",
+            "\n",
+            "5. Seine River dinner cruise (2-3 hours)\n",
+            "End your day with a romantic Seine River dinner cruise, where you'll float past some of Paris' most iconic landmarks, including the Eiffel Tower, Notre-Dame Cathedral, and the Louvre Museum, all while enjoying a delicious meal and live music.\n",
+            "\n",
+            "6. Private guided tour of Montmartre and Sacré-Coeur Basilica (2-3 hours)\n",
+            "Begin your second day with a private guided tour of Montmartre, the historic and artistic neighborhood atop a hill in Paris. This tour will take you through the charming streets of Montmartre, past the Moulin Rouge and the Place du Tertre, to the iconic white-domed Basilica of Sacré-Coeur.\n",
+            "\n",
+            "7. Cooking class at a professional cooking school in Paris (3-4 hours)\n",
+            "Next, immerse yourself in French culinary traditions with a private cooking class at a professional cooking school. You'll learn how to prepare classic French dishes such as coq au vin, ratatouille, or tarte tatin, and have the opportunity to enjoy the fruits of your labor for lunch.\n",
+            "\n",
+            "8. Private guided tour of the Musée d'Orsay (2-3 hours)\n",
+            "End your trip with a private guided tour of the Musée d'Orsay, a museum located in a former railway station, which houses a vast collection of Impressionist and Post-Impressionist art. This tour will allow you to see works by artists such as Monet, Renoir, Degas, and Van Gogh, and gain a deeper understanding of the artistic movements that defined this period."
+          ]
+        }
+      ],
+      "source": [
+        "# This time, let's also add a callback manager to log more detailed events\n",
+        "config.callback_manager = CallbackManager.create_default_manager()\n",
+        "\n",
+        "itinerary = await config.run(\n",
+        "    \"gen_itinerary\",\n",
+        "    params={\"order_by\": \"duration\"},\n",
+        "    run_with_dependencies=True,\n",
+        "    options=inference_options)"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7DTy5qLpRxlx"
+      },
+      "source": [
+        "# Add prompt to config"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "xjdyaO9HRvFr",
+        "outputId": "dd6d3b67-88e4-4a8e-b4c4-58919a6a40b1"
+      },
+      "outputs": [],
+      "source": [
+        "# Add gen_packing_list as a prompt to config\n",
+        "model = \"gpt-3.5-turbo\"\n",
+        "data = {\n",
+        "    \"model\": model,\n",
+        "    \"messages\": [\n",
+        "        {\n",
+        "            \"role\": \"system\",\n",
+        "            \"content\": \"You provide a bulleted list of items to pack for a week long trip.\"\n",
+        "        },\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": \"What should I bring to {{location}}?\"\n",
+        "        }\n",
+        "    ]\n",
+        "}\n",
+        "\n",
+        "new_prompts = await config.serialize(model, data, prompt_name=\"gen_packing_list\", params={\"location\": \"nyc\"})\n",
+        "config.add_prompt(prompt_name=\"gen_packing_list\", prompt_data=new_prompts[0])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "O9b_n26SsSZt",
+        "outputId": "0178d7ae-758e-4135-f452-75ee6ac19c41"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "- Clothes for a week, including underwear, socks, and sleepwear\n",
+            "- Outerwear appropriate for the weather (jacket, coat, or sweater)\n",
+            "- Comfortable shoes for walking\n",
+            "- Toiletries (toothbrush, toothpaste, shampoo, conditioner, soap, etc.)\n",
+            "- Medications, if needed\n",
+            "- Phone charger and other electronic accessories\n",
+            "- Personal identification and travel documents (ID, passport, visa, etc.)\n",
+            "- Wallet with cash and/or credit cards\n",
+            "- Travel-sized umbrella or raincoat, depending on the weather forecast\n",
+            "- Snacks and water bottle for the journey\n",
+            "- Any necessary electronics or gadgets (camera, laptop, etc.)\n",
+            "- Entertainment options (books, magazines, headphones, etc.)\n",
+            "- Travel adapter, if necessary\n",
+            "- Maps or guidebook of NYC\n",
+            "- Sunscreen and sunglasses, if visiting during summer or sunny weather\n",
+            "- Light backpack or day bag for touring around the city\n",
+            "- Any special items specific to your needs or interests (art supplies, workout gear, etc.)"
+          ]
+        }
+      ],
+      "source": [
+        "packing_list = await config.run(\"gen_packing_list\", params=None, options=inference_options)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Pause and appreciate what we just did\n",
+        "\n",
+        "We ran the `get_activities` prompt with LLaMA-7B, the `gen_itinerary` prompt (which depends on `get_activities`) with Mixtral-8x7B, and now just added a `gen_packing_list` prompt with gpt-3.5. \n",
+        "\n",
+        "Anyscale helps us get optimized inference for open source models, and AIConfig enables us to mix and match different model providers (OpenAI, Anyscale and others) in a model-agnostic generative AI application."
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "q9deFcBK55yN"
+      },
+      "source": [
+        "# 5. Save the AIConfig\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "9BR4-nGxSth7"
+      },
+      "outputs": [],
+      "source": [
+        "# Save the aiconfig to disk. and serialize outputs from the model run\n",
+        "config.save('updated.aiconfig.json', include_outputs=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Save the aiconfig as a YAML file\n",
+        "\n",
+        "AIConfig supports both JSON and YAML modes, allowing you to save a config representing the generative AI signature of your AI application in the format of your choice."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "config.save('travel.aiconfig.yaml', include_outputs=False, mode=\"yaml\")"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JLiElYyC6DB-"
+      },
+      "source": [
+        "# 6. Open the AIConfig in AI Workbook Playground\n",
+        "1. Download `updated.aiconfig.json`.\n",
+        "2. Go to https://lastmileai.dev.\n",
+        "3. Go to Workbooks page: https://lastmileai.dev/workbooks.\n",
+        "4. Click dropdown '+New Workbook' and select 'Create from AIConfig'\n",
+        "5. Upload `updated.aiconfig.json`.\n",
+        "\n",
+        "Try out the workbook playground here: [NYC Travel Workbook](https://lastmileai.dev/workbooks/clooqs3p200kkpe53u6n2rhr9)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.1"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/cookbooks/Anyscale/recommender.aiconfig.json
+++ b/cookbooks/Anyscale/recommender.aiconfig.json
@@ -1,0 +1,91 @@
+{
+  "name": "Book Finder",
+  "schema_version": "latest",
+  "metadata": {
+    "parameters": {},
+    "models": {},
+    "model_parsers": {
+      "mistralai/Mistral-7B-Instruct-v0.1": "AnyscaleEndpoint",
+      "mistralai/Mixtral-8x7B-Instruct-v0.1": "AnyscaleEndpoint"
+    }
+  },
+  "description": "Use Mixtral-8x7B function calling with Anyscale Endpoints to help recommend books",
+  "prompts": [
+    {
+      "name": "recommend_book",
+      "input": "I really enjoyed reading {{book}}, could you recommend me a book that is similar and tell me why?",
+      "metadata": {
+        "model": {
+          "name": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+          "settings": {
+            "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "tools": [
+              {
+                "type": "function",
+                "function": {
+                  "name": "list",
+                  "description": "list queries books by genre, and returns a list of names of books",
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "genre": {
+                        "type": "string",
+                        "enum": [
+                          "mystery",
+                          "nonfiction",
+                          "memoir",
+                          "romance",
+                          "historical"
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "function",
+                "function": {
+                  "name": "search",
+                  "description": "search queries books by their name and returns a list of book names and their ids",
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "function",
+                "function": {
+                  "name": "get",
+                  "description": "get returns a book's detailed information based on the id of the book. Note that this does not accept names, and only IDs, which you can get by using search.",
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "system_prompt": {
+              "role": "system",
+              "content": "Please use our book database, which you can access using functions to answer the following questions."
+            }
+          }
+        },
+        "parameters": {
+          "book": "To Kill a Mockingbird"
+        },
+        "remember_chat_context": true
+      },
+      "outputs": []
+    }
+  ],
+  "$schema": "https://json.schemastore.org/aiconfig-1.0"
+}

--- a/cookbooks/Anyscale/travel.aiconfig.json
+++ b/cookbooks/Anyscale/travel.aiconfig.json
@@ -1,0 +1,55 @@
+{
+  "name": "NYC Trip Planner",
+  "description": "Intrepid explorer with ChatGPT and AIConfig",
+  "schema_version": "latest",
+  "metadata": {
+    "model_parsers": {
+      "meta-llama/Llama-2-7b-chat-hf": "AnyscaleEndpoint",
+      "meta-llama/Llama-2-13b-chat-hf": "AnyscaleEndpoint",
+      "Meta-Llama/Llama-Guard-7b": "AnyscaleEndpoint",
+      "meta-llama/Llama-2-70b-chat-hf": "AnyscaleEndpoint",
+      "Open-Orca/Mistral-7B-OpenOrca": "AnyscaleEndpoint",
+      "codellama/CodeLlama-34b-Instruct-hf": "AnyscaleEndpoint",
+      "HuggingFaceH4/zephyr-7b-beta": "AnyscaleEndpoint",
+      "mistralai/Mistral-7B-Instruct-v0.1": "AnyscaleEndpoint",
+      "mistralai/Mixtral-8x7B-Instruct-v0.1": "AnyscaleEndpoint",
+      "thenlper/gte-large": "AnyscaleEndpoint"
+    },
+    "models": {
+      "meta-llama/Llama-2-7b-chat-hf": {
+        "model": "meta-llama/Llama-2-7b-chat-hf",
+        "top_p": 1,
+        "temperature": 1
+      },
+      "meta-llama/Llama-2-70b-chat-hf": {
+        "model": "meta-llama/Llama-2-70b-chat-hf",
+        "max_tokens": 3000,
+        "system_prompt": "You are an expert travel coordinator with exquisite taste."
+      }
+    },
+    "default_model": "meta-llama/Llama-2-7b-chat-hf"
+  },
+  "prompts": [
+    {
+      "name": "get_activities",
+      "input": "Tell me 10 fun attractions to do in NYC."
+    },
+    {
+      "name": "gen_itinerary",
+      "input": "Generate an itinerary ordered by {{order_by}} for these activities: {{get_activities.output}}.",
+      "metadata": {
+        "model": {
+          "name": "AnyscaleEndpoint",
+          "settings": {
+            "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "max_tokens": 3000,
+            "system_prompt": "You are an expert travel coordinator with exquisite taste."
+          }
+        },
+        "parameters": {
+          "order_by": "geographic location"
+        }
+      }
+    }
+  ]
+}

--- a/cookbooks/Anyscale/travel.aiconfig.yaml
+++ b/cookbooks/Anyscale/travel.aiconfig.yaml
@@ -1,0 +1,53 @@
+description: Intrepid explorer with ChatGPT and AIConfig
+metadata:
+  default_model: meta-llama/Llama-2-7b-chat-hf
+  model_parsers:
+    HuggingFaceH4/zephyr-7b-beta: AnyscaleEndpoint
+    Meta-Llama/Llama-Guard-7b: AnyscaleEndpoint
+    Open-Orca/Mistral-7B-OpenOrca: AnyscaleEndpoint
+    codellama/CodeLlama-34b-Instruct-hf: AnyscaleEndpoint
+    meta-llama/Llama-2-13b-chat-hf: AnyscaleEndpoint
+    meta-llama/Llama-2-70b-chat-hf: AnyscaleEndpoint
+    meta-llama/Llama-2-7b-chat-hf: AnyscaleEndpoint
+    mistralai/Mistral-7B-Instruct-v0.1: AnyscaleEndpoint
+    mistralai/Mixtral-8x7B-Instruct-v0.1: AnyscaleEndpoint
+    thenlper/gte-large: AnyscaleEndpoint
+  models:
+    meta-llama/Llama-2-70b-chat-hf:
+      max_tokens: 3000
+      model: meta-llama/Llama-2-70b-chat-hf
+      system_prompt: You are an expert travel coordinator with exquisite taste.
+    meta-llama/Llama-2-7b-chat-hf:
+      model: meta-llama/Llama-2-7b-chat-hf
+      temperature: 1
+      top_p: 1
+  parameters: {}
+name: NYC Trip Planner
+prompts:
+- input: Tell me 10 fun attractions to do in NYC.
+  name: get_activities
+- input: 'Generate an itinerary ordered by {{order_by}} for these activities: {{get_activities.output}}.'
+  metadata:
+    model:
+      name: AnyscaleEndpoint
+      settings:
+        max_tokens: 3000
+        model: mistralai/Mixtral-8x7B-Instruct-v0.1
+        system_prompt: You are an expert travel coordinator with exquisite taste.
+    parameters:
+      order_by: geographic location
+  name: gen_itinerary
+- input: What should I bring to {{location}}?
+  metadata:
+    model:
+      name: gpt-3.5-turbo
+      settings:
+        model: gpt-3.5-turbo
+        system_prompt:
+          content: You provide a bulleted list of items to pack for a week long trip.
+          role: system
+    parameters:
+      location: nyc
+    remember_chat_context: true
+  name: gen_packing_list
+schema_version: latest

--- a/cookbooks/Anyscale/updated.aiconfig.json
+++ b/cookbooks/Anyscale/updated.aiconfig.json
@@ -1,0 +1,116 @@
+{
+  "name": "NYC Trip Planner",
+  "schema_version": "latest",
+  "metadata": {
+    "parameters": {},
+    "models": {
+      "meta-llama/Llama-2-7b-chat-hf": {
+        "model": "meta-llama/Llama-2-7b-chat-hf",
+        "top_p": 1,
+        "temperature": 1
+      },
+      "meta-llama/Llama-2-70b-chat-hf": {
+        "model": "meta-llama/Llama-2-70b-chat-hf",
+        "max_tokens": 3000,
+        "system_prompt": "You are an expert travel coordinator with exquisite taste."
+      }
+    },
+    "default_model": "meta-llama/Llama-2-7b-chat-hf",
+    "model_parsers": {
+      "meta-llama/Llama-2-7b-chat-hf": "AnyscaleEndpoint",
+      "meta-llama/Llama-2-13b-chat-hf": "AnyscaleEndpoint",
+      "Meta-Llama/Llama-Guard-7b": "AnyscaleEndpoint",
+      "meta-llama/Llama-2-70b-chat-hf": "AnyscaleEndpoint",
+      "Open-Orca/Mistral-7B-OpenOrca": "AnyscaleEndpoint",
+      "codellama/CodeLlama-34b-Instruct-hf": "AnyscaleEndpoint",
+      "HuggingFaceH4/zephyr-7b-beta": "AnyscaleEndpoint",
+      "mistralai/Mistral-7B-Instruct-v0.1": "AnyscaleEndpoint",
+      "mistralai/Mixtral-8x7B-Instruct-v0.1": "AnyscaleEndpoint",
+      "thenlper/gte-large": "AnyscaleEndpoint"
+    }
+  },
+  "description": "Intrepid explorer with ChatGPT and AIConfig",
+  "prompts": [
+    {
+      "name": "get_activities",
+      "input": "Tell me 10 fun attractions to do in NYC.",
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "role": "assistant",
+            "content": "  Sure! Here are 10 fun attractions to do in New York City:\n\n1. Visit the Statue of Liberty and Ellis Island: Take a ferry to Liberty Island to see the iconic Statue of Liberty up close and learn about its history at the nearby Ellis Island Immigration Museum.\n2. Explore the Metropolitan Museum of Art: With over 2 million works of art spanning 5,000 years of history, the Met is one of the world's largest and most comprehensive art museums.\n3. Walk across the Brooklyn Bridge: Take a stroll across this iconic bridge for spectacular views of the Manhattan skyline, the East River, and Brooklyn.\n4. See a Broadway show: New York City is home to dozens of world-class theaters and performances, including Tony-award winning shows like Hamilton, Wicked, and The Lion King.\n5. Visit Central Park: This 843-acre green oasis in the middle of Manhattan offers a peaceful escape from the hustle and bustle of the city, with plenty of walking paths, lakes, and monuments to explore.\n6. Go shopping on Fifth Avenue: From high-end designer boutiques to exclusive department stores, Fifth Avenue is the ultimate shopping destination in NYC.\n7. Visit the 9/11 Memorial & Museum: A poignant tribute to the victims of the 9/11 attacks, the memorial features two reflecting pools surrounded by the names of those who were killed, as well as a museum with artifacts and stories from that fateful day.\n8. Take a food tour: New York City is a food lover's paradise, with a diverse array of cuisines and dining options. Take a guided tour to sample some of the city's best foods, from classic pizza to artisanal doughnuts.\n9. Visit the Museum of Modern Art (MoMA): With a collection of over 200,000 works of art, MoMA is one of the world's premier modern art museums, featuring pieces by artists like Picasso, Warhol, and Pollock.\n10. Take a helicopter tour of NYC: For a unique perspective on the city, take a helicopter tour of New York City's iconic skyline and landmarks. You'll soar over the Hudson River and get a bird's-eye view of Manhattan's towering skyscrapers, bridges, and parks.\n\nThese are just a few of the many fun attractions to explore in New York City. Depending on your interests, there are countless other activities and experiences to enjoy in the city that never sleeps!"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        }
+      ]
+    },
+    {
+      "name": "gen_itinerary",
+      "input": "Generate an itinerary ordered by {{order_by}} for these activities: {{get_activities.output}}.",
+      "metadata": {
+        "model": {
+          "name": "AnyscaleEndpoint",
+          "settings": {
+            "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "max_tokens": 3000,
+            "system_prompt": "You are an expert travel coordinator with exquisite taste."
+          }
+        },
+        "parameters": {
+          "order_by": "geographic location"
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "role": "assistant",
+            "content": " 1. Private guided tour of the Louvre Museum (2-3 hours)\nBegin your journey with a private guided tour of the Louvre Museum, the world's largest art museum and a historic monument in Paris. This tour will allow you to explore the museum's most famous works, including the Mona Lisa, the Winged Victory of Samothrace, and the Venus de Milo, with a knowledgeable guide who can provide context and insight into the artwork.\n\n2. Champagne tasting at a prestigious champagne house in Reims (2 hours)\nNext, head to Reims, a city in the Champagne region of France, for a private champagne tasting at a prestigious champagne house such as Taittinger, Veuve Clicquot, or Ruinart. You'll learn about the history and production methods of champagne, as well as have the opportunity to taste a selection of their finest bubbly.\n\n3. Lunch at a Michelin-starred restaurant in Reims (1.5-2 hours)\nTreat yourself to lunch at one of Reims' Michelin-starred restaurants, such as Le Foch, where you can sample local specialties such as Jambon de Reims, or Reims ham, and indulge in expertly prepared dishes made with fresh, seasonal ingredients.\n\n4. Private guided tour of the Palace of Versailles (3-4 hours)\nNo trip to France would be complete without a visit to the Palace of Versailles, the opulent palace and gardens of the French monarchy. A private guided tour will allow you to explore the palace's grand halls, ornate apartments, and incomparable art collections, as well as stroll through the meticulously manicured gardens and fountains.\n\n5. Seine River dinner cruise (2-3 hours)\nEnd your day with a romantic Seine River dinner cruise, where you'll float past some of Paris' most iconic landmarks, including the Eiffel Tower, Notre-Dame Cathedral, and the Louvre Museum, all while enjoying a delicious meal and live music.\n\n6. Private guided tour of Montmartre and Sacr\u00e9-Coeur Basilica (2-3 hours)\nBegin your second day with a private guided tour of Montmartre, the historic and artistic neighborhood atop a hill in Paris. This tour will take you through the charming streets of Montmartre, past the Moulin Rouge and the Place du Tertre, to the iconic white-domed Basilica of Sacr\u00e9-Coeur.\n\n7. Cooking class at a professional cooking school in Paris (3-4 hours)\nNext, immerse yourself in French culinary traditions with a private cooking class at a professional cooking school. You'll learn how to prepare classic French dishes such as coq au vin, ratatouille, or tarte tatin, and have the opportunity to enjoy the fruits of your labor for lunch.\n\n8. Private guided tour of the Mus\u00e9e d'Orsay (2-3 hours)\nEnd your trip with a private guided tour of the Mus\u00e9e d'Orsay, a museum located in a former railway station, which houses a vast collection of Impressionist and Post-Impressionist art. This tour will allow you to see works by artists such as Monet, Renoir, Degas, and Van Gogh, and gain a deeper understanding of the artistic movements that defined this period."
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        }
+      ]
+    },
+    {
+      "name": "gen_packing_list",
+      "input": "What should I bring to {{location}}?",
+      "metadata": {
+        "model": {
+          "name": "gpt-3.5-turbo",
+          "settings": {
+            "model": "gpt-3.5-turbo",
+            "system_prompt": {
+              "role": "system",
+              "content": "You provide a bulleted list of items to pack for a week long trip."
+            }
+          }
+        },
+        "parameters": {
+          "location": "nyc"
+        },
+        "remember_chat_context": true
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": {
+            "content": "- Clothes for a week, including underwear, socks, and sleepwear\n- Outerwear appropriate for the weather (jacket, coat, or sweater)\n- Comfortable shoes for walking\n- Toiletries (toothbrush, toothpaste, shampoo, conditioner, soap, etc.)\n- Medications, if needed\n- Phone charger and other electronic accessories\n- Personal identification and travel documents (ID, passport, visa, etc.)\n- Wallet with cash and/or credit cards\n- Travel-sized umbrella or raincoat, depending on the weather forecast\n- Snacks and water bottle for the journey\n- Any necessary electronics or gadgets (camera, laptop, etc.)\n- Entertainment options (books, magazines, headphones, etc.)\n- Travel adapter, if necessary\n- Maps or guidebook of NYC\n- Sunscreen and sunglasses, if visiting during summer or sunny weather\n- Light backpack or day bag for touring around the city\n- Any special items specific to your needs or interests (art supplies, workout gear, etc.)",
+            "role": "assistant"
+          },
+          "metadata": {
+            "finish_reason": "stop"
+          }
+        }
+      ]
+    }
+  ],
+  "$schema": "https://json.schemastore.org/aiconfig-1.0"
+}

--- a/cookbooks/Function-Calling-OpenAI/README.md
+++ b/cookbooks/Function-Calling-OpenAI/README.md
@@ -4,6 +4,6 @@
 
 This example is taken from [OpenAI's function calling demo](https://github.com/openai/openai-node/blob/v4/examples/function-call-stream.ts) and modified to show how the same functionality can be done more simply with AIConfig.
 
-TThis notebook serves as a practical guide for leveraging AIConfig and function calling with OpenAI models. We start with a mock database of books and functions to list, search, and retrieve books. Function calling is enabled so the LLM can interpret a user's question, determine the appropriate function to call, and execute the function. Read more about [Function Calling with Open AI](https://openai.com/blog/function-calling-and-other-api-updates) and [AIConfig for prompt and model management](https://github.com/lastmile-ai/aiconfig).
+This notebook serves as a practical guide for leveraging AIConfig and function calling with OpenAI models. We start with a mock database of books and functions to list, search, and retrieve books. Function calling is enabled so the LLM can interpret a user's question, determine the appropriate function to call, and execute the function. Read more about [Function Calling with Open AI](https://openai.com/blog/function-calling-and-other-api-updates) and [AIConfig for prompt and model management](https://github.com/lastmile-ai/aiconfig).
 
 [Google Colab notebook](https://colab.research.google.com/drive/1RZ5s2XmD-Gkg64QlS80lgwOFT3F7J346)

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import requests
 from aiconfig.callback import CallbackEvent, CallbackManager
+from aiconfig.default_parsers.anyscale_endpoint import DefaultAnyscaleEndpointParser
 from aiconfig.default_parsers.openai import DefaultOpenAIParser
 from aiconfig.default_parsers.palm import PaLMChatParser, PaLMTextParser
 from aiconfig.model_parser import InferenceOptions, ModelParser
@@ -35,6 +36,7 @@ gpt_models = [
 ]
 for model in gpt_models:
     ModelParserRegistry.register_model_parser(DefaultOpenAIParser(model))
+ModelParserRegistry.register_model_parser(DefaultAnyscaleEndpointParser("AnyscaleEndpoint"))
 ModelParserRegistry.register_model_parser(PaLMChatParser())
 ModelParserRegistry.register_model_parser(PaLMTextParser())
 ModelParserRegistry.register_model_parser(HuggingFaceTextGenerationParser())

--- a/python/src/aiconfig/default_parsers/anyscale_endpoint.py
+++ b/python/src/aiconfig/default_parsers/anyscale_endpoint.py
@@ -1,0 +1,270 @@
+import copy
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
+
+from openai import OpenAI
+from openai.types.chat import ChatCompletionMessage
+from aiconfig.callback import CallbackEvent
+from aiconfig.model_parser import InferenceOptions
+from aiconfig.schema import (
+    ExecuteResult,
+    FunctionCallData,
+    Output,
+    OutputDataWithValue,
+    OutputDataWithToolCallsValue,
+    Prompt,
+    ToolCallData,
+)
+from aiconfig.util.config_utils import get_api_key_from_environment
+
+from .openai import OpenAIInference
+
+if TYPE_CHECKING:
+    from aiconfig.Config import AIConfigRuntime
+
+
+class AnyscaleEndpoint(OpenAIInference):
+    async def run_inference(
+        self,
+        prompt: Prompt,
+        aiconfig: "AIConfigRuntime",
+        options: InferenceOptions,
+        parameters: Optional[Dict],
+    ) -> List[Output]:
+        """
+        Invoked to run a prompt in the .aiconfig. This method should perform
+        the actual model inference based on the provided prompt and inference settings.
+
+        Args:
+            prompt (str): The input prompt.
+            inference_settings (dict): Model-specific inference settings.
+
+        Returns:
+            ExecuteResult: The response from the model.
+        """
+        await aiconfig.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_run_start",
+                __name__,
+                {"prompt": prompt, "options": options, "parameters": parameters},
+            )
+        )
+
+        client = OpenAI(api_key=get_api_key_from_environment("ANYSCALE_ENDPOINT_API_KEY"), base_url="https://api.endpoints.anyscale.com/v1")
+
+        completion_data = await self.deserialize(prompt, aiconfig, parameters)
+        # if stream enabled in runtime options and config, then stream. Otherwise don't stream.
+        # const stream = options?.stream ?? completionParams.stream ?? true;
+        stream = True  # Default value
+
+        if options is not None and options.stream is not None:
+            stream = options.stream
+        elif "stream" in completion_data:
+            stream = completion_data["stream"]
+
+        completion_data["stream"] = stream
+
+        response = client.chat.completions.create(**completion_data)
+        outputs = []
+        if not stream:
+            # # OpenAI>1.0.0 uses pydantic models for response
+            response = response.model_dump(exclude_none=True)
+
+            response_without_choices = {key: copy.deepcopy(value) for key, value in response.items() if key != "choices"}
+            for i, choice in enumerate(response.get("choices")):
+                output_message = choice["message"]
+                output_data = build_output_data(output_message)
+
+                response_without_choices.update({"finish_reason": choice.get("finish_reason")})
+                metadata = {"raw_response": output_message, **response_without_choices}
+                if output_message.get("role", None) is not None:
+                    metadata["role"] = output_message.get("role")
+
+                output = ExecuteResult(
+                    **{
+                        "output_type": "execute_result",
+                        "data": output_data,
+                        "execution_count": i,
+                        "metadata": metadata,
+                    }
+                )
+
+                outputs.append(output)
+        else:
+            outputs = {}
+            messages = {}
+            for chunk in response:
+                # OpenAI>1.0.0 uses pydantic models. Chunk is of type ChatCompletionChunk; type is not directly importable from openai Library, will require some diffing
+                chunk = chunk.model_dump(exclude_none=True)
+                # streaming only returns one chunk, one choice at a time (before 1.0.0). The order in which the choices are returned is not guaranteed.
+                messages = multi_choice_message_reducer(messages, chunk)
+
+                for i, choice in enumerate(chunk["choices"]):
+                    index = choice.get("index")
+                    accumulated_message_for_choice = messages.get(index, "")
+                    delta = choice.get("delta")
+
+                    if options and options.stream_callback:
+                        options.stream_callback(delta, accumulated_message_for_choice, index)
+
+                    output = ExecuteResult(
+                        **{
+                            "output_type": "execute_result",
+                            "data": accumulated_message_for_choice,
+                            "execution_count": index,
+                            "metadata": {"finish_reason": choice.get("finish_reason")},
+                        }
+                    )
+                    outputs[index] = output
+            outputs = [outputs[i] for i in sorted(list(outputs.keys()))]
+
+        # rewrite or extend list of outputs?
+        prompt.outputs = outputs
+
+        await aiconfig.callback_manager.run_callbacks(CallbackEvent("on_run_complete", __name__, {"result": prompt.outputs}))
+        return prompt.outputs
+
+
+class DefaultAnyscaleEndpointParser(AnyscaleEndpoint):
+    def __init__(self, model_id: str):
+        super().__init__()
+        self.model_id = model_id
+
+    def id(self) -> str:
+        return self.model_id
+
+
+class LLaMA2_7B_Chat(DefaultAnyscaleEndpointParser):
+    def __init__(self):
+        model_id = "meta-llama/Llama-2-7b-chat-hf"
+        super().__init__(model_id)
+
+
+class LLaMA2_13B_Chat(DefaultAnyscaleEndpointParser):
+    def __init__(self):
+        model_id = "meta-llama/Llama-2-13b-chat-hf"
+        super().__init__(model_id)
+
+
+class LLaMA2_70B_Chat(DefaultAnyscaleEndpointParser):
+    def __init__(self):
+        model_id = "meta-llama/Llama-2-70b-chat-hf"
+        super().__init__(model_id)
+
+
+class LLaMAGuard_7B(DefaultAnyscaleEndpointParser):
+    def __init__(self):
+        model_id = "Meta-Llama/Llama-Guard-7b"
+        super().__init__(model_id)
+
+
+class Mistral_7B_OpenOrca(DefaultAnyscaleEndpointParser):
+    def __init__(self):
+        model_id = "Open-Orca/Mistral-7B-OpenOrca"
+        super().__init__(model_id)
+
+
+class CodeLLaMA_34B(DefaultAnyscaleEndpointParser):
+    def __init__(self):
+        model_id = "codellama/CodeLlama-34b-Instruct-hf"
+        super().__init__(model_id)
+
+
+class Zephyr_7B(DefaultAnyscaleEndpointParser):
+    def __init__(self):
+        model_id = "HuggingFaceH4/zephyr-7b-beta"
+        super().__init__(model_id)
+
+
+class Mistral_7B(DefaultAnyscaleEndpointParser):
+    def __init__(self):
+        model_id = "mistralai/Mistral-7B-Instruct-v0.1"
+        super().__init__(model_id)
+
+
+class Mixtral_8x7B(DefaultAnyscaleEndpointParser):
+    def __init__(self):
+        model_id = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+        super().__init__(model_id)
+
+
+def reduce(acc, delta):
+    acc = copy.deepcopy(acc)
+
+    for key, value in delta.items():
+        if key not in acc:
+            # If the key doesn't exist in 'acc', add it with the 'value'
+            acc[key] = value
+        elif isinstance(acc[key], str) and isinstance(value, str):
+            # If both 'acc[key]' and 'value' are strings, concatenate them
+            acc[key] += value
+        elif isinstance(acc[key], dict) and not isinstance(acc[key], list):
+            # If 'acc[key]' is a dictionary (not a list), recursively merge it with 'value'
+            acc[key] = reduce(acc[key], value)
+
+    return acc
+
+
+def multi_choice_message_reducer(messages: Union[Dict[int, dict], None], chunk: dict) -> Dict[int, dict]:
+    if messages is None:
+        messages = {}
+
+    # elif len(messages) != len(chunk["choices"]):
+    #     raise ValueError("Invalid number of previous choices -- it should match the incoming number of choices")
+
+    for choice in chunk["choices"]:
+        index = choice["index"]
+        previous_message = messages.get(index, {})
+        updated_message = reduce(previous_message, choice["delta"])
+        messages[index] = updated_message
+
+    return messages
+
+
+def build_output_data(
+    message: Union[ChatCompletionMessage, None],
+) -> Union[OutputDataWithValue, str, None]:
+    if message is None:
+        return None
+
+    output_data: Union[OutputDataWithValue, str, None] = None
+    if message.get("content") is not None:
+        output_data = message.get("content")  # string
+    elif message.get("tool_calls") is not None:
+        tool_calls = [
+            ToolCallData(
+                id=item.id,
+                function=FunctionCallData(
+                    arguments=item.function.arguments,
+                    name=item.function.name,
+                ),
+                type="function",
+            )
+            for item in message.get("tool_calls")
+            # It's possible that ChatCompletionMessageToolCall may
+            # support more than just function calls in the future
+            # so filter out other types
+            if item.type == "function"
+        ]
+        output_data = OutputDataWithToolCallsValue(
+            kind="tool_calls",
+            value=tool_calls,
+        )
+
+    # Deprecated, use tool_calls instead
+    elif message.get("function_call") is not None:
+        function_call = message.get("function_call")
+        tool_calls = [
+            ToolCallData(
+                id="function_call_data",  # value here does not matter
+                function=FunctionCallData(
+                    arguments=function_call["arguments"],
+                    name=function_call["name"],
+                ),
+                type="function",
+            )
+        ]
+        output_data = OutputDataWithToolCallsValue(
+            kind="tool_calls",
+            value=tool_calls,
+        )
+    return output_data

--- a/python/src/aiconfig/default_parsers/anyscale_endpoint.py
+++ b/python/src/aiconfig/default_parsers/anyscale_endpoint.py
@@ -1,6 +1,7 @@
 import copy
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
+import os
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessage
 from aiconfig.callback import CallbackEvent
@@ -49,7 +50,20 @@ class AnyscaleEndpoint(OpenAIInference):
             )
         )
 
-        client = OpenAI(api_key=get_api_key_from_environment("ANYSCALE_ENDPOINT_API_KEY"), base_url="https://api.endpoints.anyscale.com/v1")
+        anyscale_api_key_name = "ANYSCALE_ENDPOINT_API_KEY"
+        openai_api_key_name = "OPENAI_API_KEY"
+
+        if anyscale_api_key_name not in os.environ:
+            if openai_api_key_name not in os.environ:
+                raise Exception(
+                    f"Missing API keys '{anyscale_api_key_name}' and '{openai_api_key_name}' in environment. Expected one of them to be specified"
+                )
+            else:
+                api_key = os.environ[openai_api_key_name]
+        else:
+            api_key = os.environ[anyscale_api_key_name]
+
+        client = OpenAI(api_key=api_key, base_url="https://api.endpoints.anyscale.com/v1")
 
         completion_data = await self.deserialize(prompt, aiconfig, parameters)
         # if stream enabled in runtime options and config, then stream. Otherwise don't stream.

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -285,6 +285,7 @@ class OpenAIInference(ParameterizedModelParser):
             for chunk in response:
                 # OpenAI>1.0.0 uses pydantic models. Chunk is of type ChatCompletionChunk; type is not directly importable from openai Library, will require some diffing
                 chunk = chunk.model_dump(exclude_none=True)
+                chunk_without_choices = {key: copy.deepcopy(value) for key, value in chunk.items() if key != "choices"}
                 # streaming only returns one chunk, one choice at a time (before 1.0.0). The order in which the choices are returned is not guaranteed.
                 messages = multi_choice_message_reducer(messages, chunk)
 
@@ -301,11 +302,23 @@ class OpenAIInference(ParameterizedModelParser):
                             "output_type": "execute_result",
                             "data": accumulated_message_for_choice,
                             "execution_count": index,
-                            "metadata": {"finish_reason": choice.get("finish_reason")},
+                            "metadata": chunk_without_choices,
                         }
                     )
                     outputs[index] = output
             outputs = [outputs[i] for i in sorted(list(outputs.keys()))]
+
+            # Now that we have the complete outputs, we can parse it into our object model properly
+            for output in outputs:
+                output_message = output.data
+                output_data = build_output_data(output.data)
+
+                metadata = {"raw_response": output_message}
+                if output_message.get("role", None) is not None:
+                    metadata["role"] = output_message.get("role")
+
+                output.data = output_data
+                output.metadata = {**output.metadata, **metadata}
 
         # rewrite or extend list of outputs?
         prompt.outputs = outputs
@@ -537,7 +550,7 @@ def build_output_data(
         return None
 
     output_data: Union[OutputDataWithValue, str, None] = None
-    if message.get("content") is not None:
+    if message.get("content") is not None and message.get("content") != "":
         output_data = message.get("content")  # string
     elif message.get("tool_calls") is not None:
         tool_calls = []

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -853,13 +853,9 @@ AIConfig-level settings. If this is a mistake, please rerun the \
         """
         prompt = self.get_prompt(prompt_name)
         if not prompt:
-            raise IndexError(
-                f"Cannot add outputs. Prompt '{prompt_name}' not found in config."
-            )
+            raise IndexError(f"Cannot add outputs. Prompt '{prompt_name}' not found in config.")
         if not outputs:
-            raise ValueError(
-                f"Cannot add outputs. No outputs provided for prompt '{prompt_name}'."
-            )
+            raise ValueError(f"Cannot add outputs. No outputs provided for prompt '{prompt_name}'.")
         if overwrite:
             prompt.outputs = outputs
         else:

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -20,6 +20,7 @@ import { PaLMTextParser } from "./parsers/palm";
 import { extractOverrideSettings } from "./utils";
 import { HuggingFaceTextGenerationParser } from "./parsers/hf";
 import { CallbackEvent, CallbackManager } from "./callback";
+import { AnyscaleEndpointModelParser } from "./parsers/anyscale";
 
 /**
  * Options for saving an AIConfig to a file.
@@ -57,6 +58,11 @@ ModelParserRegistry.registerModelParser(new OpenAIChatModelParser(), [
   "gpt-3.5-turbo-0613",
   "gpt-3.5-turbo-16k-0613",
 ]);
+
+ModelParserRegistry.registerModelParser(new AnyscaleEndpointModelParser(), [
+  "AnyscaleEndpoint",
+]);
+
 ModelParserRegistry.registerModelParser(new HuggingFaceTextGenerationParser());
 ModelParserRegistry.registerModelParser(new PaLMTextParser());
 

--- a/typescript/lib/parsers/anyscale.ts
+++ b/typescript/lib/parsers/anyscale.ts
@@ -1,0 +1,33 @@
+import { JSONObject } from "../../common";
+import { Output, Prompt } from "../../types";
+import { AIConfigRuntime } from "../config";
+import OpenAI from "openai";
+import { InferenceOptions } from "../modelParser";
+import { OpenAIChatModelParser } from "./openai";
+
+export class AnyscaleEndpointModelParser extends OpenAIChatModelParser {
+  public async run(
+    prompt: Prompt,
+    aiConfig: AIConfigRuntime,
+    options?: InferenceOptions,
+    params?: JSONObject | undefined
+  ): Promise<Output[]> {
+    if (!this.openai) {
+      const apiKey =
+        process.env.ANYSCALE_ENDPOINT_API_KEY ?? process.env.OPENAI_API_KEY;
+      if (!apiKey) {
+        throw new Error(
+          "Missing API key ANYSCALE_ENDPOINT_API_KEY or OPENAI_API_KEY in environment. Please set one of these environment variables to utilize Anyscale Endpoints. You can get your API key from https://docs.endpoints.anyscale.com/guides/authenticate"
+        );
+      }
+
+      this.openai = new OpenAI({
+        apiKey,
+        baseURL: "https://api.endpoints.anyscale.com/v1",
+        ...(this.openaiOptions || {}),
+      });
+    }
+
+    return super.run(prompt, aiConfig, options, params);
+  }
+}

--- a/typescript/lib/parsers/openai.ts
+++ b/typescript/lib/parsers/openai.ts
@@ -289,8 +289,8 @@ export class OpenAIModelParser extends ParameterizedModelParser<CompletionCreate
 }
 
 export class OpenAIChatModelParser extends ParameterizedModelParser<Chat.ChatCompletionCreateParams> {
-  private openai: OpenAI | null = null;
-  private openaiOptions: ClientOptions | undefined;
+  protected openai: OpenAI | null = null;
+  protected openaiOptions: ClientOptions | undefined;
 
   public constructor(options?: ClientOptions) {
     super();


### PR DESCRIPTION
[bug] Ensure that Output is constructed consistently across streaming and non-streaming

Currently the openai modelparser calls `build_output_data` to properly construct the response from the inference endpoint into an AIConfig OutputData type.

However, it only does this when stream = False. This change adds the same logic to stream = True (and also ensures that the metadata is set consistently and in a loss-less way.

Also updated the same logic for Anyscale Endpoint model parser.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/752).
* __->__ #752
* #748
* #746
* #745
* #743
* #730