### PR TITLE
[editor] HuggingFaceText2ImageDiffusorPromptSchema

### DIFF
--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/DalleImageGenerationParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/DalleImageGenerationParserPromptSchema.ts
@@ -3,6 +3,7 @@ import { PromptSchema } from "../../utils/promptUtils";
 export const DalleImageGenerationParserPromptSchema: PromptSchema = {
   // See /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/openai/resources/images.py
   // for supported settings
+  // https://platform.openai.com/docs/api-reference/images/create for descriptions
 
   input: {
     type: "string",
@@ -17,22 +18,30 @@ export const DalleImageGenerationParserPromptSchema: PromptSchema = {
         type: "integer",
         minimum: 1,
         maximum: 10,
+        description: "Number of images to generate",
       },
       quality: {
         type: "string",
         enum: ["standard", "hd"],
+        description: `The quality of the image that will be generated. 
+        'hd' creates images with finer details and greater consistency across the image`,
       },
       response_format: {
         type: "string",
         enum: ["url", "b64_json"],
+        description: "The format in which the generated images are returned.",
       },
       size: {
         type: "string",
         enum: ["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"],
+        description: "The size of the generated images.",
       },
       style: {
         type: "string",
         enum: ["vivid", "natural"],
+        description: `The style of the generated images. Must be one of vivid or natural. 
+        Vivid causes the model to lean towards generating hyper-real and dramatic images. 
+        Natural causes the model to produce more natural, less hyper-real looking images.`,
       },
     },
   },

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceText2ImageDiffusorPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceText2ImageDiffusorPromptSchema.ts
@@ -1,0 +1,102 @@
+import { PromptSchema } from "../../utils/promptUtils";
+
+export const HuggingFaceText2ImageDiffusorPromptSchema: PromptSchema = {
+  // See /Users/ryanholinshead/Projects/aiconfig/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_2_image.py
+  // for supported settings.
+  // See https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/text2img#diffusers.StableDiffusionPipeline.__call__
+  // for descriptions.
+
+  // This is currently for Kandinsky 2.2
+
+  // The following supported properties cannot be cleanly modeled in the schema and must be implemented programatically:
+  // generator, latents, prompt_embeds, negative_prompt_embeds, callback
+
+  input: {
+    type: "string",
+  },
+  model_settings: {
+    type: "object",
+    properties: {
+      height: {
+        type: "integer",
+        description: `The height in pixels of the generated image.`,
+      },
+      width: {
+        type: "integer",
+        description: `The width in pixels of the generated image.`,
+      },
+      num_inference_steps: {
+        type: "integer",
+        description: `The number of denoising steps. More denoising steps usually lead to a higher 
+        quality image at the expense of slower inference.`,
+      },
+      guidance_scale: {
+        type: "number",
+        description: `A higher guidance scale value encourages the model to generate images closely linked 
+        to the text prompt at the expense of lower image quality. Guidance scale is enabled when guidance_scale > 1.`,
+      },
+      // TODO: Convert to anyOf once renderer supports it
+      negative_prompt: {
+        type: "union",
+        types: [
+          {
+            type: "string",
+          },
+          {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+        ],
+      },
+      num_images_per_prompt: {
+        type: "integer",
+        description: `The number of images to generate per prompt.`,
+      },
+      eta: {
+        type: "number",
+        description: `Corresponds to parameter eta (η) from the DDIM paper. 
+        Only applies to the DDIMScheduler, and is ignored in other schedulers.`,
+      },
+      output_type: {
+        type: "string",
+        enum: ["pil", "array"],
+        description: `The output format of the generated image. Choose between PIL.Image or np.array.`,
+      },
+      return_dict: {
+        type: "boolean",
+        description: `Whether or not to return a StableDiffusionPipelineOutput instead of a plain tuple.`,
+      },
+      cross_attention_kwargs: {
+        type: "map",
+        keys: {
+          type: "string",
+        },
+        items: {
+          type: "string",
+        },
+        description: `A kwargs dictionary that if specified is passed along to the AttentionProcessor as defined in self.processor.`,
+      },
+      guidance_rescale: {
+        type: "number",
+        description: `Guidance rescale factor from Common Diffusion Noise Schedules and Sample Steps are Flawed.
+         Guidance rescale factor should fix overexposure when using zero terminal SNR.`,
+      },
+      clip_skip: {
+        type: "integer",
+        description: `Number of layers to be skipped from CLIP while computing the prompt embeddings. 
+        A value of 1 means that the output of the pre-final layer will be used for computing the prompt embeddings.`,
+      },
+      requires_safety_checker: {
+        type: "boolean",
+        description: `Whether or not the model requires a safety checker to be used.`,
+      },
+      callback_steps: {
+        type: "integer",
+        description: `The frequency at which the callback function will be called. 
+        If not specified, the callback will be called at every step.`,
+      },
+    },
+  },
+};

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextGenerationParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextGenerationParserPromptSchema.ts
@@ -17,15 +17,22 @@ export const HuggingFaceTextGenerationParserPromptSchema: PromptSchema = {
       temperature: {
         type: "number",
         minimum: 0,
-        maximum: 1,
+        maximum: 100,
+        description: `The temperature of the sampling operation. 
+        1 means regular sampling, 0 means always take the highest score, 
+        100.0 is getting closer to uniform probability.`,
       },
       top_k: {
         type: "integer",
+        description: `Integer to define the top tokens considered within the sample operation to create new text.`,
       },
       top_p: {
         type: "number",
         minimum: 0,
         maximum: 1,
+        description: `Float to define the tokens that are within the sample operation of text generation. 
+        Add tokens in the sample for more probable to least probable until the sum of the probabilities 
+        is greater than top_p.`,
       },
       details: {
         type: "boolean",
@@ -36,9 +43,13 @@ export const HuggingFaceTextGenerationParserPromptSchema: PromptSchema = {
       },
       do_sample: {
         type: "boolean",
+        description: `Whether or not to use sampling, use greedy decoding otherwise.`,
       },
       max_new_tokens: {
         type: "integer",
+        description: `The amount of new tokens to be generated, this does not include the input length 
+        it is a estimate of the size of generated text you want. Each new tokens slows down the request, 
+        so look for balance between response times and length of text generated.`,
       },
       best_of: {
         type: "integer",
@@ -46,10 +57,13 @@ export const HuggingFaceTextGenerationParserPromptSchema: PromptSchema = {
       repetition_penalty: {
         type: "number",
         minimum: 0,
-        maximum: 1,
+        maximum: 100,
+        description: `The more a token is used within generation the more it is penalized to not be picked
+         in successive generation passes.`,
       },
       return_full_text: {
         type: "boolean",
+        description: `If set to False, the return results will not contain the original query making it easier for prompting.`,
       },
       seed: {
         type: "integer",

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMChatParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMChatParserPromptSchema.ts
@@ -15,26 +15,51 @@ export const PaLMChatParserPromptSchema: PromptSchema = {
       },
       context: {
         type: "string",
+        description: `Context shapes how the model responds throughout the conversation. 
+        For example, you can use context to specify words the model can or cannot use, 
+        topics to focus on or avoid, or the response format or style.`,
       },
       candidate_count: {
         type: "integer",
         minimum: 1,
         maximum: 4,
+        description: "The number of response variations to return.",
       },
       temperature: {
         type: "number",
         minimum: 0,
         maximum: 1,
+        description: `The temperature is used for sampling during response generation, 
+        which occurs when topP and topK are applied. Temperature controls the degree of 
+        randomness in token selection. Lower temperatures are good for prompts that require 
+        a less open-ended or creative response, while higher temperatures can lead to more 
+        diverse or creative results. A temperature of 0 means that the highest probability 
+        tokens are always selected. In this case, responses for a given prompt are mostly 
+        deterministic, but a small amount of variation is still possible.
+        If the model returns a response that's too generic, too short, or the model gives 
+        a fallback response, try increasing the temperature.`,
       },
       top_p: {
         type: "number",
         minimum: 0,
         maximum: 1,
+        description: `Top-P changes how the model selects tokens for output. Tokens are selected from 
+        the most (see top-K) to least probable until the sum of their probabilities equals the top-P value. 
+        For example, if tokens A, B, and C have a probability of 0.3, 0.2, and 0.1 and the top-P value is 0.5, 
+        then the model will select either A or B as the next token by using temperature and excludes C as a candidate.
+        Specify a lower value for less random responses and a higher value for more random responses.`,
       },
       top_k: {
         type: "integer",
         minimum: 1,
         maximum: 40,
+        description: `Top-K changes how the model selects tokens for output. A top-K of 1 means the next 
+        selected token is the most probable among all tokens in the model's vocabulary (also called greedy decoding), 
+        while a top-K of 3 means that the next token is selected from among the three most probable tokens 
+        by using temperature.
+        For each token selection step, the top-K tokens with the highest probabilities are sampled. 
+        Then tokens are further filtered based on top-P with the final token selected using temperature sampling.
+        Specify a lower value for less random responses and a higher value for more random responses.`,
       },
       examples: {
         type: "array",
@@ -50,6 +75,7 @@ export const PaLMChatParserPromptSchema: PromptSchema = {
             },
           },
         },
+        description: `Examples for the model to learn how to respond to the conversation.`,
       },
     },
   },

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMTextParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/PaLMTextParserPromptSchema.ts
@@ -17,21 +17,45 @@ export const PaLMTextParserPromptSchema: PromptSchema = {
         type: "integer",
         minimum: 1,
         maximum: 4,
+        description: "The number of response variations to return.",
       },
       temperature: {
         type: "number",
         minimum: 0,
         maximum: 1,
+        description: `The temperature is used for sampling during response generation, 
+        which occurs when topP and topK are applied. Temperature controls the degree of 
+        randomness in token selection. Lower temperatures are good for prompts that require 
+        a less open-ended or creative response, while higher temperatures can lead to more 
+        diverse or creative results. A temperature of 0 means that the highest probability 
+        tokens are always selected. In this case, responses for a given prompt are mostly 
+        deterministic, but a small amount of variation is still possible.
+        If the model returns a response that's too generic, too short, or the model gives a 
+        fallback response, try increasing the temperature.`,
       },
       top_p: {
         type: "number",
         minimum: 0,
         maximum: 1,
+        description: `Top-P changes how the model selects tokens for output. Tokens are selected 
+        from the most (see top-K) to least probable until the sum of their probabilities equals 
+        the top-P value. For example, if tokens A, B, and C have a probability of 0.3, 0.2, and 0.1 
+        and the top-P value is 0.5, then the model will select either A or B as the next token by 
+        using temperature and excludes C as a candidate.
+        Specify a lower value for less random responses and a higher value for more random responses.`,
       },
       top_k: {
         type: "integer",
         minimum: 1,
         maximum: 40,
+        description: `Top-K changes how the model selects tokens for output. A top-K of 1 means the 
+        next selected token is the most probable among all tokens in the model's vocabulary 
+        (also called greedy decoding), while a top-K of 3 means that the next token is selected 
+        from among the three most probable tokens by using temperature.
+        For each token selection step, the top-K tokens with the highest probabilities are sampled. 
+        Then tokens are further filtered based on top-P with the final token selected using temperature sampling.
+        
+        Specify a lower value for less random responses and a higher value for more random responses.`,
       },
     },
   },

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -6,6 +6,7 @@ import { PaLMTextParserPromptSchema } from "../shared/prompt_schemas/PaLMTextPar
 import { PaLMChatParserPromptSchema } from "../shared/prompt_schemas/PaLMChatParserPromptSchema";
 import { HuggingFaceTextGenerationParserPromptSchema } from "../shared/prompt_schemas/HuggingFaceTextGenerationParserPromptSchema";
 import { AnyscaleEndpointPromptSchema } from "../shared/prompt_schemas/AnyscaleEndpointPromptSchema";
+import { HuggingFaceText2ImageDiffusorPromptSchema } from "../shared/prompt_schemas/HuggingFaceText2ImageDiffusorPromptSchema";
 
 /**
  * Get the name of the model for the specified prompt. The name will either be specified in the prompt's
@@ -80,6 +81,9 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
 
   // AnyscaleEndpoint
   AnyscaleEndpoint: AnyscaleEndpointPromptSchema,
+
+  // Local HuggingFace Parsers
+  HuggingFaceText2ImageDiffusor: HuggingFaceText2ImageDiffusorPromptSchema,
 };
 
 export type PromptInputSchema =


### PR DESCRIPTION
[editor] HuggingFaceText2ImageDiffusorPromptSchema

# [editor] HuggingFaceText2ImageDiffusorPromptSchema

Add the PromptSchema for HuggingFaceText2ImageDiffusor. Note that there are several settings which are going to have to just be supported programatically since modelling them with schema types would be pretty hard:
generator, latents, prompt_embeds, negative_prompt_embeds, callback

Each is of a python class-derived type

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/815).
* #818
* __->__ #815
* #814