### PR TITLE
Use facebook/mms-tts-eng instead of suno/bark in Gradio cookbook for Text2Speech

### DIFF
--- a/cookbooks/Gradio/huggingface.aiconfig.json
+++ b/cookbooks/Gradio/huggingface.aiconfig.json
@@ -16,7 +16,7 @@
     "default_model": "stevhliu/my_awesome_billsum_model",
     "model_parsers": {
       "Salesforce/blip-image-captioning-base": "HuggingFaceImage2TextTransformer",
-      "suno/bark": "HuggingFaceText2SpeechTransformer"
+      "facebook/mms-tts-eng": "HuggingFaceText2SpeechTransformer"
     }
   },
   "description": "Welcome to the first Hugging Face AIConfig! Let's showcase the many capabilities of Hugging Face models, all in one place.",
@@ -141,7 +141,7 @@
         "model": {
           "name": "HuggingFaceText2SpeechTransformer",
           "settings": {
-            "model": "suno/bark",
+            "model": "facebook/mms-tts-eng",
             "max_length": 100,
             "min_length": 50,
             "num_beams": 1

--- a/cookbooks/Gradio/huggingface.aiconfig.json
+++ b/cookbooks/Gradio/huggingface.aiconfig.json
@@ -214,14 +214,13 @@
       },
       "metadata": {
         "model": {
-          "name": "HuggingFaceAutomaticSpeechRecognition",
+          "name": "HuggingFaceAutomaticSpeechRecognitionTransformer",
           "settings": {
             "model": "openai/whisper-small"
           }
         },
         "parameters": {}
-      },
-      "outputs": []
+      }
     }
   ],
   "$schema": "https://json.schemastore.org/aiconfig-1.0"

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
@@ -85,7 +85,7 @@ class HuggingFaceAutomaticSpeechRecognitionTransformer(ModelParser):
         await aiconfig.callback_manager.run_callbacks(CallbackEvent("on_deserialize_complete", __name__, {"output": completion_data}))
         return completion_data
 
-    async def run(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any]) -> list[Output]:
+    async def run(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any], **kwargs) -> list[Output]:
         await aiconfig.callback_manager.run_callbacks(
             CallbackEvent(
                 "on_run_start",

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
@@ -196,7 +196,6 @@ def refine_pipeline_creation_params(model_settings: Dict[str, Any]) -> List[Dict
     """
 
     supported_keys = {
-        "model",
         "chunk_length_s",
         "decoder",
         "device",

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/automatic_speech_recognition.py
@@ -3,17 +3,15 @@ from typing import Any, Dict, Optional, List, TYPE_CHECKING
 import torch
 from transformers import pipeline, Pipeline
 from aiconfig_extension_hugging_face.local_inference.util import get_hf_model
-
+from aiconfig import ModelParser, InferenceOptions
 from aiconfig.callback import CallbackEvent
-from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
-from aiconfig.model_parser import InferenceOptions
 from aiconfig.schema import Prompt, Output, ExecuteResult, Attachment
 
 if TYPE_CHECKING:
     from aiconfig import AIConfigRuntime
 
 
-class HuggingFaceAutomaticSpeechRecognitionTransformer(ParameterizedModelParser):
+class HuggingFaceAutomaticSpeechRecognitionTransformer(ModelParser):
     """
     Model Parser for HuggingFace ASR (Automatic Speech Recognition) models.
     """
@@ -87,7 +85,7 @@ class HuggingFaceAutomaticSpeechRecognitionTransformer(ParameterizedModelParser)
         await aiconfig.callback_manager.run_callbacks(CallbackEvent("on_deserialize_complete", __name__, {"output": completion_data}))
         return completion_data
 
-    async def run_inference(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any]) -> List[Output]:
+    async def run(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any]) -> list[Output]:
         await aiconfig.callback_manager.run_callbacks(
             CallbackEvent(
                 "on_run_start",

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/image_2_text.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/image_2_text.py
@@ -117,7 +117,7 @@ class HuggingFaceImage2TextTransformer(ModelParser):
         await aiconfig.callback_manager.run_callbacks(CallbackEvent("on_deserialize_complete", __name__, {"output": completion_params}))
         return completion_params
 
-    async def run(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any]) -> list[Output]:
+    async def run(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any], **kwargs) -> list[Output]:
         await aiconfig.callback_manager.run_callbacks(
             CallbackEvent(
                 "on_run_start",

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/image_2_text.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/image_2_text.py
@@ -10,9 +10,8 @@ from transformers import (
 
 from aiconfig_extension_hugging_face.local_inference.util import get_hf_model
 
+from aiconfig import ModelParser, InferenceOptions
 from aiconfig.callback import CallbackEvent
-from aiconfig.default_parsers.parameterized_model_parser import ParameterizedModelParser
-from aiconfig.model_parser import InferenceOptions
 from aiconfig.schema import (
     Attachment,
     ExecuteResult,
@@ -25,7 +24,7 @@ if TYPE_CHECKING:
     from aiconfig import AIConfigRuntime
 
 
-class HuggingFaceImage2TextTransformer(ParameterizedModelParser):
+class HuggingFaceImage2TextTransformer(ModelParser):
     def __init__(self):
         """
         Returns:
@@ -118,7 +117,7 @@ class HuggingFaceImage2TextTransformer(ParameterizedModelParser):
         await aiconfig.callback_manager.run_callbacks(CallbackEvent("on_deserialize_complete", __name__, {"output": completion_params}))
         return completion_params
 
-    async def run_inference(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any]) -> List[Output]:
+    async def run(self, prompt: Prompt, aiconfig: "AIConfigRuntime", options: InferenceOptions, parameters: Dict[str, Any]) -> list[Output]:
         await aiconfig.callback_manager.run_callbacks(
             CallbackEvent(
                 "on_run_start",

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_2_speech.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/text_2_speech.py
@@ -14,6 +14,7 @@ from aiconfig.model_parser import InferenceOptions
 from aiconfig.schema import (
     ExecuteResult,
     Output,
+    OutputDataWithStringValue,
     Prompt,
     PromptMetadata,
 )
@@ -230,9 +231,13 @@ class HuggingFaceText2SpeechTransformer(ParameterizedModelParser):
         # TODO (rossdanlm): Handle multiple outputs in list
         # https://github.com/lastmile-ai/aiconfig/issues/467
         if output.output_type == "execute_result":
-            if isinstance(output.data, str):
-                return output.data
-            # HuggingFace text to speech outputs should only ever be string
-            # format so shouldn't get here, but just being safe
-            return json.dumps(output.data, indent=2)
+            output_data = output.data
+            if isinstance(output_data, OutputDataWithStringValue):
+                return output_data.value
+            # HuggingFace text to image outputs should only ever be in
+            # outputDataWithStringValue format so shouldn't get here, but
+            # just being safe
+            if isinstance(output_data, str):
+                return output_data
+            return json.dumps(output_data, indent=2)
         return ""

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/util.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/util.py
@@ -14,7 +14,7 @@ def get_hf_model(aiconfig: "AIConfigRuntime", prompt: Prompt, model_parser: Para
     """
     model_name: str | None = aiconfig.get_model_name(prompt)
     model_settings = model_parser.get_model_settings(prompt, aiconfig)
-    hf_model = model_settings.get("model", None)
+    hf_model = model_settings.get("model") or None # Replace "" with None value
 
     if hf_model is not None and isinstance(hf_model, str):
         # If the model property is set in the model settings, use that.

--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -268,7 +268,7 @@ class AIConfigRuntime(AIConfig):
             options,
             params,
             callback_manager=self.callback_manager,
-            **kwargs,
+            **kwargs, # TODO: We should remove and make argument explicit
         )
 
         event = CallbackEvent("on_run_complete", __name__, {"result": response})

--- a/python/src/aiconfig/default_parsers/parameterized_model_parser.py
+++ b/python/src/aiconfig/default_parsers/parameterized_model_parser.py
@@ -45,7 +45,7 @@ class ParameterizedModelParser(ModelParser):
         aiconfig: AIConfig,
         options: Optional[InferenceOptions] = None,
         parameters: Dict = {},
-        **kwargs,
+        **kwargs, #TODO: We should remove and make arguments explicit
     ) -> List[Output]:
         # maybe use prompt metadata instead of kwargs?
         if kwargs.get("run_with_dependencies", False):

--- a/python/src/aiconfig/model_parser.py
+++ b/python/src/aiconfig/model_parser.py
@@ -66,6 +66,7 @@ class ModelParser(ABC):
         aiconfig: AIConfig,
         options: Optional["InferenceOptions"] = None,
         parameters: Dict = {},
+        **kwargs, # TODO: Remove this, just a hack for now to ensure that it doesn't break
     ) -> ExecuteResult:
         """
         Execute model inference based on completion data to be constructed in deserialize(), which includes the input prompt and


### PR DESCRIPTION
Use facebook/mms-tts-eng instead of suno/bark in Gradio cookbook for Text2Speech

Bark is ~5GB and took my laptop 30mins to download for the first time. The Facebook MMS (https://huggingface.co/facebook/mms-tts-eng?fbclid=IwAR22U5VSaZ_V7QW4TJe77CM7f4fsTHjqCMjgLKV31wUl66ww1vXYSrEl-MA) is only ~100MB which is way better and at least for cookbook I feel much more worth it to quickly test things out. Yes the output quality is way more memey and "voice AI" stereotype, but I feel the tradeoff is worth it

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/885).
* __->__ #885
* #883
* #882
* #881
* #879