### PR TITLE
[bug fix] bump lastmile utils to 0.0.20

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,7 @@ flask[async]
 google-generativeai
 huggingface_hub
 hypothesis==6.91.0
-lastmile-utils==0.0.14
+lastmile-utils==0.0.20
 mock
 nest_asyncio
 nltk


### PR DESCRIPTION
[bug fix] bump lastmile utils to 0.0.20

get_logger doesn't import. this bump adds that function and should fix main.

<img width="872" alt="image" src="https://github.com/lastmile-ai/aiconfig/assets/148090348/004d6184-f486-4dcb-adaa-ee8e134b8854">
