### PR TITLE
[aiconfig] Remove Duplicate GPT-4 Model from Default Registry

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -22,7 +22,6 @@ from .util.config_utils import is_yaml_ext
 
 gpt_models = [
     "gpt-4",
-    "GPT-4",
     "gpt-4-0314",
     "gpt-4-0613",
     "gpt-4-32k",

--- a/python/tests/aiconfigs/GPT4 Coding Assistant_aiconfig.json
+++ b/python/tests/aiconfigs/GPT4 Coding Assistant_aiconfig.json
@@ -27,7 +27,7 @@
             "input": "Refactor {{code_gen.output}} and add comments",
             "metadata": {
                 "model": {
-                    "name": "GPT-4",
+                    "name": "gpt-4",
                     "settings": {
                         "model": "gpt-4",
                         "top_p": 1,
@@ -46,7 +46,7 @@
             "input": "Refine {{refactor_cell.output}} to clean it up with proper error handling and add appropriate typing if applicable? If there is anything missing, explain and show the updated code.",
             "metadata": {
                 "model": {
-                    "name": "GPT-4",
+                    "name": "gpt-4",
                     "settings": {
                         "model": "gpt-4",
                         "top_p": 1,
@@ -65,7 +65,7 @@
             "input": "Convert from {{refine_code_cell.output}} into {{language}}. Maintain modern programming standards for that new language and equivalent standards of commenting, documentation. ",
             "metadata": {
                 "model": {
-                    "name": "GPT-4",
+                    "name": "gpt-4",
                     "settings": {
                         "model": "gpt-4",
                         "top_p": 1,
@@ -81,7 +81,7 @@
             "input": "Give me a concise explanation of what a function does. Use bullet points and headings so the summary is organized and readable. Here is the function: {{code}}",
             "metadata": {
                 "model": {
-                    "name": "GPT-4",
+                    "name": "gpt-4",
                     "settings": {
                         "model": "gpt-4",
                         "top_p": 1,
@@ -97,7 +97,7 @@
             "input": "{{code}}",
             "metadata": {
                 "model": {
-                    "name": "GPT-4",
+                    "name": "gpt-4",
                     "settings": {
                         "model": "gpt-4",
                         "top_p": 1,


### PR DESCRIPTION
# [aiconfig] Remove Duplicate GPT-4 Model from Default Registry

The default model parser registry was registering GPT-4 with capitals and was only used in this example config used for testing. Let's just fix that config to use "gpt-4" (lowercase) and remove the duplicate/confusing capitalized model.

## Testing:
`pytest`
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================================== 103 passed, 38 warnings in 1.59s =======================================================================================
```
