### PR TITLE
[editor][server] fix save

### DIFF
--- a/python/src/aiconfig/editor/server/server_utils.py
+++ b/python/src/aiconfig/editor/server/server_utils.py
@@ -221,6 +221,7 @@ def init_server_state(app: Flask, edit_config: EditServerConfig) -> Result[None,
     else:
         LOGGER.info(f"Creating new AIConfig at {edit_config.aiconfig_path}")
         aiconfig_runtime = AIConfigRuntime.create()  # type: ignore
+        aiconfig_runtime.file_path = edit_config.aiconfig_path # type: ignore
         model_ids = ModelParserRegistry.parser_ids()
         if len(model_ids) > 0:
             aiconfig_runtime.add_prompt("prompt_1", Prompt(name="prompt_1", input="", metadata=PromptMetadata(model=model_ids[0])))


### PR DESCRIPTION
[editor][server] fix save



on creating a new config, server does not persist file path into server state, nor does it update the AIConfigRuntime with file_path

Quick fix: set aiconfig.file_path to the path in server, when creating the New AIconfig/AIConfigRuntime

## Testplan
1. aiconfig edit on a config that doesn't exist

https://github.com/lastmile-ai/aiconfig/assets/141073967/99008b27-0ff3-4891-b9eb-c1b826c6ecab
