### PR TITLE
Fix wrong import name in Hugging Face model parser extension

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/__init__.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/__init__.py
@@ -1,6 +1,6 @@
 from .local_inference.text_2_image import HuggingFaceText2ImageDiffusor
 from .local_inference.text_generation import HuggingFaceTextGenerationTransformer
-from .remote_inference_client.text_generation import HuggingFaceTextGenerationClient
+from .remote_inference_client.text_generation import HuggingFaceTextGenerationParser
 from .local_inference.text_summarization import HuggingFaceTextSummarizationTransformer
 from .local_inference.text_translation import HuggingFaceTextTranslationTransformer
 
@@ -12,5 +12,5 @@ LOCAL_INFERENCE_CLASSES = [
     "HuggingFaceTextSummarizationTransformer",
     "HuggingFaceTextTranslationTransformer",
 ]
-REMOTE_INFERENCE_CLASSES = ["HuggingFaceTextGenerationClient"]
+REMOTE_INFERENCE_CLASSES = ["HuggingFaceTextGenerationParser"]
 __ALL__ = LOCAL_INFERENCE_CLASSES + REMOTE_INFERENCE_CLASSES

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
@@ -162,7 +162,7 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         """
         Returns an identifier for the Model Parser
         """
-        return "HuggingFaceTextGenerationClient"
+        return "HuggingFaceTextGenerationParser"
 
     async def serialize(
         self,


### PR DESCRIPTION
Fix wrong import name in Hugging Face model parser extension


This was bad, now it's fixed

## Test plan
Run `pytest` automated tests

Before
```
INTERNALERROR> extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/__init__.py:3: in <module>
INTERNALERROR>     from .remote_inference_client.text_generation import HuggingFaceTextGenerationClient
INTERNALERROR> E   ImportError: cannot import name 'HuggingFaceTextGenerationClient' from 'aiconfig_extension_hugging_face.remote_inference_client.text_generation' (/Users/rossdancraig/Projects/aiconfig/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py)
```

After
```
======================================================== 103 passed, 13 warnings in 1.94s ========================================================
```
