### PR TITLE
[editor] AddPromptButton UI Update

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
@@ -1,4 +1,10 @@
-import { ActionIcon, Menu, TextInput } from "@mantine/core";
+import {
+  ActionIcon,
+  Menu,
+  ScrollArea,
+  TextInput,
+  Tooltip,
+} from "@mantine/core";
 import { IconPlus, IconSearch, IconTextCaption } from "@tabler/icons-react";
 import { memo, useCallback, useState } from "react";
 import useLoadModels from "../../hooks/useLoadModels";
@@ -22,7 +28,7 @@ function ModelMenuItems({
   const displayModels = isCollapsed ? models.slice(0, collapseLimit) : models;
 
   return (
-    <>
+    <ScrollArea mah={300} style={{ overflowY: "auto" }}>
       {displayModels.map((model) => (
         <Menu.Item
           key={model}
@@ -35,7 +41,7 @@ function ModelMenuItems({
       {isCollapsed && (
         <Menu.Item onClick={() => setIsCollapsed(false)}>...</Menu.Item>
       )}
-    </>
+    </ScrollArea>
   );
 }
 
@@ -62,9 +68,11 @@ export default memo(function AddPromptButton({ addPrompt, getModels }: Props) {
       onChange={setIsOpen}
     >
       <Menu.Target>
-        <ActionIcon>
-          <IconPlus size={20} />
-        </ActionIcon>
+        <Tooltip label="Add prompt">
+          <ActionIcon>
+            <IconPlus size={20} />
+          </ActionIcon>
+        </Tooltip>
       </Menu.Target>
 
       <Menu.Dropdown>


### PR DESCRIPTION
# [editor] AddPromptButton UI Update

Quick UI fixes from bug bash:
- Add 'Add prompt' label to button:
<img width="241" alt="Screenshot 2024-01-04 at 7 29 57 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/404c8784-40ab-465e-8393-11cd311ccca1">

- Limit menu height with scroll area:

https://github.com/lastmile-ai/aiconfig/assets/5060851/4d8a126f-06fc-4e01-a2be-6e1a3e5499b6


