### PR TITLE
[editor] Streaming Outputs

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -1,6 +1,6 @@
 import { ClientAIConfig, ClientPrompt } from "../shared/types";
 import { getPromptModelName } from "../utils/promptUtils";
-import { AIConfig, JSONObject, PromptInput } from "aiconfig";
+import { AIConfig, JSONObject, Output, PromptInput } from "aiconfig";
 
 export type AIConfigReducerAction =
   | MutateAIConfigAction
@@ -14,6 +14,7 @@ export type MutateAIConfigAction =
   | RunPromptAction
   | SetDescriptionAction
   | SetNameAction
+  | StreamOutputChunkAction
   | UpdatePromptInputAction
   | UpdatePromptNameAction
   | UpdatePromptModelAction
@@ -61,6 +62,12 @@ export type SetDescriptionAction = {
 export type SetNameAction = {
   type: "SET_NAME";
   name: string;
+};
+
+export type StreamOutputChunkAction = {
+  type: "STREAM_OUTPUT_CHUNK";
+  id: string;
+  output: Output;
 };
 
 export type UpdatePromptInputAction = {
@@ -254,6 +261,12 @@ export default function aiconfigReducer(
         ...dirtyState,
         name: action.name,
       };
+    }
+    case "STREAM_OUTPUT_CHUNK": {
+      return reduceReplacePrompt(dirtyState, action.id, (prompt) => ({
+        ...prompt,
+        outputs: [action.output],
+      }));
     }
     case "UPDATE_PROMPT_INPUT": {
       return reduceReplaceInput(dirtyState, action.id, () => action.input);

--- a/python/src/aiconfig/editor/client/src/utils/aiconfigStateUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/aiconfigStateUtils.ts
@@ -1,5 +1,6 @@
 import { AIConfig } from "aiconfig";
 import { ClientAIConfig, ClientPrompt } from "../shared/types";
+import { getPromptModelName } from "./promptUtils";
 
 export function getDefaultNewPromptName(aiconfig: AIConfig): string {
   const existingNames = aiconfig.prompts.map((prompt) => prompt.name);
@@ -15,4 +16,32 @@ export function getPrompt(
   id: string
 ): ClientPrompt | undefined {
   return aiconfig.prompts.find((prompt) => prompt._ui.id === id);
+}
+
+// TODO: This is pretty hacky. Streaming is actually part of AIConfig runtime and not necessarily part of model settings,
+// let alone required to be defined by 'stream' boolean... Ideally we should treat everything as stream but this should work for now.
+export function isStreamingSupported(
+  prompt: ClientPrompt,
+  config: ClientAIConfig
+): boolean {
+  const promptModelSettings =
+    prompt.metadata?.model && typeof prompt.metadata.model !== "string"
+      ? prompt.metadata.model?.settings
+      : undefined;
+  if (promptModelSettings) {
+    if (promptModelSettings?.stream === true) {
+      return true;
+    } else if (promptModelSettings?.stream === false) {
+      return false;
+    }
+  }
+
+  const promptModelName = getPromptModelName(prompt);
+  if (promptModelName) {
+    const globalModelSettings =
+      config.metadata?.models?.[promptModelName]?.settings;
+    return globalModelSettings?.stream === true;
+  }
+
+  return false;
 }

--- a/python/src/aiconfig/editor/client/src/utils/oboeHelpers.ts
+++ b/python/src/aiconfig/editor/client/src/utils/oboeHelpers.ts
@@ -7,11 +7,11 @@ import oboe, { Options } from "oboe";
 export async function streamingApi<T>(
   headers: Options,
   on: string = "*",
-  fn: (data: any) => void,
+  fn: (data: unknown) => void,
   on2?: string,
-  fn2?: (data: any) => void,
+  fn2?: (data: unknown) => void,
   on3?: string,
-  fn3?: (data: any) => void
+  fn3?: (data: unknown) => void
 ): Promise<T> {
   return new Promise((resolve, reject) => {
     if (fn2 && on2 && fn3 && on3) {


### PR DESCRIPTION
# [editor] Streaming Outputs

Add client-side handling for streaming outputs. We currently derive whether the request should stream by checking settings. Not a huge fan of this since:
- it couples client with config runtime logic for getting the 'stream' value
- assumes 'stream' setting is used by the models

This is sufficient for now, I think. Note that I do think it's nice to allow the editor user to toggle between stream/no stream since it will be useful for debugging their model parser

## Testing:
- Error handling: added `return HttpResponseWithAIConfig(message="No AIConfig loaded", code=400, aiconfig=None).to_flask_format()` in /run with 'stream' set to true and ensured error is shown as notification and run state is stopped on the client
- Non-streaming model (dall-e) run correctly
- Streaming works for models with stream setting set to tru/false:

https://github.com/lastmile-ai/aiconfig/assets/5060851/5242f49f-0003-45a6-af19-1e29c611eca4


