### PR TITLE
[ez][fix][HF]Explicitly set hf_model to None if it's empty string

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/util.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/util.py
@@ -14,7 +14,7 @@ def get_hf_model(aiconfig: "AIConfigRuntime", prompt: Prompt, model_parser: Para
     """
     model_name: str | None = aiconfig.get_model_name(prompt)
     model_settings = model_parser.get_model_settings(prompt, aiconfig)
-    hf_model = model_settings.get("model", None)
+    hf_model = model_settings.get("model") or None # Replace "" with None value
 
     if hf_model is not None and isinstance(hf_model, str):
         # If the model property is set in the model settings, use that.


### PR DESCRIPTION
[ez][fix][HF]Explicitly set hf_model to None if it's empty string

Lol literally a 1-line fix.

I tested by removing the model name explicitly from HF model parsers to use the default, but this errored since we're setting it to "" instead of None.
<img width="610" alt="Screenshot 2024-01-11 at 03 02 00" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/1a045dbb-ad1c-46db-ba1c-32b05d923484">


## Test Plan

Before
```
model_name=""
```
I got an error saying that no model "" exists, forgot to take screenshot but it was real pls believe me


After
```
model_name=None
No model was supplied, defaulted to sshleifer/distilbart-cnn-12-6 and revision a4f8f3e (https://huggingface.co/sshleifer/distilbart-cnn-12-6).
Using a pipeline without specifying a model name and revision in production is not recommended.
```

https://github.com/lastmile-ai/aiconfig/assets/151060367/db6b35d4-9e03-4ff5-b035-c77263978fd4

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/879).
* #885
* #883
* #882
* #881
* __->__ #879