### PR TITLE
[docs] update to correct command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You must specify your [OpenAI API Key](https://platform.openai.com/account/api-k
 AIConfig Editor helps you visually create and edit the prompts and model parameters stored as AIConfigs.
 
 1. Open your Terminal
-2. Run this command: `aiconfig edit --aiconfig-path travel.aiconfig.json`
+2. Run this command: `aiconfig edit --aiconfig-path=travel.aiconfig.json`
 
 This will open AIConfig Editor in your default browser at http://localhost:8080/ and create a new AIConfig JSON file `travel.aiconfig.json` in your current directory.
 
@@ -148,7 +148,7 @@ config.save('updated_travel.aiconfig.json', include_outputs=True)
 You can quickly iterate and edit your aiconfig using AIConfig Editor.
 
 1. Open your Terminal
-2. Run this command: `aiconfig edit --aiconfig-path travel.aiconfig.json`
+2. Run this command: `aiconfig edit --aiconfig-path=travel.aiconfig.json`
 
 A new tab with AIConfig Editor opens in your default browser at http://localhost:8080/ with the prompts, chaining logic, and settings from `travel.aiconfig.json`. The editor auto-saves every 15 seconds and you can manually save with the Save button. Your updates will be reflected in the AIConfig file.
 
@@ -169,7 +169,7 @@ AIConfig helps unwind complexity by separating prompts, model parameters, and mo
 ## Features
 
 - **Prompts as Configs**: [standardized JSON format](https://aiconfig.lastmileai.dev/docs/overview/ai-config-format) to store prompts and model settings in source control.
-- **Editor for Prompts**: Prototype and quickly iterate on your prompts and model settings with AIConfig Editor.
+- **Editor for Prompts**: Prototype and quickly iterate on your prompts and model settings with [AIConfig Editor](https://aiconfig.lastmileai.dev/docs/editor).
 - **Model-agnostic and multimodal SDK**: Python & Node SDKs to use `aiconfig` in your application code. AIConfig is designed to be **model-agnostic** and **multi-modal**, so you can extend it to work with any generative AI model, including text, image and audio.
 - **Extensible**: Extend AIConfig to work with any model and your own endpoints.
 - **Collaborative Development**: AIConfig enables different people to work on prompts and app development, and collaborate together by sharing the `aiconfig` artifact.

--- a/aiconfig-docs/docs/editor.md
+++ b/aiconfig-docs/docs/editor.md
@@ -100,7 +100,7 @@ If you already have an AIConfig JSON file, you can use the AIConfig Editor to vi
 Open Terminal, run this command:
 
 ```bash
-aiconfig edit --aiconfig-path {file_path_existing_aiconfig}
+aiconfig edit --aiconfig-path={file_path_existing_aiconfig}
 ```
 
 A new tab with the AIConfig Editor opens in your default browser with the prompts, chaining logic, and settings from the specified AIConfig populated in the editor. If the file path doesn’t exist, a new AIConfig will be created at that path and the editor will be blank.

--- a/aiconfig-docs/docs/getting-started.md
+++ b/aiconfig-docs/docs/getting-started.md
@@ -85,7 +85,7 @@ For this tutorial, you will need to have an OpenAI API key that has access to GP
 AIConfig Editor allows you to visually create and edit the prompt chains and model parameters that are stored as AIConfigs. You can also chain prompts and use global and local variables in your prompts. Learn more about [AIConfig Editor](https://aiconfig.lastmileai.dev/docs/editor).
 
 1. Open your Terminal
-2. Run this command: `aiconfig edit --aiconfig-path travel.aiconfig.json`
+2. Run this command: `aiconfig edit --aiconfig-path=travel.aiconfig.json`
 
 This will open AIConfig Editor in your default browser at http://localhost:8080/ and create a new AIConfig JSON file `travel.aiconfig.json` in your current directory.
 
@@ -520,7 +520,7 @@ travelWithGPT();
 You can iterate and edit your aiconfig using the AIConfig Editor. Now that we have an aiconfig file artifact that encapsulates the generative AI parts of our application, the application code doesn't need to change even as the aiconfig is updated.
 
 1. Open your Terminal
-2. Run this command: `aiconfig edit --aiconfig-path updated_travel.aiconfig.json`
+2. Run this command: `aiconfig edit --aiconfig-path=updated_travel.aiconfig.json`
 
 A new tab with the AIConfig Editor opens in your default browser at http://localhost:8080/ with the prompts, chaining logic, and settings from `updated_travel.aiconfig.json`. Your edits will auto-save every 15 seconds. You can also manually save with the Save button.
 


### PR DESCRIPTION
[docs] update to correct command

missing equal signs in 'aiconfig edit --aiconfig-path={file_name}' in documentation
