### PR TITLE
Implement STREAM_AICONFIG_CHUNK action

### DIFF
--- a/python/src/aiconfig/editor/client/src/LocalEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/LocalEditor.tsx
@@ -98,8 +98,8 @@ export default function Editor() {
           output_chunk: (data) => {
             onStream({ type: "output_chunk", data: data as Output });
           },
-          aiconfig: (data) => {
-            onStream({ type: "aiconfig", data: data as AIConfig });
+          aiconfig_chunk: (data) => {
+            onStream({ type: "aiconfig_chunk", data: data as AIConfig });
           },
           stop_streaming: (_data) => {
             onStream({ type: "stop_streaming", data: null });

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -637,13 +637,12 @@ export default function EditorContainer({
                 output: event.data,
               });
             } else if (event.type === "aiconfig_chunk") {
-              // Next PR: Change this to aiconfig_stream to make it more obvious
-              // and make STREAM_AICONFIG it's own event so we don't need to pass
-              // the `isRunning` state to set. See Ryan's comments about this in
               dispatch({
                 type: "CONSOLIDATE_AICONFIG",
                 action: {
-                  ...action,
+                  type: "STREAM_AICONFIG_CHUNK",
+                  id: promptId,
+                  cancellationToken,
                   // Keep the prompt running state until the end of streaming
                   isRunning: true,
                 },

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -69,7 +69,7 @@ export type RunPromptStreamEvent =
       data: Output;
     }
   | {
-      type: "aiconfig";
+      type: "aiconfig_chunk";
       data: AIConfig;
     }
   | {
@@ -636,7 +636,7 @@ export default function EditorContainer({
                 id: promptId,
                 output: event.data,
               });
-            } else if (event.type === "aiconfig") {
+            } else if (event.type === "aiconfig_chunk") {
               // Next PR: Change this to aiconfig_stream to make it more obvious
               // and make STREAM_AICONFIG it's own event so we don't need to pass
               // the `isRunning` state to set. See Ryan's comments about this in

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -638,15 +638,9 @@ export default function EditorContainer({
               });
             } else if (event.type === "aiconfig_chunk") {
               dispatch({
-                type: "CONSOLIDATE_AICONFIG",
-                action: {
-                  type: "STREAM_AICONFIG_CHUNK",
-                  id: promptId,
-                  cancellationToken,
-                  // Keep the prompt running state until the end of streaming
-                  isRunning: true,
-                },
+                type: "STREAM_AICONFIG_CHUNK",
                 config: event.data,
+                cancellationToken,
               });
             } else if (event.type === "stop_streaming") {
               // Pass this event at the end of streaming to signal

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -24,9 +24,15 @@ export type MutateAIConfigAction =
   | UpdatePromptParametersAction
   | UpdateGlobalParametersAction;
 
+// Actions that appear when called via ConsolidateAIConfigAction
+export type ConsolidateAIConfigSubAction =
+  | AddPromptAction
+  | RunPromptAction
+  | UpdatePromptInputAction;
+
 export type ConsolidateAIConfigAction = {
   type: "CONSOLIDATE_AICONFIG";
-  action: MutateAIConfigAction;
+  action: ConsolidateAIConfigSubAction;
   config: AIConfig;
 };
 
@@ -159,7 +165,7 @@ function reduceInsertPromptAtIndex(
 
 function reduceConsolidateAIConfig(
   state: ClientAIConfig,
-  action: MutateAIConfigAction,
+  action: ConsolidateAIConfigSubAction,
   responseConfig: AIConfig
 ): ClientAIConfig {
   // Make sure prompt structure is properly updated. Client input and metadata takes precedence

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -29,7 +29,6 @@ export type MutateAIConfigAction =
 export type ConsolidateAIConfigSubAction =
   | AddPromptAction
   | RunPromptAction
-  | StreamAIConfigChunkAction
   | UpdatePromptInputAction;
 
 export type ConsolidateAIConfigAction = {
@@ -82,9 +81,8 @@ export type SetNameAction = {
 
 export type StreamAIConfigChunkAction = {
   type: "STREAM_AICONFIG_CHUNK";
-  id: string;
+  config: AIConfig;
   cancellationToken?: string;
-  isRunning?: boolean;
 };
 
 export type StreamOutputChunkAction = {
@@ -201,20 +199,16 @@ function reduceConsolidateAIConfig(
         consolidatePrompt
       );
     }
+    // Next PR: Split "RUN_PROMPT" into two actions:
+    // 1) "RUN_PROMPT_START"
+    // 2) "RUN_PROMPT_SUCCESS"
+    // 3) (Already exists) "RUN_PROMPT_ERROR"
     case "RUN_PROMPT": {
-      // Note: If we are calling "RUN_PROMPT" directly as a dispatched event
-      // type, we automatically set the state there to `isRunning` for that
-      // prompt. That logic does not happen here, it happens in
-      // `aiconfigReducer`.
-      // If we are calling "RUN_PROMPT" indirectly via the action of a
-      // "CONSOLIDATE_AICONFIG" dispatch, we end up here. We need to check
-      // if we actually want to set the prompt state to `isRunning`
-      const isRunning = action.isRunning ?? false;
       const stateWithUpdatedRunningPromptId = {
         ...state,
         _ui: {
           ...state._ui,
-          runningPromptId: isRunning ? action.id : undefined,
+          runningPromptId: undefined,
         },
       };
       return reduceReplacePrompt(
@@ -231,44 +225,7 @@ function reduceConsolidateAIConfig(
             ...prompt,
             _ui: {
               ...prompt._ui,
-              isRunning,
-            },
-            outputs,
-          };
-        }
-      );
-    }
-    case "STREAM_AICONFIG_CHUNK": {
-      // Note: If we are calling "RUN_PROMPT" directly as a dispatched event
-      // type, we automatically set the state there to `isRunning` for that
-      // prompt. That logic does not happen here, it happens in
-      // `aiconfigReducer`.
-      // If we are calling "RUN_PROMPT" indirectly via the action of a
-      // "CONSOLIDATE_AICONFIG" dispatch, we end up here. We need to check
-      // if we actually want to set the prompt state to `isRunning`
-      const isRunning = action.isRunning ?? false;
-      const stateWithUpdatedRunningPromptId = {
-        ...state,
-        _ui: {
-          ...state._ui,
-          runningPromptId: isRunning ? action.id : undefined,
-        },
-      };
-      return reduceReplacePrompt(
-        stateWithUpdatedRunningPromptId,
-        action.id,
-        (prompt) => {
-          const responsePrompt = responseConfig.prompts.find(
-            (resPrompt) => resPrompt.name === prompt.name
-          );
-
-          const outputs = responsePrompt?.outputs ?? prompt.outputs;
-
-          return {
-            ...prompt,
-            _ui: {
-              ...prompt._ui,
-              isRunning,
+              isRunning: false,
             },
             outputs,
           };
@@ -393,21 +350,22 @@ export default function aiconfigReducer(
       };
     }
     case "STREAM_AICONFIG_CHUNK": {
-      const runningState = {
-        ...dirtyState,
-        _ui: {
-          ...dirtyState._ui,
-          runningPromptId: action.id,
-        },
+      const replaceOutput = (statePrompt: ClientPrompt) => {
+        const responsePrompt = action.config.prompts.find(
+          (resPrompt) => resPrompt.name === statePrompt.name
+        );
+        return {
+          // Note: Don't need to set `isRunning` or `cancellationToken`
+          // because we already call RUN_PROMPT earlier in `onRunPrompt`
+          ...statePrompt,
+          outputs: responsePrompt?.outputs,
+        } as ClientPrompt;
       };
-      return reduceReplacePrompt(runningState, action.id, (prompt) => ({
-        ...prompt,
-        _ui: {
-          ...prompt._ui,
-          cancellationToken: action.cancellationToken,
-          isRunning: true,
-        },
-      }));
+      return reduceReplacePrompt(
+        dirtyState,
+        dirtyState._ui.runningPromptId as string,
+        replaceOutput
+      );
     }
     case "STREAM_OUTPUT_CHUNK": {
       return reduceReplacePrompt(dirtyState, action.id, (prompt) => ({

--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -348,7 +348,7 @@ def run() -> FlaskResponse:
 
             aiconfig_json = aiconfig.model_dump(exclude=EXCLUDE_OPTIONS) if aiconfig is not None else None
             yield "["
-            yield json.dumps({"aiconfig": aiconfig_json})
+            yield json.dumps({"aiconfig_chunk": aiconfig_json})
             yield "]"
         
         yield "["


### PR DESCRIPTION
Implement STREAM_AICONFIG_CHUNK action



This is the biggest part of this diff stack. The functionality is still exactly the same as before, but now we can call it directly instead of as a sub-action within `"CONSOLIDATE_AICONFIG"`. I think this is much cleaner.

Another benefit is this removes the need for having to check the `isRunning` flags within the consolidated `"RUN_PROMPT"` sub-action, since we now know that the only time we can call that is through the beginning and the end (non-streaming end). Next PR I am going to split this into two separate Actions:
1. `"RUN_PROMPT_START"`
2. `"RUN_PROMPT_SUCCESS"`


## Test Plan
Streaming and non-streaming models still work. Can cancel, it'll end, etc

https://github.com/lastmile-ai/aiconfig/assets/151060367/cf29ee99-9ede-4c5e-99a7-a7f7816adfe1

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/920).
* #928
* #926
* #925
* #924
* #922
* #921
* __->__ #920
* #919
* #918
* #917