### PR TITLE
Fix issue where hugging face response was not correct type

### DIFF
--- a/cookbooks/HuggingFace/hf.py
+++ b/cookbooks/HuggingFace/hf.py
@@ -128,7 +128,7 @@ class HuggingFaceTextParser(ParameterizedModelParser):
     A model parser for HuggingFace text generation models.
     """
 
-    def __init__(self, model_id: str = None, use_api_token=False):
+    def __init__(self, model_id: str = None, use_api_token=True):
         """
         Args:
             model_id (str): The model ID of the model to use.

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
@@ -154,7 +154,9 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         token = None
 
         if use_api_token:
-            token = get_api_key_from_environment("HUGGING_FACE_API_TOKEN")
+            # You are allowed to use Hugging Face for a bit before you get
+            # rate limited, in which case you will receive a clear error
+            token = get_api_key_from_environment("HUGGING_FACE_API_TOKEN", required=False).unwrap()
 
         self.client = InferenceClient(model_id, token=token)
 

--- a/python/src/aiconfig/default_parsers/hf.py
+++ b/python/src/aiconfig/default_parsers/hf.py
@@ -99,7 +99,7 @@ def construct_stream_output(
     return output
 
 
-def construct_regular_output(response: TextGenerationResponse, response_includes_details: bool) -> Output:
+def construct_regular_output(response: str, response_includes_details: bool) -> Output:
     metadata = {"raw_response": response}
     if response_includes_details:
         metadata["details"] = response.details
@@ -107,7 +107,7 @@ def construct_regular_output(response: TextGenerationResponse, response_includes
     output = ExecuteResult(
         **{
             "output_type": "execute_result",
-            "data": response.generated_text or "",
+            "data": response,
             "execution_count": 0,
             "metadata": metadata,
         }
@@ -120,7 +120,7 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
     A model parser for HuggingFace text generation models.
     """
 
-    def __init__(self, model_id: str = None, use_api_token=False):
+    def __init__(self, model_id: str = None, use_api_token=True):
         """
         Args:
             model_id (str): The model ID of the model to use.


### PR DESCRIPTION
Fix issue where hugging face response was not correct type

Turned out to be a typing issue that python did not actually help with.

I also had to adjust the way we load in hugging face key because I got rate limited. We NEED to have more clear way to set API keys in `aiconfig/.env` file though, or else people won't know how to use it! cc @tanya-rai let's add an FAQ/README similar to what we have in the cookbooks: https://github.com/lastmile-ai/aiconfig/blob/3dcf70bcddda7f7041c3bfb6e5d4b6c9a7abd4ab/cookbooks/Getting-Started/getting_started.ipynb?short_path=dcb1340#L23-L25

We need to do this for keys
- HUGGING_FACE_API_TOKEN
- ANYSCALE_ENDPOINT_API_KEY
- OPENAI_API_KEY
- GOOGLE_API_KEY


## Testing
Connected to local editor (you'll have to modify the `max_tokens` setting) and runs now. We should also have automated testing for this hugging face model parser. Created task for it in https://github.com/lastmile-ai/aiconfig/issues/768

<img width="1512" alt="Screenshot 2024-01-05 at 00 47 51" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/5ecae48a-c0cd-43cf-a7ed-ccc74929c6b3">
