### PR TITLE
Center the Add Prompt button

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   Alert,
   Group,
+  rem,
 } from "@mantine/core";
 import { Notifications, showNotification } from "@mantine/notifications";
 import {
@@ -133,10 +134,11 @@ type RequestCallbackError = { message?: string };
 
 const useStyles = createStyles((theme) => ({
   addPromptRow: {
-    borderRadius: "4px",
-    display: "inline-block",
-    bottom: -24,
-    left: -40,
+    borderRadius: rem(4),
+    display: "flex",
+    justifyContent: "center",
+    align: "center",
+    width: "100%",
     "&:hover": {
       backgroundColor:
         theme.colorScheme === "light"

--- a/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
@@ -61,7 +61,7 @@ export default memo(function AddPromptButton({ addPrompt, getModels }: Props) {
 
   return (
     <Menu
-      position="bottom-start"
+      position="bottom"
       // Manually maintain open state to support ... expand button
       closeOnItemClick={false}
       opened={isOpen}
@@ -69,7 +69,7 @@ export default memo(function AddPromptButton({ addPrompt, getModels }: Props) {
     >
       <Menu.Target>
         <Tooltip label="Add prompt">
-          <ActionIcon>
+          <ActionIcon w="100%">
             <IconPlus size={20} />
           </ActionIcon>
         </Tooltip>


### PR DESCRIPTION
Center the Add Prompt button




This took so long, literally this was the "how do you center a div" meme. I also did a few others things, mainly:

1. Make the entire grey-out hover area clickable and opening the menu, not simply the space around the `+` icon
2. Made the very first top `+` menu item hover the entire width. Before it would only have greyed hover over area around the `+` icon

There were basically 2 main parts that took me a while:

1. Had to update `display` from `"inline-block"` to `"flex"`. After this you don't even need to set `width: "100%"`, but I just kept it there anyways to make it obvious.
2. Even after doing that, the menu itself wasn't spread to 100%, and would only be wrapped around the `+` icon. The `Menu` component in mantine does not take regular styles (https://github.com/mantinedev/mantine/blob/703bf447b1a751daee7f3c2fff9c418bd13f5779/packages/%40mantine/core/src/components/Menu/Menu.tsx#L23-L29C24), so it took me a while to realize I had to change the child component within `Menu.Target` to `width: "100%"`

I also changed the position to be bottom centered instead of bottom left, which looks nicer imo now that this is centered.

## Test Plan
All the functionality still works

**Before**

https://github.com/lastmile-ai/aiconfig/assets/151060367/b768d03c-da3c-4ce7-bead-14967220832c


**After**
I noticed that the GlobalParametersContainer doesn't match the same width padding/margins as the PromptContainer. This isn't usually noticeable full screen, but you can tell when you adjust the window width


https://github.com/lastmile-ai/aiconfig/assets/151060367/86104feb-5fb4-4ef3-abcf-785292f19eda
