### PR TITLE
Replace RUN_PROMPT with STREAM_AICONFIG_CHUNK inside of streaming implementation

### DIFF
--- a/python/src/aiconfig/editor/client/src/LocalEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/LocalEditor.tsx
@@ -98,8 +98,8 @@ export default function Editor() {
           output_chunk: (data) => {
             onStream({ type: "output_chunk", data: data as Output });
           },
-          aiconfig: (data) => {
-            onStream({ type: "aiconfig", data: data as AIConfig });
+          aiconfig_chunk: (data) => {
+            onStream({ type: "aiconfig_chunk", data: data as AIConfig });
           },
           stop_streaming: (_data) => {
             onStream({ type: "stop_streaming", data: null });

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -637,13 +637,12 @@ export default function EditorContainer({
                 output: event.data,
               });
             } else if (event.type === "aiconfig_chunk") {
-              // Next PR: Change this to aiconfig_stream to make it more obvious
-              // and make STREAM_AICONFIG it's own event so we don't need to pass
-              // the `isRunning` state to set. See Ryan's comments about this in
               dispatch({
                 type: "CONSOLIDATE_AICONFIG",
                 action: {
-                  ...action,
+                  type: "STREAM_AICONFIG_CHUNK",
+                  id: promptId,
+                  cancellationToken,
                   // Keep the prompt running state until the end of streaming
                   isRunning: true,
                 },

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -69,7 +69,7 @@ export type RunPromptStreamEvent =
       data: Output;
     }
   | {
-      type: "aiconfig";
+      type: "aiconfig_chunk";
       data: AIConfig;
     }
   | {
@@ -636,7 +636,7 @@ export default function EditorContainer({
                 id: promptId,
                 output: event.data,
               });
-            } else if (event.type === "aiconfig") {
+            } else if (event.type === "aiconfig_chunk") {
               // Next PR: Change this to aiconfig_stream to make it more obvious
               // and make STREAM_AICONFIG it's own event so we don't need to pass
               // the `isRunning` state to set. See Ryan's comments about this in

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -24,9 +24,15 @@ export type MutateAIConfigAction =
   | UpdatePromptParametersAction
   | UpdateGlobalParametersAction;
 
+// Actions that appear when called via ConsolidateAIConfigAction
+export type ConsolidateAIConfigSubAction =
+  | AddPromptAction
+  | RunPromptAction
+  | UpdatePromptInputAction;
+
 export type ConsolidateAIConfigAction = {
   type: "CONSOLIDATE_AICONFIG";
-  action: MutateAIConfigAction;
+  action: ConsolidateAIConfigSubAction;
   config: AIConfig;
 };
 
@@ -159,7 +165,7 @@ function reduceInsertPromptAtIndex(
 
 function reduceConsolidateAIConfig(
   state: ClientAIConfig,
-  action: MutateAIConfigAction,
+  action: ConsolidateAIConfigSubAction,
   responseConfig: AIConfig
 ): ClientAIConfig {
   // Make sure prompt structure is properly updated. Client input and metadata takes precedence

--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -348,7 +348,7 @@ def run() -> FlaskResponse:
 
             aiconfig_json = aiconfig.model_dump(exclude=EXCLUDE_OPTIONS) if aiconfig is not None else None
             yield "["
-            yield json.dumps({"aiconfig": aiconfig_json})
+            yield json.dumps({"aiconfig_chunk": aiconfig_json})
             yield "]"
         
         yield "["


### PR DESCRIPTION
Replace RUN_PROMPT with STREAM_AICONFIG_CHUNK inside of streaming implementation


This is the exact same logic, but I'm just going to do this as intermediate step to keep things clear and easy to review

## Test Plan
No functional changes, streaming and non streaming models still work

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/919).
* #928
* #926
* #925
* #924
* #922
* #921
* #920
* __->__ #919
* #918
* #917