### PR TITLE
[easy][extension][py][hf] add unintended-removed comma

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
@@ -199,7 +199,8 @@ def refine_pipeline_creation_params(model_settings: Dict[str, Any]) -> List[Dict
         "device",
         "framework",
         "feature_extractor",
-        "stride_length_s" "tokenizer",
+        "stride_length_s",
+        "tokenizer",
     }
 
     pipeline_creation_params: Dict[str, Any] = {}


### PR DESCRIPTION
[easy][extension][py][hf] add unintended-removed comma


comma was mistakenly removed. Adding it back in.

For context: Doesn't break anything because in python  you can concatenate strings without using the + operator by simply placing them adjacent to each other, like this:

```
"string1" "string2"
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/839).
* #840
* __->__ #839