### PR TITLE
[editor] Only stream output, not entire AIConfig

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -2,7 +2,6 @@ import asyncio
 import copy
 import ctypes
 import json
-import copy
 import logging
 import threading
 import time
@@ -284,11 +283,6 @@ def run() -> FlaskResponse:
         t = threading.Thread(target=run_async_config_in_thread)
         t.start()
 
-        # Create a deep copy of the state aiconfig so we can yield an AIConfig
-        # with streaming partial outputs in the meantime. This probably isn't
-        # necessary, but just getting unblocked for now
-        displaying_config = copy.deepcopy(aiconfig)
-
         # If model supports streaming, need to wait until streamer has at
         # least 1 item to display. If model does not support streaming,
         # need to wait until the aiconfig.run() thread is complete
@@ -338,11 +332,8 @@ def run() -> FlaskResponse:
                         "metadata": {},
                     }  # type: ignore
                 )
-
-                displaying_config.add_output(prompt_name, accumulated_output, overwrite=True)
-                aiconfig_json = displaying_config.model_dump(exclude=EXCLUDE_OPTIONS)
                 yield "["
-                yield json.dumps({"aiconfig": aiconfig_json})
+                yield json.dumps({"output_chunk": accumulated_output.to_json()})
                 yield "]"
 
         # Ensure that the run process is complete to yield final output

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -1,3 +1,4 @@
+import json
 import warnings
 from typing import Any, Dict, List, Literal, Optional, Union
 
@@ -10,6 +11,11 @@ JSONObject = Dict[str, Any]
 # InferenceSettings represents settings for model inference as a JSON object
 InferenceSettings = JSONObject
 
+EXCLUDE_OPTIONS = {
+    "prompt_index": True,
+    "file_path": True,
+    "callback_manager": True,
+}
 
 class OutputDataWithStringValue(BaseModel):
     """
@@ -89,6 +95,14 @@ class ExecuteResult(BaseModel):
     mime_type: Optional[str] = None
     # Output metadata
     metadata: Dict[str, Any]
+    
+    def to_json(self) -> JSONObject:
+        """
+        Helper method used to ensure this is formatted to a valid JSON object
+        so that it can be used for streaming
+        """
+        # TODO: We have EXCLUDE_OPTIONS all throughout codebase, just centralize them in one place in this file
+        return self.model_dump(exclude=EXCLUDE_OPTIONS)
 
 
 class Error(BaseModel):


### PR DESCRIPTION
[editor] Only stream output, not entire AIConfig





This will be a bug for anything that streams multiple return outputs, but for now we don't have that and all our models which support streaming only output a single output

## Test Plan
Ok wow yea, even on Chrome this is *noticeably* faster!

https://github.com/lastmile-ai/aiconfig/assets/151060367/3613c2e5-8a8c-43c8-994d-d7ae62469594



