### PR TITLE
[editor] Fix Prompt Model Name Check

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/EditorContainer.tsx
@@ -299,7 +299,10 @@ export default function EditorContainer({
         if (!statePrompt) {
           throw new Error(`Could not find prompt with id ${promptId}`);
         }
-        const modelName = getPromptModelName(statePrompt);
+        const modelName = getPromptModelName(
+          statePrompt,
+          stateRef.current.metadata.default_model
+        );
         if (!modelName) {
           throw new Error(`Could not find model name for prompt ${promptId}`);
         }


### PR DESCRIPTION
# [editor] Fix Prompt Model Name Check

Noticed in bug bash for the example aiconfig file, modifying the model settings for the first prompt fails.
The error was thrown if setting the model settings when the prompt has no model set; when this happens we need to set the model name to the default model in the config and then we can set the remaining settings.

## Testing:
```
aiconfig edit --aiconfig-path=python/src/aiconfig/editor/travel.aiconfig.json --server-mode='debug_servers'
```
Edit settings for the first prompt and make sure it succeeds and sets correct config data:
```
      "name": "get_activities",
      "input": "Tell me 10 fun attractions to do in NYC.",
      "metadata": {
        "model": {
          "name": "gpt-3.5-turbo",
          "settings": {
            "system_prompt": "test"
          }
        },
        "parameters": {}
      },
```
