### PR TITLE
Add sacremoses dependency to HF extension

### DIFF
--- a/extensions/HuggingFace/python/requirements.txt
+++ b/extensions/HuggingFace/python/requirements.txt
@@ -11,6 +11,7 @@ huggingface_hub
 #Hugging Face Libraries - Local Inference Tranformers & Diffusors
 accelerate # Used to help speed up image generation
 diffusers # Used for image generation
+sacremoses # Used for tokenizer, detokenizer, pipelines
 scipy # array -> wav file, text-speech. torchaudio.save seems broken.
 sentencepiece # Used for text translation
 torch


### PR DESCRIPTION
Add sacremoses dependency to HF extension

We'd be getting this issue where the streaming suddenly stops and hangs

I suspect that this is to due being in debug mode instead of prod mode. We also know that debug mode in general gets runtime errors

See doc here for more details on how I investigated, including what commands I used:
https://docs.google.com/document/d/1NJjFMQ1_y9iz7kXEX_yZeY4yYgVsTsMF5IQhThXU87c/edit#heading=h.44hkfutqnu8c

Still, just saw that it was recommened to install this dependency, and there doesn't seem to be an issue with it os just adding it: https://pypi.org/project/sacremoses/


## Test Plan
First get the `python-aiconfig-test` module:
```bash
pip3 install --index-url https://test.pypi.org/simple --extra-index-url https://pypi.org/simple python-aiconfig-test==1.1.30 --force
```

I also configured my UI paths:
```bash
rossdancraig@Rossdans-MacBook-Pro aiconfig % parsers_path=/Users/rossdancraig/Projects/aiconfig/cookbooks/Gradio/hf_model_parsers.py
rossdancraig@Rossdans-MacBook-Pro aiconfig % aiconfig_path=/Users/rossdancraig/Projects/aiconfig/cookbooks/Gradio/huggingface.aiconfig.json
```

Before (ran in dev mode from main AIConfig repo)
```bash
aiconfig edit --aiconfig-path=$aiconfig_path --server-port=8080 --server-mode=debug_servers --parsers-module-path=$parsers_path
```

https://github.com/lastmile-ai/aiconfig/assets/151060367/8d4e5d51-3915-4184-8278-dbcace643acd

After (ran in prod mode from AIConfig repo)
```
aiconfig edit --aiconfig-path=$aiconfig_path --server-port=8080 --parsers-module-path=$parsers_path
```

https://github.com/lastmile-ai/aiconfig/assets/151060367/e7796366-29e7-479b-984d-559cc2044f89
