### PR TITLE
[editor] Add Missing Styling Changes to Core Components

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/GlobalParametersContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/GlobalParametersContainer.tsx
@@ -1,4 +1,4 @@
-import { createStyles, Container, Accordion, Text } from "@mantine/core";
+import { Container, Accordion, Text } from "@mantine/core";
 import { JSONObject } from "aiconfig";
 import { memo, useState } from "react";
 import ParametersRenderer from "./ParametersRenderer";
@@ -8,22 +8,11 @@ type Props = {
   onUpdateParameters: (newParameters: JSONObject) => void;
 };
 
-const useStyles = createStyles((theme) => ({
-  parametersContainer: {
-    [theme.fn.smallerThan("sm")]: {
-      padding: "0 0 200px 0",
-    },
-    paddingBottom: 50,
-  },
-}));
-
 export default memo(function GlobalParametersContainer({
   initialValue,
   onUpdateParameters,
 }: Props) {
   const [isParametersDrawerOpen, setIsParametersDrawerOpen] = useState(false);
-
-  const { classes } = useStyles();
 
   return (
     <Container maw="80rem" className="parametersContainer">

--- a/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
@@ -41,6 +41,7 @@ export default memo(function ModelSelector({
       placeholder="Select model"
       limit={100}
       className="ghost"
+      label="Model"
       variant="unstyled"
       maxDropdownHeight={200}
       rightSection={

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptName.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptName.tsx
@@ -23,6 +23,7 @@ export default memo(function PromptName({ promptId, name, onUpdate }: Props) {
   return (
     <TextInput
       value={nameInput}
+      label="Prompt Name"
       className="ghost"
       variant="unstyled"
       placeholder="Name this prompt"

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
@@ -74,6 +74,7 @@ export default memo(function PromptInputSchemaRenderer(props: Props) {
     return (
       <Textarea
         value={props.input}
+        label="Prompt"
         onChange={(e) => props.onChangeInput(e.target.value)}
         placeholder="Type a prompt"
         autosize


### PR DESCRIPTION
# [editor] Add Missing Styling Changes to Core Components

Some things that got left out / missed as part of this stack split: https://github.com/lastmile-ai/aiconfig/pull/810/files

Mainly just the labels for prompt name/input/model selector; styling already handles hiding them in local editor and showing them in gradio:

## With Gradio Styles:
![Screenshot 2024-01-10 at 11 39 11 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/47f08c40-774c-4ab4-88d0-6318f8671689)

## With Local Editor Styles:
![Screenshot 2024-01-10 at 11 39 34 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/901fb17b-35d8-438d-859b-60361514da6e)

