### PR TITLE
[HF][fix] Use ParameterizedModelParser instead of ModelParser

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
@@ -3,15 +3,17 @@ from typing import Any, Dict, Optional, List, TYPE_CHECKING
 import torch
 from transformers import pipeline, Pipeline
 from aiconfig_extension_hugging_face.local_inference.util import get_hf_model
-from aiconfig import ModelParser, InferenceOptions
+
 from aiconfig.callback import CallbackEvent
+from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
+from aiconfig.model_parser import InferenceOptions
 from aiconfig.schema import Prompt, Output, ExecuteResult, Attachment
 
 if TYPE_CHECKING:
     from aiconfig import AIConfigRuntime
 
 
-class HuggingFaceAutomaticSpeechRecognitionTransformer(ModelParser):
+class HuggingFaceAutomaticSpeechRecognitionTransformer(ParameterizedModelParser):
     """
     Model Parser for HuggingFace ASR (Automatic Speech Recognition) models.
     """
@@ -85,7 +87,7 @@ class HuggingFaceAutomaticSpeechRecognitionTransformer(ModelParser):
         await aiconfig.callback_manager.run_callbacks(CallbackEvent("on_deserialize_complete", __name__, {"output": completion_data}))
         return completion_data
 
-    async def run(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any]) -> list[Output]:
+    async def run_inference(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any]) -> List[Output]:
         await aiconfig.callback_manager.run_callbacks(
             CallbackEvent(
                 "on_run_start",

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/image_2_text.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/image_2_text.py
@@ -10,8 +10,9 @@ from transformers import (
 
 from aiconfig_extension_hugging_face.local_inference.util import get_hf_model
 
-from aiconfig import ModelParser, InferenceOptions
 from aiconfig.callback import CallbackEvent
+from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
+from aiconfig.model_parser import InferenceOptions
 from aiconfig.schema import (
     Attachment,
     ExecuteResult,
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
     from aiconfig import AIConfigRuntime
 
 
-class HuggingFaceImage2TextTransformer(ModelParser):
+class HuggingFaceImage2TextTransformer(ParameterizedModelParser):
     def __init__(self):
         """
         Returns:
@@ -117,7 +118,7 @@ class HuggingFaceImage2TextTransformer(ModelParser):
         await aiconfig.callback_manager.run_callbacks(CallbackEvent("on_deserialize_complete", __name__, {"output": completion_params}))
         return completion_params
 
-    async def run(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any]) -> list[Output]:
+    async def run_inference(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any]) -> List[Output]:
         await aiconfig.callback_manager.run_callbacks(
             CallbackEvent(
                 "on_run_start",


### PR DESCRIPTION
[HF][fix] Use ParameterizedModelParser instead of ModelParser


Fixing this error:
```
Exception: HuggingFaceImage2TextTransformer.run() got an unexpected keyword argument 'callback_manager'
```

This seems like a pretty brittle bug. If we use `ModelParser` isntead of `ParameterizedModelParser`, we get a bug because `callback_manager` is not a supported kwargs for the `run_inference()` method. This gets filtered out by the `ParameterizedModelParser.run()` method (https://github.com/lastmile-ai/aiconfig/blob/0ceb17636bae2b5416e7b415cdc87fd71b5ba3b0/python/src/aiconfig/default_parsers/parameterized_model_parser.py#L48-L54) but these kwags are not accepted  by the `ModelParser.run()` method (https://github.com/lastmile-ai/aiconfig/blob/0ceb17636bae2b5416e7b415cdc87fd71b5ba3b0/python/src/aiconfig/model_parser.py#L62-L69)

## Test Plan

Before

https://github.com/lastmile-ai/aiconfig/assets/151060367/a23a5d5c-d9a2-415b-8a6e-9826da56e985


After

https://github.com/lastmile-ai/aiconfig/assets/151060367/8899c527-7496-410b-b6b6-9e5a9525b1b5
