### PR TITLE
HF transformers: Small fixes nits

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/__init__.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/__init__.py
@@ -1,3 +1,4 @@
+from .local_inference.automatic_speech_recognition import HuggingFaceAutomaticSpeechRecognitionTransformer
 from .local_inference.image_2_text import HuggingFaceImage2TextTransformer
 from .local_inference.text_2_image import HuggingFaceText2ImageDiffusor
 from .local_inference.text_2_speech import HuggingFaceText2SpeechTransformer
@@ -5,18 +6,16 @@ from .local_inference.text_generation import HuggingFaceTextGenerationTransforme
 from .local_inference.text_summarization import HuggingFaceTextSummarizationTransformer
 from .local_inference.text_translation import HuggingFaceTextTranslationTransformer
 from .remote_inference_client.text_generation import HuggingFaceTextGenerationParser
-from .local_inference.automatic_speech_recognition import HuggingFaceAutomaticSpeechRecognitionTransformer
 
 
 LOCAL_INFERENCE_CLASSES = [
+    "HuggingFaceAutomaticSpeechRecognitionTransformer",
+    "HuggingFaceImage2TextTransformer",
     "HuggingFaceText2ImageDiffusor",
+    "HuggingFaceText2SpeechTransformer",
     "HuggingFaceTextGenerationTransformer",
     "HuggingFaceTextSummarizationTransformer",
     "HuggingFaceTextTranslationTransformer",
-    "HuggingFaceText2SpeechTransformer",
-    "HuggingFaceAutomaticSpeechRecognition",
-    "HuggingFaceImage2TextTransformer",
-    "HuggingFaceAutomaticSpeechRecognitionTransformer",
 ]
 REMOTE_INFERENCE_CLASSES = ["HuggingFaceTextGenerationParser"]
 __ALL__ = LOCAL_INFERENCE_CLASSES + REMOTE_INFERENCE_CLASSES

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
@@ -1,28 +1,29 @@
-from typing import Any, Dict, Literal, Optional, List, TYPE_CHECKING
+from typing import Any, Dict, Optional, List, TYPE_CHECKING
+
+import torch
+from transformers import pipeline, Pipeline
 from aiconfig import ParameterizedModelParser, InferenceOptions
 from aiconfig.callback import CallbackEvent
-from pydantic import BaseModel
-import torch
 from aiconfig.schema import Prompt, Output, ExecuteResult, Attachment
 
-from transformers import pipeline, Pipeline
 
 if TYPE_CHECKING:
     from aiconfig import AIConfigRuntime
-"""
-Model Parser for HuggingFace ASR (Automatic Speech Recognition) models.
-"""
 
 
 class HuggingFaceAutomaticSpeechRecognitionTransformer(ParameterizedModelParser):
+    """
+    Model Parser for HuggingFace ASR (Automatic Speech Recognition) models.
+    """
+
     def __init__(self):
         """
         Returns:
-            HuggingFaceAutomaticSpeechRecognition
+            HuggingFaceAutomaticSpeechRecognitionTransformer
 
         Usage:
         1. Create a new model parser object with the model ID of the model to use.
-                parser = HuggingFaceAutomaticSpeechRecognition()
+                parser = HuggingFaceAutomaticSpeechRecognitionTransformer()
         2. Add the model parser to the registry.
                 config.register_model_parser(parser)
         """
@@ -55,7 +56,8 @@ class HuggingFaceAutomaticSpeechRecognitionTransformer(ParameterizedModelParser)
         Returns:
             str: Serialized representation of the prompt and inference settings.
         """
-        raise NotImplementedError("serialize is not implemented for HuggingFaceAutomaticSpeechRecognition")
+        # TODO: See https://github.com/lastmile-ai/aiconfig/issues/822
+        raise NotImplementedError("serialize is not implemented for HuggingFaceAutomaticSpeechRecognitionTransformer")
 
     async def deserialize(
         self,

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_2_speech.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_2_speech.py
@@ -1,8 +1,8 @@
 import base64
 import copy
 import io
+import json
 import numpy as np
-import torch
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from transformers import Pipeline, pipeline
 from scipy.io.wavfile import write as write_wav
@@ -12,7 +12,6 @@ from aiconfig.model_parser import InferenceOptions
 from aiconfig.schema import (
     ExecuteResult,
     Output,
-    OutputDataWithValue,
     Prompt,
     PromptMetadata,
 )
@@ -25,7 +24,7 @@ if TYPE_CHECKING:
 
 # Step 1: define Helpers
 def refine_pipeline_creation_params(model_settings: Dict[str, Any]) -> List[Dict[str, Any]]:
-    # There are from the transformers Github repo: 
+    # These are from the transformers Github repo: 
     # https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L2534
     supported_keys = {
         "torch_dtype",
@@ -228,8 +227,9 @@ class HuggingFaceText2SpeechTransformer(ParameterizedModelParser):
         # TODO (rossdanlm): Handle multiple outputs in list
         # https://github.com/lastmile-ai/aiconfig/issues/467
         if output.output_type == "execute_result":
-            if isinstance(output.data, OutputDataWithValue):
-                return output.data.value
-            elif isinstance(output.data, str):
+            if isinstance(output.data, str):
                 return output.data
+            # HuggingFace text to speech outputs should only ever be string
+            # format so shouldn't get here, but just being safe
+            return json.dumps(output.data, indent=2)
         return ""

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_generation.py
@@ -14,7 +14,6 @@ from aiconfig.model_parser import InferenceOptions
 from aiconfig.schema import (
     ExecuteResult,
     Output,
-    OutputDataWithValue,
     Prompt,
     PromptMetadata,
 )
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
 
 
 # Step 1: define Helpers
-def refine_chat_completion_params(model_settings: Dict[str, Any]) -> Dict[str, Any]:
+def refine_completion_params(model_settings: Dict[str, Any]) -> Dict[str, Any]:
     """
     Refines the completion params for the HF text generation api. Removes any unsupported params.
     The supported keys were found by looking at the HF text generation api. `huggingface_hub.InferenceClient.text_generation()`
@@ -216,7 +215,7 @@ class HuggingFaceTextGenerationTransformer(ParameterizedModelParser):
         """
         # Build Completion data
         model_settings = self.get_model_settings(prompt, aiconfig)
-        completion_data = refine_chat_completion_params(model_settings)
+        completion_data = refine_completion_params(model_settings)
 
         #Add resolved prompt
         resolved_prompt = resolve_prompt(prompt, params, aiconfig)
@@ -296,10 +295,8 @@ class HuggingFaceTextGenerationTransformer(ParameterizedModelParser):
             output_data = output.data
             if isinstance(output_data, str):
                 return output_data
-            if isinstance(output_data, OutputDataWithValue):
-                if isinstance(output_data.value, str):
-                    return output_data.value
-                # HuggingFace Text generation does not support function
-                # calls so shouldn't get here, but just being safe
-                return json.dumps(output_data.value, indent=2)
+            # HuggingFace text generation outputs should only ever be in
+            # string format so shouldn't get here, but
+            # just being safe
+            return json.dumps(output_data, indent=2)
         return ""

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_summarization.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_summarization.py
@@ -14,7 +14,6 @@ from aiconfig.model_parser import InferenceOptions
 from aiconfig.schema import (
     ExecuteResult,
     Output,
-    OutputDataWithValue,
     Prompt,
     PromptMetadata,
 )
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
 
 
 # Step 1: define Helpers
-def refine_chat_completion_params(model_settings: Dict[str, Any]) -> Dict[str, Any]:
+def refine_completion_params(model_settings: Dict[str, Any]) -> Dict[str, Any]:
     """
     Refines the completion params for the HF text summarization api. Removes any unsupported params.
     The supported keys were found by looking at the HF text summarization api. `huggingface_hub.InferenceClient.text_summarization()`
@@ -221,7 +220,7 @@ class HuggingFaceTextSummarizationTransformer(ParameterizedModelParser):
         """
         # Build Completion data
         model_settings = self.get_model_settings(prompt, aiconfig)
-        completion_data = refine_chat_completion_params(model_settings)
+        completion_data = refine_completion_params(model_settings)
 
         # Add resolved prompt
         resolved_prompt = resolve_prompt(prompt, params, aiconfig)
@@ -301,10 +300,7 @@ class HuggingFaceTextSummarizationTransformer(ParameterizedModelParser):
             output_data = output.data
             if isinstance(output_data, str):
                 return output_data
-            if isinstance(output_data, OutputDataWithValue):
-                if isinstance(output_data.value, str):
-                    return output_data.value
-                # HuggingFace Text summarization does not support function
-                # calls so shouldn't get here, but just being safe
-                return json.dumps(output_data.value, indent=2)
+            # HuggingFace text summarization outputs should only ever be in
+            # string format so shouldn't get here, but just being safe
+            return json.dumps(output_data, indent=2)
         return ""

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_translation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_translation.py
@@ -14,7 +14,6 @@ from aiconfig.model_parser import InferenceOptions
 from aiconfig.schema import (
     ExecuteResult,
     Output,
-    OutputDataWithValue,
     Prompt,
     PromptMetadata,
 )
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
 
 
 # Step 1: define Helpers
-def refine_chat_completion_params(model_settings: Dict[str, Any]) -> Dict[str, Any]:
+def refine_completion_params(model_settings: Dict[str, Any]) -> Dict[str, Any]:
     """
     Refines the completion params for the HF text translation api. Removes any unsupported params.
     The supported keys were found by looking at the HF text translation api. `huggingface_hub.InferenceClient.text_translation()`
@@ -223,7 +222,7 @@ class HuggingFaceTextTranslationTransformer(ParameterizedModelParser):
         """
         # Build Completion data
         model_settings = self.get_model_settings(prompt, aiconfig)
-        completion_data = refine_chat_completion_params(model_settings)
+        completion_data = refine_completion_params(model_settings)
 
         # Add resolved prompt
         resolved_prompt = resolve_prompt(prompt, params, aiconfig)
@@ -304,10 +303,7 @@ class HuggingFaceTextTranslationTransformer(ParameterizedModelParser):
             output_data = output.data
             if isinstance(output_data, str):
                 return output_data
-            if isinstance(output_data, OutputDataWithValue):
-                if isinstance(output_data.value, str):
-                    return output_data.value
-                # HuggingFace Text translation does not support function
-                # calls so shouldn't get here, but just being safe
-                return json.dumps(output_data.value, indent=2)
+            # HuggingFace text translation outputs should only ever be in
+            # string format so shouldn't get here, but just being safe
+            return json.dumps(output_data, indent=2)
         return ""

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
@@ -15,7 +15,6 @@ from aiconfig.model_parser import InferenceOptions
 from aiconfig.schema import (
     ExecuteResult,
     Output,
-    OutputDataWithValue,
     Prompt,
     PromptMetadata,
 )
@@ -29,9 +28,7 @@ if TYPE_CHECKING:
 
 
 # Step 1: define Helpers
-
-
-def refine_chat_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
+def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
     """
     Refines the completion params for the HF text generation api. Removes any unsupported params.
     The supported keys were found by looking at the HF text generation api. `huggingface_hub.InferenceClient.text_generation()`
@@ -243,7 +240,7 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
         # Build Completion data
         model_settings = self.get_model_settings(prompt, aiconfig)
 
-        completion_data = refine_chat_completion_params(model_settings)
+        completion_data = refine_completion_params(model_settings)
 
         completion_data["prompt"] = resolved_prompt
 
@@ -318,10 +315,8 @@ class HuggingFaceTextGenerationParser(ParameterizedModelParser):
             output_data = output.data
             if isinstance(output_data, str):
                 return output_data
-            if isinstance(output_data, OutputDataWithValue):
-                if isinstance(output_data.value, str):
-                    return output_data.value
-                # HuggingFace Text generation does not support function
-                # calls so shouldn't get here, but just being safe
-                return json.dumps(output_data.value, indent=2)
+            
+            # HuggingFace text generation outputs should only ever be string
+            # format so shouldn't get here, but just being safe
+            return json.dumps(output_data, indent=2)
         return ""


### PR DESCRIPTION
HF transformers: Small fixes nits

Small fixes from comments from Sarmad + me from these diffs:

- https://github.com/lastmile-ai/aiconfig/pull/854
- https://github.com/lastmile-ai/aiconfig/pull/855
- https://github.com/lastmile-ai/aiconfig/pull/821

Main things I did
- rename `refine_chat_completion_params` --> `chat_completion_params`
- edit `get_text_output` to not check for `OutputDataWithValue`
- sorted the init file to be alphabetical
- fixed some typos/print statements
- made some error messages a bit more intuitive with prompt name
- sorted some imports
- fixed old class name `HuggingFaceAutomaticSpeechRecognition` --> `HuggingFaceAutomaticSpeechRecognitionTransformer`

## Test Plan
These are all small nits and shouldn't change functionality
