### PR TITLE
Add explicit "stop_streaming" event to signal streaming is finished

### DIFF
--- a/python/src/aiconfig/editor/client/src/LocalEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/LocalEditor.tsx
@@ -101,6 +101,9 @@ export default function Editor() {
           aiconfig: (data) => {
             onStream({ type: "aiconfig", data: data as AIConfig });
           },
+          stop_streaming: (_data) => {
+            onStream({ type: "stop_streaming", data: null });
+          },
           error: (data) => {
             onError({
               type: "error",

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -71,6 +71,10 @@ export type RunPromptStreamEvent =
   | {
       type: "aiconfig";
       data: AIConfig;
+    }
+  | {
+      type: "stop_streaming";
+      data: null;
     };
 
 export type RunPromptStreamErrorEvent = {
@@ -633,12 +637,25 @@ export default function EditorContainer({
                 output: event.data,
               });
             } else if (event.type === "aiconfig") {
+              // Next PR: Change this to aiconfig_stream to make it more obvious
+              // and make STREAM_AICONFIG it's own event so we don't need to pass
+              // the `isRunning` state to set. See Ryan's comments about this in
               dispatch({
                 type: "CONSOLIDATE_AICONFIG",
                 action: {
                   ...action,
+                  // Keep the prompt running state until the end of streaming
+                  isRunning: true,
                 },
                 config: event.data,
+              });
+            } else if (event.type === "stop_streaming") {
+              // Pass this event at the end of streaming to signal
+              // that the prompt is done running and we're ready
+              // to reset the ClientAIConfig to a non-running state
+              dispatch({
+                type: "STOP_STREAMING",
+                id: promptId,
               });
             }
           },

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -16,6 +16,7 @@ export type MutateAIConfigAction =
   | SetDescriptionAction
   | SetNameAction
   | StreamOutputChunkAction
+  | StopStreamingAction
   | UpdatePromptInputAction
   | UpdatePromptNameAction
   | UpdatePromptModelAction
@@ -75,6 +76,11 @@ export type StreamOutputChunkAction = {
   type: "STREAM_OUTPUT_CHUNK";
   id: string;
   output: Output;
+};
+
+export type StopStreamingAction = {
+  type: "STOP_STREAMING";
+  id: string;
 };
 
 export type UpdatePromptInputAction = {
@@ -339,6 +345,27 @@ export default function aiconfigReducer(
         ...prompt,
         outputs: [action.output],
       }));
+    }
+    case "STOP_STREAMING": {
+      const finishedStreamingState = {
+        ...dirtyState,
+        _ui: {
+          ...dirtyState._ui,
+          runningPromptId: undefined,
+        },
+      };
+      return reduceReplacePrompt(
+        finishedStreamingState,
+        action.id,
+        (prompt) => ({
+          ...prompt,
+          _ui: {
+            ...prompt._ui,
+            cancellationToken: undefined,
+            isRunning: false,
+          },
+        })
+      );
     }
     case "UPDATE_PROMPT_INPUT": {
       return reduceReplaceInput(dirtyState, action.id, () => action.input);

--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -350,6 +350,10 @@ def run() -> FlaskResponse:
             yield "["
             yield json.dumps({"aiconfig": aiconfig_json})
             yield "]"
+        
+        yield "["
+        yield json.dumps({"stop_streaming": None})
+        yield "]"
 
     try:
         LOGGER.info(f"Running `aiconfig.run()` command with request: {request_json}")


### PR DESCRIPTION
Add explicit "stop_streaming" event to signal streaming is finished



I think this is cleaner and better for us to deal with. It also breaks down the aiconfig streaming logic to be more explicitly handled for next PR.

See comments about this in

- https://github.com/lastmile-ai/aiconfig/pull/907#discussion_r1451013546
- https://github.com/lastmile-ai/aiconfig/pull/911#discussion_r1451629515

## Test Plan
Both the streaming and non-streaming models work the same as before

https://github.com/lastmile-ai/aiconfig/assets/151060367/2c3fd802-e95e-417c-ac80-7b6e18983520
