### PR TITLE
[editor] ErrorBoundary Renderer for PromptInput

### DIFF
--- a/python/src/aiconfig/editor/client/package.json
+++ b/python/src/aiconfig/editor/client/package.json
@@ -41,6 +41,7 @@
     "oboe": "^2.1.5",
     "react": "^18",
     "react-dom": "^18",
+    "react-error-boundary": "^4.0.12",
     "react-markdown": "^8.0.6",
     "react-scripts": "5.0.1",
     "remark-gfm": "^4.0.0",

--- a/python/src/aiconfig/editor/client/src/components/JSONEditorToggleButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/JSONEditorToggleButton.tsx
@@ -1,0 +1,20 @@
+import { ActionIcon, Tooltip } from "@mantine/core";
+import { IconBraces, IconBracesOff } from "@tabler/icons-react";
+
+type Props = {
+  isRawJSON: boolean;
+  setIsRawJSON: (value: boolean) => void;
+};
+
+export default function JSONEditorToggleButton({
+  isRawJSON,
+  setIsRawJSON,
+}: Props) {
+  return (
+    <Tooltip label="Toggle JSON editor" withArrow>
+      <ActionIcon onClick={() => setIsRawJSON(!isRawJSON)}>
+        {isRawJSON ? <IconBracesOff size="1rem" /> : <IconBraces size="1rem" />}
+      </ActionIcon>
+    </Tooltip>
+  );
+}

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/PromptInputRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/PromptInputRenderer.tsx
@@ -3,9 +3,12 @@ import { memo, useState } from "react";
 import { PromptInputSchema } from "../../../utils/promptUtils";
 import PromptInputSchemaRenderer from "./schema_renderer/PromptInputSchemaRenderer";
 import PromptInputConfigRenderer from "./PromptInputConfigRenderer";
-import { ActionIcon, Flex, Tooltip } from "@mantine/core";
-import { IconBraces, IconBracesOff } from "@tabler/icons-react";
+import { Flex } from "@mantine/core";
 import PromptInputJSONRenderer from "./PromptInputJSONRenderer";
+import { ErrorBoundary, useErrorBoundary } from "react-error-boundary";
+import { Text } from "@mantine/core";
+import JSONRenderer from "../../JSONRenderer";
+import JSONEditorToggleButton from "../../JSONEditorToggleButton";
 
 type Props = {
   input: PromptInput;
@@ -13,17 +16,50 @@ type Props = {
   onChangeInput: (value: PromptInput) => void;
 };
 
+type ErrorFallbackProps = {
+  input: PromptInput;
+  toggleJSONEditor: () => void;
+};
+
+function InputErrorFallback({ input, toggleJSONEditor }: ErrorFallbackProps) {
+  const { resetBoundary: clearRenderError } = useErrorBoundary();
+  return (
+    <Flex direction="column">
+      <Text color="red" size="sm">
+        Invalid input format for model. Toggle JSON editor to update
+      </Text>
+      <JSONRenderer content={input} />
+      <Flex justify="flex-end">
+        <JSONEditorToggleButton
+          isRawJSON={false}
+          setIsRawJSON={() => {
+            clearRenderError();
+            toggleJSONEditor();
+          }}
+        />
+      </Flex>
+    </Flex>
+  );
+}
+
 export default memo(function PromptInputRenderer({
   input,
   schema,
   onChangeInput,
 }: Props) {
   const [isRawJSON, setIsRawJSON] = useState(false);
-  return (
+  const rawJSONToggleButton = (
+    <Flex justify="flex-end">
+      <JSONEditorToggleButton
+        isRawJSON={isRawJSON}
+        setIsRawJSON={setIsRawJSON}
+      />
+    </Flex>
+  );
+
+  const nonJSONRenderer = (
     <>
-      {isRawJSON ? (
-        <PromptInputJSONRenderer input={input} onChangeInput={onChangeInput} />
-      ) : schema ? (
+      {schema ? (
         <PromptInputSchemaRenderer
           input={input}
           schema={schema}
@@ -35,17 +71,34 @@ export default memo(function PromptInputRenderer({
           onChangeInput={onChangeInput}
         />
       )}
-      <Flex justify="flex-end">
-        <Tooltip label="Toggle JSON editor" withArrow>
-          <ActionIcon onClick={() => setIsRawJSON((curr) => !curr)}>
-            {isRawJSON ? (
-              <IconBracesOff size="1rem" />
-            ) : (
-              <IconBraces size="1rem" />
-            )}
-          </ActionIcon>
-        </Tooltip>
-      </Flex>
+      {rawJSONToggleButton}
+    </>
+  );
+
+  return (
+    <>
+      {isRawJSON ? (
+        <>
+          <PromptInputJSONRenderer
+            input={input}
+            onChangeInput={onChangeInput}
+          />
+          {rawJSONToggleButton}
+        </>
+      ) : (
+        <ErrorBoundary
+          fallbackRender={() => (
+            <InputErrorFallback
+              input={input}
+              // Fallback is only shown when an error occurs in non-JSON renderer
+              // so toggle must be to JSON editor
+              toggleJSONEditor={() => setIsRawJSON(true)}
+            />
+          )}
+        >
+          {nonJSONRenderer}
+        </ErrorBoundary>
+      )}
     </>
   );
 });

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
@@ -27,8 +27,7 @@ function SchemaRenderer({ input, schema, onChangeInput }: SchemaRendererProps) {
   } = schema.properties;
 
   if (typeof input === "string") {
-    return null;
-    // TODO: Add ErrorBoundary handling and throw error here
+    throw new Error("Expected input type object but got string");
   }
 
   const { data, attachments, ..._restData } = input;

--- a/python/src/aiconfig/editor/client/yarn.lock
+++ b/python/src/aiconfig/editor/client/yarn.lock
@@ -9594,6 +9594,13 @@ react-dropzone@14.2.3:
     file-selector "^0.6.0"
     prop-types "^15.8.1"
 
+react-error-boundary@^4.0.12:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.12.tgz#59f8f1dbc53bbbb34fc384c8db7cf4082cb63e2c"
+  integrity sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"


### PR DESCRIPTION
[editor] ErrorBoundary Renderer for PromptInput

# [editor] ErrorBoundary Renderer for PromptInput

With the ability to set arbitrary JSON for the prompt input, if we have a PromptSchema which states what the input should look like, we should be able to do some basic validation that the input at least matches the general type (for now, compare 'string' PromptInput vs object -- in the future, we could do some basic validation against the schema).

If there is any error with rendering the schema-based rendering for the input, we can use ErrorBoundary to fallback to an error message informing the user that the format is invalid and to toggle to JSON editor to fix.

<img width="1083" alt="Screenshot 2024-01-05 at 11 01 07 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/d0a817f5-b85b-4501-9ca5-28b324061ed4">

Toggling to the JSON editor will clear the error state and try to render the correct Schema renderer when toggling back.

Note that in dev mode, these errors are still propagated to a top-level error screen which you can dismiss to show the fallback. In prod, that won't happen and will just show the fallback and an error in the console.

We will do the same for the SettingsRenderer in a subsequent PR

## Testing:
- Updated `OpenAIChatModelParserPromptSchema` input to match that of `OpenAIChatVisionModelParserPromptSchema` while the input is still string. See the error fallback
- Toggle to JSON editor and back, ensure error fallback still shows
- Toggle to JSON editor and update to valid input
```
{
        "attachments": [
          {
            "data": "https://s3.amazonaws.com/files.uploads.lastmileai.com/uploads/cldxsqbel0000qs8owp8mkd0z/2023_12_1_21_23_24/942/Screenshot 2023-11-28 at 11.11.25 AM.png",
            "mime_type": "image/png"
          },
          {
            "data": "https://s3.amazonaws.com/files.uploads.lastmileai.com/uploads/cldxsqbel0000qs8owp8mkd0z/2023_12_1_21_23_24/8325/Screenshot 2023-11-28 at 1.51.52 PM.png",
            "mime_type": "image/png"
          }
        ],
        "data": "What do these images show?"
      }
```
and see proper schema rendering


https://github.com/lastmile-ai/aiconfig/assets/5060851/1343a201-e5eb-46a0-a7f5-a4bdb228d120

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/799).
* #803
* #802
* #801
* #800
* __->__ #799