### PR TITLE
[editor][easy] Add Descriptions to Prompt Schemas

### DIFF
--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/DalleImageGenerationParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/DalleImageGenerationParserPromptSchema.ts
@@ -3,6 +3,7 @@ import { PromptSchema } from "../../utils/promptUtils";
 export const DalleImageGenerationParserPromptSchema: PromptSchema = {
   // See /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/openai/resources/images.py
   // for supported settings
+  // https://platform.openai.com/docs/api-reference/images/create for descriptions
 
   input: {
     type: "string",
@@ -17,22 +18,30 @@ export const DalleImageGenerationParserPromptSchema: PromptSchema = {
         type: "integer",
         minimum: 1,
         maximum: 10,
+        description: "Number of images to generate",
       },
       quality: {
         type: "string",
         enum: ["standard", "hd"],
+        description: `The quality of the image that will be generated. 
+        'hd' creates images with finer details and greater consistency across the image`,
       },
       response_format: {
         type: "string",
         enum: ["url", "b64_json"],
+        description: "The format in which the generated images are returned.",
       },
       size: {
         type: "string",
         enum: ["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"],
+        description: "The size of the generated images.",
       },
       style: {
         type: "string",
         enum: ["vivid", "natural"],
+        description: `The style of the generated images. Must be one of vivid or natural. 
+        Vivid causes the model to lean towards generating hyper-real and dramatic images. 
+        Natural causes the model to produce more natural, less hyper-real looking images.`,
       },
     },
   },

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextGenerationParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextGenerationParserPromptSchema.ts
@@ -17,15 +17,22 @@ export const HuggingFaceTextGenerationParserPromptSchema: PromptSchema = {
       temperature: {
         type: "number",
         minimum: 0,
-        maximum: 1,
+        maximum: 100,
+        description: `The temperature of the sampling operation. 
+        1 means regular sampling, 0 means always take the highest score, 
+        100.0 is getting closer to uniform probability.`,
       },
       top_k: {
         type: "integer",
+        description: `Integer to define the top tokens considered within the sample operation to create new text.`,
       },
       top_p: {
         type: "number",
         minimum: 0,
         maximum: 1,
+        description: `Float to define the tokens that are within the sample operation of text generation. 
+        Add tokens in the sample for more probable to least probable until the sum of the probabilities 
+        is greater than top_p.`,
       },
       details: {
         type: "boolean",
@@ -36,9 +43,13 @@ export const HuggingFaceTextGenerationParserPromptSchema: PromptSchema = {
       },
       do_sample: {
         type: "boolean",
+        description: `Whether or not to use sampling, use greedy decoding otherwise.`,
       },
       max_new_tokens: {
         type: "integer",
+        description: `The amount of new tokens to be generated, this does not include the input length 
+        it is a estimate of the size of generated text you want. Each new tokens slows down the request, 
+        so look for balance between response times and length of text generated.`,
       },
       best_of: {
         type: "integer",
@@ -46,10 +57,13 @@ export const HuggingFaceTextGenerationParserPromptSchema: PromptSchema = {
       repetition_penalty: {
         type: "number",
         minimum: 0,
-        maximum: 1,
+        maximum: 100,
+        description: `The more a token is used within generation the more it is penalized to not be picked
+         in successive generation passes.`,
       },
       return_full_text: {
         type: "boolean",
+        description: `If set to False, the return results will not contain the original query making it easier for prompting.`,
       },
       seed: {
         type: "integer",

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMChatParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMChatParserPromptSchema.ts
@@ -15,26 +15,51 @@ export const PaLMChatParserPromptSchema: PromptSchema = {
       },
       context: {
         type: "string",
+        description: `Context shapes how the model responds throughout the conversation. 
+        For example, you can use context to specify words the model can or cannot use, 
+        topics to focus on or avoid, or the response format or style.`,
       },
       candidate_count: {
         type: "integer",
         minimum: 1,
         maximum: 4,
+        description: "The number of response variations to return.",
       },
       temperature: {
         type: "number",
         minimum: 0,
         maximum: 1,
+        description: `The temperature is used for sampling during response generation, 
+        which occurs when topP and topK are applied. Temperature controls the degree of 
+        randomness in token selection. Lower temperatures are good for prompts that require 
+        a less open-ended or creative response, while higher temperatures can lead to more 
+        diverse or creative results. A temperature of 0 means that the highest probability 
+        tokens are always selected. In this case, responses for a given prompt are mostly 
+        deterministic, but a small amount of variation is still possible.
+        If the model returns a response that's too generic, too short, or the model gives 
+        a fallback response, try increasing the temperature.`,
       },
       top_p: {
         type: "number",
         minimum: 0,
         maximum: 1,
+        description: `Top-P changes how the model selects tokens for output. Tokens are selected from 
+        the most (see top-K) to least probable until the sum of their probabilities equals the top-P value. 
+        For example, if tokens A, B, and C have a probability of 0.3, 0.2, and 0.1 and the top-P value is 0.5, 
+        then the model will select either A or B as the next token by using temperature and excludes C as a candidate.
+        Specify a lower value for less random responses and a higher value for more random responses.`,
       },
       top_k: {
         type: "integer",
         minimum: 1,
         maximum: 40,
+        description: `Top-K changes how the model selects tokens for output. A top-K of 1 means the next 
+        selected token is the most probable among all tokens in the model's vocabulary (also called greedy decoding), 
+        while a top-K of 3 means that the next token is selected from among the three most probable tokens 
+        by using temperature.
+        For each token selection step, the top-K tokens with the highest probabilities are sampled. 
+        Then tokens are further filtered based on top-P with the final token selected using temperature sampling.
+        Specify a lower value for less random responses and a higher value for more random responses.`,
       },
       examples: {
         type: "array",
@@ -50,6 +75,7 @@ export const PaLMChatParserPromptSchema: PromptSchema = {
             },
           },
         },
+        description: `Examples for the model to learn how to respond to the conversation.`,
       },
     },
   },

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMTextParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMTextParserPromptSchema.ts
@@ -17,21 +17,45 @@ export const PaLMTextParserPromptSchema: PromptSchema = {
         type: "integer",
         minimum: 1,
         maximum: 4,
+        description: "The number of response variations to return.",
       },
       temperature: {
         type: "number",
         minimum: 0,
         maximum: 1,
+        description: `The temperature is used for sampling during response generation, 
+        which occurs when topP and topK are applied. Temperature controls the degree of 
+        randomness in token selection. Lower temperatures are good for prompts that require 
+        a less open-ended or creative response, while higher temperatures can lead to more 
+        diverse or creative results. A temperature of 0 means that the highest probability 
+        tokens are always selected. In this case, responses for a given prompt are mostly 
+        deterministic, but a small amount of variation is still possible.
+        If the model returns a response that's too generic, too short, or the model gives a 
+        fallback response, try increasing the temperature.`,
       },
       top_p: {
         type: "number",
         minimum: 0,
         maximum: 1,
+        description: `Top-P changes how the model selects tokens for output. Tokens are selected 
+        from the most (see top-K) to least probable until the sum of their probabilities equals 
+        the top-P value. For example, if tokens A, B, and C have a probability of 0.3, 0.2, and 0.1 
+        and the top-P value is 0.5, then the model will select either A or B as the next token by 
+        using temperature and excludes C as a candidate.
+        Specify a lower value for less random responses and a higher value for more random responses.`,
       },
       top_k: {
         type: "integer",
         minimum: 1,
         maximum: 40,
+        description: `Top-K changes how the model selects tokens for output. A top-K of 1 means the 
+        next selected token is the most probable among all tokens in the model's vocabulary 
+        (also called greedy decoding), while a top-K of 3 means that the next token is selected 
+        from among the three most probable tokens by using temperature.
+        For each token selection step, the top-K tokens with the highest probabilities are sampled. 
+        Then tokens are further filtered based on top-P with the final token selected using temperature sampling.
+        
+        Specify a lower value for less random responses and a higher value for more random responses.`,
       },
     },
   },


### PR DESCRIPTION
[editor][easy] Add Descriptions to Prompt Schemas

# [editor][easy] Add Descriptions to Prompt Schemas

Add descriptions to the other prompt schemas for the core models. Also, fix some of the hugging face properties to have correct ranges based on the documentation (tested those ranges are valid by setting the values to 80 or so and running HF prompt).

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/814).
* #818
* #815
* __->__ #814