### PR TITLE
[editor] Updates to  ASR prompt Schema

### DIFF
--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionPromptSchema.ts
@@ -15,7 +15,7 @@ export const HuggingFaceAutomaticSpeechRecognitionPromptSchema: PromptSchema = {
         items: {
           type: "attachment",
           required: ["data"],
-          mime_types: ["audio/mpeg", "audio/wav", "audio/webm"],
+          mime_types: ["audio/mpeg", "audio/wav", "audio/webm", "audio/flac", "audio/ogg", "audio/ogg"],
           properties: {
             data: {
               type: "string",
@@ -45,6 +45,11 @@ export const HuggingFaceAutomaticSpeechRecognitionPromptSchema: PromptSchema = {
          bits at the end to make the final reconstitution as perfect as possible.
          Defaults to defaults to chunk_length_s / 6`,
       },
+      device:{
+        type: "string",
+        enum: ["cuda", "mps", "cpu"],
+        description: `The device to load the pipeline to. Mps backend not supported for all models.`
+      },
       framework: {
         type: "string",
         enum: ["pt", "tf"],
@@ -54,6 +59,21 @@ export const HuggingFaceAutomaticSpeechRecognitionPromptSchema: PromptSchema = {
         frameworks are installed, will default to the framework of the model, or to PyTorch if 
         no model is provided.`,
       },
+      tokenizer: {
+        type: "string",
+      },
+      return_timestamps: {
+        type: "string",
+        enum: ["word", "char", "True", ""],
+        description: `Only available for pure CTC models (Wav2Vec2, HuBERT, etc) and the Whisper model. Not available for other sequence-to-sequence models.`
+      },
+      max_new_tokens: {
+        type: "number",
+        description: `The maximum numbers of tokens to generate, ignoring the number of tokens in the prompt`
+      }
     },
   },
 };
+
+
+

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -77,6 +77,7 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
 
   // HuggingFaceTextGenerationParser
   HuggingFaceTextGenerationParser: HuggingFaceTextGenerationParserPromptSchema,
+  "HuggingFaceAutomaticSpeechRecognitionTransformer": HuggingFaceAutomaticSpeechRecognitionPromptSchema,
 
   // PaLMTextParser
   "models/text-bison-001": PaLMTextParserPromptSchema,


### PR DESCRIPTION
[editor] Updates to  ASR prompt Schema







Adding in changes to the ASR prompt schema. Previously this schema was shipped to unblock.

Couple of changes:

- Support a list of 5 audio formats.
- - Top 5 chosen by [asking GPT](https://lastmileai.dev/workbooks/clr6yqzzy0015pe4ewvgm4ce9)
- - Note: ASR supports FFmpeg to transcribe audio. For now we are choosing a few to start
- Added a few completion params, found while implementing model parser for ASR
- Added a few params for pipeline creation.

TODO:
investigate these types because they may not be primitives
- pipeline creation:
- - "decoder",
- - - I believe this should be an in memory object
- - "feature_extractor"
- - - Same with this, this might have to be an in memory object
- completion params:
- - "generate_kwargs"
- - This is a dictionary/map of ad-hoc parameters


## Testplan

1. run server with model parser registered:
<img width="800" alt="Screenshot 2024-01-09 at 10 50 22 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/7a965c73-4df4-404d-813c-5abe20023756">

render:

<img width="1268" alt="Screenshot 2024-01-09 at 10 49 50 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/b13eaa2a-d2e0-465b-88ea-69031d7e3e0d">
