### PR TITLE
Delete unused callback_manager argument from run commands

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -267,7 +267,6 @@ class AIConfigRuntime(AIConfig):
             self,
             options,
             params,
-            callback_manager=self.callback_manager,
             **kwargs, # TODO: We should remove and make argument explicit
         )
 
@@ -333,7 +332,6 @@ class AIConfigRuntime(AIConfig):
             self,
             parameters_list,
             options,
-            callback_manager=self.callback_manager,
             **kwargs,
         )
 


### PR DESCRIPTION
Delete unused callback_manager argument from run commands

This is an extension of https://github.com/lastmile-ai/aiconfig/pull/881

Now once this is removed, only the `run-with_dependencies` kwarg should be used and this will unblock Sudhanshu from completing https://github.com/lastmile-ai/aiconfig/issues/664

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/886).
* #887
* __->__ #886