### PR TITLE
Refactor ConsolidateAIConfig to only take in specificed sub-actions

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -24,9 +24,15 @@ export type MutateAIConfigAction =
   | UpdatePromptParametersAction
   | UpdateGlobalParametersAction;
 
+// Actions that appear when called via ConsolidateAIConfigAction
+export type ConsolidateAIConfigSubAction =
+  | AddPromptAction
+  | RunPromptAction
+  | UpdatePromptInputAction;
+
 export type ConsolidateAIConfigAction = {
   type: "CONSOLIDATE_AICONFIG";
-  action: MutateAIConfigAction;
+  action: ConsolidateAIConfigSubAction;
   config: AIConfig;
 };
 
@@ -159,7 +165,7 @@ function reduceInsertPromptAtIndex(
 
 function reduceConsolidateAIConfig(
   state: ClientAIConfig,
-  action: MutateAIConfigAction,
+  action: ConsolidateAIConfigSubAction,
   responseConfig: AIConfig
 ): ClientAIConfig {
   // Make sure prompt structure is properly updated. Client input and metadata takes precedence


### PR DESCRIPTION
Refactor ConsolidateAIConfig to only take in specificed sub-actions

I was having some trouble converting everything to `STREAM_AICONFIG_CHUNK` so I'm just doing really easy steps to keep diffs easy to review and test. You'll see final code changes at end of diff stack.

## This diff
No functional changes, but I want to use the `CONSOLIDATE_AICONFIG` event to pass in nested action `STREAM_AICONFIG_CHUNK` action later in stack, without requiring me to pass it in directly to the `aiconfigReducer`. By separating these, they can be distinct types and easier to manage

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/917).
* #928
* #926
* #925
* #924
* #922
* #921
* #920
* #919
* #918
* __->__ #917