### PR TITLE
[editor] RunPromptButton Placement

### DIFF
--- a/python/src/aiconfig/editor/client/src/LocalEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/LocalEditor.tsx
@@ -311,7 +311,6 @@ export default function Editor() {
             ".runPromptButton": {
               background: "#ff1cf7",
               color: "white",
-              borderRadius: "0",
               height: "auto",
               "&:hover": {
                 background: "#ff46f8",

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
@@ -7,16 +7,13 @@ import {
 } from "../../utils/promptUtils";
 import { ActionIcon, Container, Flex, Tabs } from "@mantine/core";
 import { IconClearAll } from "@tabler/icons-react";
-import { memo, useCallback, useState } from "react";
+import { memo, useState } from "react";
 import ParametersRenderer from "../ParametersRenderer";
-import RunPromptButton from "./RunPromptButton";
 import { JSONObject } from "aiconfig";
 
 type Props = {
   prompt: ClientPrompt;
   promptSchema?: PromptSchema;
-  cancel: (cancellationToken: string) => Promise<void>;
-  onRunPrompt: () => Promise<void>;
   onUpdateModelSettings: (settings: Record<string, unknown>) => void;
   onUpdateParameters: (parameters: JSONObject) => void;
 };
@@ -36,8 +33,6 @@ function getPromptParameters(prompt: ClientPrompt) {
 export default memo(function PromptActionBar({
   prompt,
   promptSchema,
-  cancel,
-  onRunPrompt,
   onUpdateModelSettings,
   onUpdateParameters,
 }: Props) {
@@ -45,18 +40,6 @@ export default memo(function PromptActionBar({
   // TODO: Handle drag-to-resize
   const modelSettingsSchema = promptSchema?.model_settings;
   const promptMetadataSchema = promptSchema?.prompt_metadata;
-
-  const onCancel = useCallback(async () => {
-    if (prompt._ui.cancellationToken) {
-      return await cancel(prompt._ui.cancellationToken);
-    } else {
-      // TODO: saqadri - Maybe surface an error to the user, or explicitly throw an error in this case.
-      console.log(
-        `Warning: No cancellation token found for prompt: ${prompt.name}`
-      );
-      return;
-    }
-  }, [prompt.name, prompt._ui.cancellationToken, cancel]);
 
   return (
     <Flex direction="column" justify="space-between" h="100%">
@@ -102,12 +85,6 @@ export default memo(function PromptActionBar({
               )}
             </Tabs>
           </Container>
-          <RunPromptButton
-            isRunning={prompt._ui.isRunning}
-            cancel={onCancel}
-            runPrompt={onRunPrompt}
-            size="full"
-          />
         </>
       ) : (
         <Flex direction="column" justify="space-between" h="100%">
@@ -116,12 +93,6 @@ export default memo(function PromptActionBar({
               <IconClearAll />
             </ActionIcon>
           </Flex>
-          <RunPromptButton
-            isRunning={prompt._ui.isRunning}
-            cancel={onCancel}
-            runPrompt={onRunPrompt}
-            size="compact"
-          />
         </Flex>
       )}
     </Flex>

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
@@ -71,6 +71,18 @@ export default memo(function PromptContainer({
     [promptId, onRunPrompt]
   );
 
+  const onCancelRun = useCallback(async () => {
+    if (prompt._ui.cancellationToken) {
+      return await cancel(prompt._ui.cancellationToken);
+    } else {
+      // TODO: saqadri - Maybe surface an error to the user, or explicitly throw an error in this case.
+      console.log(
+        `Warning: No cancellation token found for prompt: ${prompt.name}`
+      );
+      return;
+    }
+  }, [prompt.name, prompt._ui.cancellationToken, cancel]);
+
   const updateModel = useCallback(
     (model?: string) => onUpdateModel(promptId, model),
     [promptId, onUpdateModel]
@@ -104,6 +116,9 @@ export default memo(function PromptContainer({
             input={prompt.input}
             schema={inputSchema}
             onChangeInput={onChangeInput}
+            onCancelRun={onCancelRun}
+            onRunPrompt={runPrompt}
+            isRunning={prompt._ui.isRunning}
           />
           <PromptOutputBar />
           {prompt.outputs && <PromptOutputsRenderer outputs={prompt.outputs} />}
@@ -113,8 +128,6 @@ export default memo(function PromptContainer({
         <PromptActionBar
           prompt={prompt}
           promptSchema={promptSchema}
-          cancel={cancel}
-          onRunPrompt={runPrompt}
           onUpdateModelSettings={updateModelSettings}
           onUpdateParameters={updateParameters}
         />

--- a/python/src/aiconfig/editor/client/src/components/prompt/RunPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/RunPromptButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Loader, Text } from "@mantine/core";
+import { Button, Flex, Loader } from "@mantine/core";
 import { IconPlayerPlayFilled, IconPlayerStop } from "@tabler/icons-react";
 import { memo } from "react";
 
@@ -6,13 +6,11 @@ type Props = {
   isRunning?: boolean;
   cancel: () => Promise<void>;
   runPrompt: () => Promise<void>;
-  size: "compact" | "full";
 };
 
 export default memo(function RunPromptButton({
   cancel,
   runPrompt,
-  size,
   isRunning = false,
 }: Props) {
   const onClick = async () => {
@@ -29,7 +27,6 @@ export default memo(function RunPromptButton({
       disabled={false}
       p="xs"
       size="xs"
-      fullWidth={size === "full"}
       className="runPromptButton"
     >
       {isRunning ? (
@@ -40,7 +37,6 @@ export default memo(function RunPromptButton({
       ) : (
         <>
           <IconPlayerPlayFilled size="16" />
-          {size === "full" && <Text ml="0.5em">Run</Text>}
         </>
       )}
     </Button>


### PR DESCRIPTION
# [editor] RunPromptButton Placement

Update the RunPromptButton placement to be beside the input so that it is easy to access (stays in place) regardless of long input/outputs, per discussion in https://github.com/lastmile-ai/aiconfig/pull/844:

## Normal Placement
![Screenshot 2024-01-10 at 11 16 11 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/86b7219c-9e30-4b77-bb38-61dbe9d4520e)

## Long Input:
![Screenshot 2024-01-10 at 11 15 56 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/6aa91e44-9401-41ae-bc4d-afc7bbdf8f2a)

## Long Output:
![Screenshot 2024-01-10 at 11 17 58 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/9e944601-273b-435c-bb66-4f8c54179bf6)

## JSON Editor Toggled:
![Screenshot 2024-01-10 at 11 16 24 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/8ab019b3-db00-4cd5-9895-98426f2fe6a5)

## Error Boundary Hit / Fallback Rendering:
![Screenshot 2024-01-10 at 11 14 19 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/aa046089-a517-47e9-9411-62f8a33d0857)


## Testing:
- Make sure run and cancel still work

