### PR TITLE
Fix `get_prompt_template()` for parameterized_model_parser

### DIFF
--- a/python/src/aiconfig/default_parsers/parameterized_model_parser.py
+++ b/python/src/aiconfig/default_parsers/parameterized_model_parser.py
@@ -117,13 +117,13 @@ class ParameterizedModelParser(ModelParser):
         """
         return resolve_prompt_string(prompt, params, ai_config, prompt_template)
 
-    def get_prompt_template(self, prompt: Prompt, aiConfig: "AIConfigRuntime") -> str:
+    def get_prompt_template(self, prompt: Prompt, aiConfig: "AIConfigRuntime") -> str | None:
         """
         An overrideable method that returns a template for a prompt.
         """
         if isinstance(prompt.input, str):
             return prompt.input
-        elif isinstance(prompt.input, PromptInput) and isinstance(prompt.input.data, str):
+        if isinstance(prompt.input, PromptInput) and isinstance(prompt.input.data, str):
             return prompt.input.data
-        else:
-            raise Exception(f"Cannot get prompt template string from prompt input: {prompt.input}")
+        # Not all model inputs are parameterizable (e.g. image inputs)
+        return None


### PR DESCRIPTION
Fix `get_prompt_template()` for parameterized_model_parser


Getting this error:
```
Exception: Cannot get prompt template string from prompt input: attachments=[Attachment(data='https://s3.amazonaws.com/lastmileai.aiconfig.public/uploads/2024_1_10_18_41_31/1742/bear_with_honey.png', mime_type='image/png', metadata=None), Attachment(data='https://s3.amazonaws.com/lastmileai.aiconfig.public/uploads/2024_1_10_18_41_31/7275/fox_in_forest.png', mime_type='image/png', metadata=None)] data=None
```

When Sarmad did this fix in https://github.com/lastmile-ai/aiconfig/pull/866, he missed a callsite in the `parameterized_model_parser`. This was missed because at the time the image_2_text model parser was of type `ModelParser` instead of `ParameterizedModelParser`, which had to be converted in here to fix a bug: https://github.com/lastmile-ai/aiconfig/pull/877


## Test Plan

Before
<img width="1295" alt="Screenshot 2024-01-11 at 02 52 42" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/c0c99f1e-2996-41f3-8274-c13ecc43f07e">


After

https://github.com/lastmile-ai/aiconfig/assets/151060367/7a10932c-8580-4584-8942-4c287f23fc82

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/878).
* #879
* __->__ #878