### PR TITLE
[bug fix] [AIC-py] issue #889

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -156,6 +156,7 @@ def save() -> FlaskResponse:
         if aiconfig is None:
             return HttpResponseWithAIConfig(message="No AIConfig loaded", code=400, aiconfig=None).to_flask_format()
         else:
+            LOGGER.info(f"No path provided, saving to original path, {aiconfig.file_path}")
             path = aiconfig.file_path
 
     res_path_val = get_validated_path(path, allow_create=True)

--- a/python/src/aiconfig/editor/server/server_utils.py
+++ b/python/src/aiconfig/editor/server/server_utils.py
@@ -229,7 +229,8 @@ def init_server_state(app: Flask, edit_config: EditServerConfig) -> Result[None,
         LOGGER.info("Created new AIConfig")
         try:
             aiconfig_runtime.save(edit_config.aiconfig_path)
-            LOGGER.info(f"Saved new AIConfig to {edit_config.aiconfig_path}")
+            aiconfig_runtime.file_path = edit_config.aiconfig_path  # type: ignore[bug in runtime init]
+            LOGGER.info(f"Saved new AIConfig to {edit_config.aiconfig_path} (aiconfig path field: {aiconfig_runtime.file_path})")
             state.aiconfig = aiconfig_runtime
             return Ok(None)
         except Exception as e:


### PR DESCRIPTION
[bug fix] [AIC-py] issue #889

Root cause: here (https://github.com/lastmile-ai/aiconfig/blob/49ac58d0111a3f4df79d72786002a55ad8b585f1/python/src/aiconfig/editor/server/server.py#L159),
we set the path to save at from the aiconfig instance's path field
if no path is given in the HTTP request.

However, the field will be None if the file did not exist when the server is initialized.

Why is that? Because if we're in the file create branch here (https://github.com/lastmile-ai/aiconfig/blob/49ac58d0111a3f4df79d72786002a55ad8b585f1/python/src/aiconfig/editor/server/server_utils.py#L221-L234)

then the aiconfig gets initialized and saved, but the field name is None.
You can see the field gets set to None in the AIConfigRuntime init.

Hacky fix (this PR): set the runtime field name right after calling save.

Proposed better fix: set the field inside .save().


Test:

1. Repro on trunk: tail a fresh log file

rm editor_flask_server.log; tail -F editor_flask_server.log

kill any extra servers, make sure the default file path _does not exist_, and rerun:

sudo lsof -i :8080 | awk '{print $2}' | tail -n +2 | xargs kill -9; ps aux | grep node | grep -v grep | awk '{print $2}' | xargs kill -9; rm my_aiconfig.aiconfig.json; c; python python/src/aiconfig/scripts/aiconfig_cli.py  edit --server-mode='debug_servers'  --log-level=debug

Send a save request:

import requests

url = 'http://localhost:8080/api/save'

data = {

}
response = requests.post(url, json=data)
print(f"{response=}")

response=<Response [400]>


2. Repro with this fix, same steps

response=<Response [200]>


You can verify that the file was saved. This can be done from the UI as well.
