### PR TITLE
[editor][server] 1/n endpoint clear outputs

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -457,3 +457,30 @@ def set_description() -> FlaskResponse:
     operation = make_op_run_method(MethodName("set_description"))
     operation_args: Result[OpArgs, str] = result.Ok(OpArgs({"description": description}))
     return run_aiconfig_operation_with_op_args(aiconfig, "set_description", operation, operation_args)
+
+@app.route("/api/clear_outputs", methods=["POST"])
+def clear_outputs() -> FlaskResponse:
+    """
+    Clears all outputs in the server state's AIConfig.
+    """
+    state = get_server_state(app)
+    aiconfig = state.aiconfig
+    request_json = request.get_json()
+
+    if aiconfig is None:
+        LOGGER.info("No AIConfig in memory, can't run clear outputs.")
+        return HttpResponseWithAIConfig(
+            message="No AIConfig in memory, can't run clear outputs.",
+            code=400,
+            aiconfig=None,
+        ).to_flask_format()
+
+    def _op(aiconfig_runtime: AIConfigRuntime, _op_args: OpArgs) -> Result[None, str]:
+        for prompt in aiconfig_runtime.prompts:
+            prompt_name = prompt.name
+            # fn name `delete_output`` is misleading. TODO: Rename to `delete_outputs`` in AIConfig API
+            aiconfig_runtime.delete_output(prompt_name)
+        return Ok(None)
+
+    signature: dict[str, Type[Any]] = {}
+    return run_aiconfig_operation_with_request_json(aiconfig, request_json, f"method_", _op, signature)


### PR DESCRIPTION
[editor][server] 1/n endpoint clear outputs


server endpoint to clear outputs from server side aiconfig state (changes not persisted to disk).

## Testplan

1. Run Prompt
<img width="716" alt="Screenshot 2024-01-08 at 10 43 49 AM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/fd76e8b5-23e8-45c5-8358-6ab769dbb6f9">


2. Clear outputs.

<img width="962" alt="Screenshot 2024-01-08 at 10 54 12 AM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/fd419d01-ad88-4215-84cc-0abd721131e8">

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/790).
* #791
* __->__ #790