### PR TITLE
[py][easy] Set Deleted Outputs as None

### DIFF
--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -873,7 +873,7 @@ AIConfig-level settings. If this is a mistake, please rerun the \
         """
         prompt = self.get_prompt(prompt_name)
         existing_outputs = prompt.outputs
-        prompt.outputs = []
+        prompt.outputs = None
 
         return existing_outputs
 


### PR DESCRIPTION
[py][easy] Set Deleted Outputs as None










Inside the python sdk, `delete_output` previously set attribute outputs of prompts to []. While this does delete the outputs, it also retains an empty list as the value of prompt.output

When executing config.save(),  the config would have persisted empty arrays. This behaviour is not what we want.

Instead, set to None. When config.save() is called, None values can be ignored and removed from the resulting aiconfig.json

## Testplan
1. Run prompt
2. delete output
3. Save config.validate that config doesn't have "outputs" field for config

| ipynb  | resulting config |
| ------------- | ------------- |
| <img width="768" alt="Screenshot 2024-01-08 at 3 26 05 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/616d8fce-bf54-488b-8cc4-57b83b76744b">  | <img width="704" alt="Screenshot 2024-01-08 at 3 27 40 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/10600037-04cb-400a-919d-11a60cedbc0c"> |

came up in #791
