### PR TITLE
[1/n] Disable Run Button: UI Display

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/prompt/RunPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/RunPromptButton.tsx
@@ -1,17 +1,19 @@
-import { Button, Flex, Loader } from "@mantine/core";
+import { Button, Flex, Loader, Tooltip } from "@mantine/core";
 import { IconPlayerPlayFilled, IconPlayerStop } from "@tabler/icons-react";
 import { memo } from "react";
 
 type Props = {
-  isRunning?: boolean;
   cancel: () => Promise<void>;
   runPrompt: () => Promise<void>;
+  isRunning?: boolean;
+  disabled?: boolean;
 };
 
 export default memo(function RunPromptButton({
   cancel,
   runPrompt,
   isRunning = false,
+  disabled = false,
 }: Props) {
   const onClick = async () => {
     if (isRunning) {
@@ -20,11 +22,10 @@ export default memo(function RunPromptButton({
       return await runPrompt();
     }
   };
-
-  return (
+  const button = (
     <Button
       onClick={onClick}
-      disabled={false}
+      disabled={disabled}
       p="xs"
       size="xs"
       className="runPromptButton"
@@ -40,5 +41,13 @@ export default memo(function RunPromptButton({
         </>
       )}
     </Button>
+  );
+
+  return !disabled ? (
+    button
+  ) : (
+    <Tooltip label="Can't run while another prompt is running" withArrow>
+      <div>{button}</div>
+    </Tooltip>
   );
 });


### PR DESCRIPTION
[1/n] Disable Run Button: UI Display




For now no functionality, just setting up the visual UI display, will connect next PR. Doing this to make PRs smaller and easier to review + land

## Test Plan
When setting `disabled` to True
<img width="1512" alt="Screenshot 2024-01-12 at 14 57 38" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/61999b01-e4d5-4fd6-bc34-9e2dd4f914b7">

When setting `disabled` to False, still works as before

https://github.com/lastmile-ai/aiconfig/assets/151060367/1c6ad683-8c50-46aa-9760-8eea8bd40fed

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/905).
* #907
* __->__ #905