### PR TITLE
[ez] Rename `aiconfig` stream response to `aiconfig_chunk` response

### DIFF
--- a/python/src/aiconfig/editor/client/src/LocalEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/LocalEditor.tsx
@@ -98,8 +98,8 @@ export default function Editor() {
           output_chunk: (data) => {
             onStream({ type: "output_chunk", data: data as Output });
           },
-          aiconfig: (data) => {
-            onStream({ type: "aiconfig", data: data as AIConfig });
+          aiconfig_chunk: (data) => {
+            onStream({ type: "aiconfig_chunk", data: data as AIConfig });
           },
           stop_streaming: (_data) => {
             onStream({ type: "stop_streaming", data: null });

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -69,7 +69,7 @@ export type RunPromptStreamEvent =
       data: Output;
     }
   | {
-      type: "aiconfig";
+      type: "aiconfig_chunk";
       data: AIConfig;
     }
   | {
@@ -636,7 +636,7 @@ export default function EditorContainer({
                 id: promptId,
                 output: event.data,
               });
-            } else if (event.type === "aiconfig") {
+            } else if (event.type === "aiconfig_chunk") {
               // Next PR: Change this to aiconfig_stream to make it more obvious
               // and make STREAM_AICONFIG it's own event so we don't need to pass
               // the `isRunning` state to set. See Ryan's comments about this in

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -24,9 +24,15 @@ export type MutateAIConfigAction =
   | UpdatePromptParametersAction
   | UpdateGlobalParametersAction;
 
+// Actions that appear when called via ConsolidateAIConfigAction
+export type ConsolidateAIConfigSubAction =
+  | AddPromptAction
+  | RunPromptAction
+  | UpdatePromptInputAction;
+
 export type ConsolidateAIConfigAction = {
   type: "CONSOLIDATE_AICONFIG";
-  action: MutateAIConfigAction;
+  action: ConsolidateAIConfigSubAction;
   config: AIConfig;
 };
 
@@ -159,7 +165,7 @@ function reduceInsertPromptAtIndex(
 
 function reduceConsolidateAIConfig(
   state: ClientAIConfig,
-  action: MutateAIConfigAction,
+  action: ConsolidateAIConfigSubAction,
   responseConfig: AIConfig
 ): ClientAIConfig {
   // Make sure prompt structure is properly updated. Client input and metadata takes precedence

--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -348,7 +348,7 @@ def run() -> FlaskResponse:
 
             aiconfig_json = aiconfig.model_dump(exclude=EXCLUDE_OPTIONS) if aiconfig is not None else None
             yield "["
-            yield json.dumps({"aiconfig": aiconfig_json})
+            yield json.dumps({"aiconfig_chunk": aiconfig_json})
             yield "]"
         
         yield "["


### PR DESCRIPTION
[ez] Rename `aiconfig` stream response to `aiconfig_chunk` response


I was having some trouble converting everything to `STREAM_AICONFIG_CHUNK` so I'm just doing really easy steps to keep diffs easy to review and test. You'll be able to see final result at end of diff stack

## This diff
Just doing very simple name coy and replace, no functional changes

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/918).
* #928
* #926
* #925
* #924
* #922
* #921
* #920
* #919
* __->__ #918
* #917