### PR TITLE
[editor] HuggingFaceTextGenerationParserPromptSchema

### DIFF
--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextGenerationParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextGenerationParserPromptSchema.ts
@@ -1,0 +1,73 @@
+import { PromptSchema } from "../../utils/promptUtils";
+
+export const HuggingFaceTextGenerationParserPromptSchema: PromptSchema = {
+  // See https://github.com/huggingface/huggingface_hub/blob/a331e82aad1bc63038194611236db28fa013814c/src/huggingface_hub/inference/_client.py#L1206
+  // for settings and https://huggingface.co/docs/api-inference/detailed_parameters for defaults.
+  // The settings below are supported settings specified in the HuggingFaceTextGenerationParser
+  // refine_chat_completion_params implementation.
+  input: {
+    type: "string",
+  },
+  model_settings: {
+    type: "object",
+    properties: {
+      model: {
+        type: "string",
+      },
+      temperature: {
+        type: "number",
+        minimum: 0,
+        maximum: 1,
+      },
+      top_k: {
+        type: "integer",
+      },
+      top_p: {
+        type: "number",
+        minimum: 0,
+        maximum: 1,
+      },
+      details: {
+        type: "boolean",
+      },
+      stream: {
+        type: "boolean",
+      },
+      do_sample: {
+        type: "boolean",
+      },
+      max_new_tokens: {
+        type: "integer",
+      },
+      best_of: {
+        type: "integer",
+      },
+      repetition_penalty: {
+        type: "number",
+        minimum: 0,
+        maximum: 1,
+      },
+      return_full_text: {
+        type: "boolean",
+      },
+      seed: {
+        type: "integer",
+      },
+      stop_sequences: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
+      truncate: {
+        type: "integer",
+      },
+      typical_p: {
+        type: "number",
+      },
+      watermark: {
+        type: "boolean",
+      },
+    },
+  },
+};

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/OpenAIChatModelParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/OpenAIChatModelParserPromptSchema.ts
@@ -38,7 +38,7 @@ export const OpenAIChatModelParserPromptSchema: PromptSchema = {
         items: {
           type: "object",
           required: ["name", "parameters"],
-          parameters: {
+          properties: {
             name: {
               type: "string",
             },

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMChatParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMChatParserPromptSchema.ts
@@ -1,0 +1,61 @@
+import { PromptSchema } from "../../utils/promptUtils";
+
+export const PaLMChatParserPromptSchema: PromptSchema = {
+  // See https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-chat for settings
+  // and defaults. The settings below are supported settings specified in the PaLMChatParser
+  // refine_chat_completion_params implementation.
+  input: {
+    type: "string",
+  },
+  model_settings: {
+    type: "object",
+    properties: {
+      context: {
+        type: "string",
+      },
+      candidate_count: {
+        type: "integer",
+        minimum: 1,
+        maximum: 4,
+      },
+      temperature: {
+        type: "number",
+        minimum: 0,
+        maximum: 1,
+      },
+      top_p: {
+        type: "number",
+        minimum: 0,
+        maximum: 1,
+      },
+      top_k: {
+        type: "integer",
+        minimum: 1,
+        maximum: 40,
+      },
+      examples: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["input", "output"],
+          properties: {
+            input: {
+              type: "string",
+            },
+            output: {
+              type: "string",
+            },
+          },
+        },
+      },
+    },
+  },
+  prompt_metadata: {
+    type: "object",
+    properties: {
+      remember_chat_context: {
+        type: "boolean",
+      },
+    },
+  },
+};

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -4,6 +4,7 @@ import { OpenAIChatVisionModelParserPromptSchema } from "../shared/prompt_schema
 import { DalleImageGenerationParserPromptSchema } from "../shared/prompt_schemas/DalleImageGenerationParserPromptSchema";
 import { PaLMTextParserPromptSchema } from "../shared/prompt_schemas/PaLMTextParserPromptSchema";
 import { PaLMChatParserPromptSchema } from "../shared/prompt_schemas/PaLMChatParserPromptSchema";
+import { HuggingFaceTextGenerationParserPromptSchema } from "../shared/prompt_schemas/HuggingFaceTextGenerationParserPromptSchema";
 
 /**
  * Get the name of the model for the specified prompt. The name will either be specified in the prompt's
@@ -68,7 +69,7 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   "dall-e-3": DalleImageGenerationParserPromptSchema,
 
   // HuggingFaceTextGenerationParser
-  // "HuggingFaceTextGenerationParser":
+  HuggingFaceTextGenerationParser: HuggingFaceTextGenerationParserPromptSchema,
 
   // PaLMTextParser
   "models/text-bison-001": PaLMTextParserPromptSchema,

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -3,6 +3,7 @@ import { OpenAIChatModelParserPromptSchema } from "../shared/prompt_schemas/Open
 import { OpenAIChatVisionModelParserPromptSchema } from "../shared/prompt_schemas/OpenAIChatVisionModelParserPromptSchema";
 import { DalleImageGenerationParserPromptSchema } from "../shared/prompt_schemas/DalleImageGenerationParserPromptSchema";
 import { PaLMTextParserPromptSchema } from "../shared/prompt_schemas/PaLMTextParserPromptSchema";
+import { PaLMChatParserPromptSchema } from "../shared/prompt_schemas/PaLMChatParserPromptSchema";
 
 /**
  * Get the name of the model for the specified prompt. The name will either be specified in the prompt's
@@ -73,7 +74,7 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   "models/text-bison-001": PaLMTextParserPromptSchema,
 
   // PaLMChatParser
-  // "models/chat-bison-001":
+  "models/chat-bison-001": PaLMChatParserPromptSchema,
 };
 
 export type PromptInputSchema =


### PR DESCRIPTION
[editor] HuggingFaceTextGenerationParserPromptSchema

# [editor] HuggingFaceTextGenerationParserPromptSchema

Adding the PromptSchema for HuggingFaceTextGenerationParser, with supported properties from `refine_chat_completion_params` in the parser implementation. Types obtained from https://github.com/huggingface/huggingface_hub/blob/a331e82aad1bc63038194611236db28fa013814c/src/huggingface_hub/inference/_client.py#L1206 and defaults obtained from https://huggingface.co/docs/api-inference/detailed_parameters if they're listed

<img width="1080" alt="Screenshot 2024-01-04 at 3 19 05 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/8cb40459-1f7c-42b2-8b35-0333c380be01">


Note, this is for the default/core parser which uses inference API. We'll need to add the other prompt schemas for the extension models for gradio.

Will update the hf prompt UX to support actual 'model' in a subsequent diff

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/755).
* #756
* __->__ #755
* #754