### PR TITLE
Split Action Types and AIConfigReducer into it's own folder

### DIFF
--- a/python/src/aiconfig/editor/client/src/LocalEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/LocalEditor.tsx
@@ -98,8 +98,8 @@ export default function Editor() {
           output_chunk: (data) => {
             onStream({ type: "output_chunk", data: data as Output });
           },
-          aiconfig: (data) => {
-            onStream({ type: "aiconfig", data: data as AIConfig });
+          aiconfig_chunk: (data) => {
+            onStream({ type: "aiconfig_chunk", data: data as AIConfig });
           },
           stop_streaming: (_data) => {
             onStream({ type: "stop_streaming", data: null });

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -670,8 +670,8 @@ export default function EditorContainer({
 
                 showNotification({
                   title: `Execution interrupted for prompt${
-                    promptName ? ` ${promptName}` : ""
-                  }. Resetting to previous state.`,
+                    promptName ? ` '${promptName}'` : ""
+                  }. Resetting output to previous state.`,
                   message: event.data.message,
                   color: "yellow",
                 });

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -637,13 +637,12 @@ export default function EditorContainer({
                 output: event.data,
               });
             } else if (event.type === "aiconfig_chunk") {
-              // Next PR: Change this to aiconfig_stream to make it more obvious
-              // and make STREAM_AICONFIG it's own event so we don't need to pass
-              // the `isRunning` state to set. See Ryan's comments about this in
               dispatch({
                 type: "CONSOLIDATE_AICONFIG",
                 action: {
-                  ...action,
+                  type: "STREAM_AICONFIG_CHUNK",
+                  id: promptId,
+                  cancellationToken,
                   // Keep the prompt running state until the end of streaming
                   isRunning: true,
                 },

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -690,9 +690,9 @@ export default function EditorContainer({
         // aiconfig as a streaming format
         if (serverConfigResponse?.aiconfig) {
           dispatch({
-            type: "CONSOLIDATE_AICONFIG",
-            action,
-            config: serverConfigResponse?.aiconfig,
+            type: "RUN_PROMPT_SUCCESS",
+            id: promptId,
+            config: serverConfigResponse.aiconfig,
           });
         }
       } catch (err: unknown) {

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -69,7 +69,7 @@ export type RunPromptStreamEvent =
       data: Output;
     }
   | {
-      type: "aiconfig";
+      type: "aiconfig_chunk";
       data: AIConfig;
     }
   | {
@@ -636,7 +636,7 @@ export default function EditorContainer({
                 id: promptId,
                 output: event.data,
               });
-            } else if (event.type === "aiconfig") {
+            } else if (event.type === "aiconfig_chunk") {
               // Next PR: Change this to aiconfig_stream to make it more obvious
               // and make STREAM_AICONFIG it's own event so we don't need to pass
               // the `isRunning` state to set. See Ryan's comments about this in

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -638,15 +638,9 @@ export default function EditorContainer({
               });
             } else if (event.type === "aiconfig_chunk") {
               dispatch({
-                type: "CONSOLIDATE_AICONFIG",
-                action: {
-                  type: "STREAM_AICONFIG_CHUNK",
-                  id: promptId,
-                  cancellationToken,
-                  // Keep the prompt running state until the end of streaming
-                  isRunning: true,
-                },
+                type: "STREAM_AICONFIG_CHUNK",
                 config: event.data,
+                cancellationToken,
               });
             } else if (event.type === "stop_streaming") {
               // Pass this event at the end of streaming to signal

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -591,13 +591,13 @@ export default function EditorContainer({
   const onRunPrompt = useCallback(
     async (promptId: string) => {
       const cancellationToken = uuidv4();
-      const action: AIConfigReducerAction = {
-        type: "RUN_PROMPT",
+
+      dispatch({
+        // This sets the isRunning and runningPromptId flags
+        type: "RUN_PROMPT_START",
         id: promptId,
         cancellationToken,
-      };
-
-      dispatch(action);
+      });
 
       const onPromptError = (message: string | null) => {
         dispatch({

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -28,7 +28,8 @@ import {
   useState,
 } from "react";
 import { v4 as uuidv4 } from "uuid";
-import aiconfigReducer, { AIConfigReducerAction } from "./aiconfigReducer";
+import aiconfigReducer from "../reducers/aiconfigReducer";
+import type { AIConfigReducerAction } from "../reducers/actions";
 import {
   ClientPrompt,
   aiConfigToClientConfig,

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -661,8 +661,10 @@ export default function EditorContainer({
                 // This is a cancellation
                 // Reset the aiconfig to the state before we started running the prompt
                 dispatch({
-                  type: "CONSOLIDATE_AICONFIG",
-                  action,
+                  type: "RUN_PROMPT_CANCEL",
+                  id: promptId,
+                  cancellationToken,
+                  // Returned config output is reset to before running RUN_PROMPT
                   config: event.data.data,
                 });
 

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -24,9 +24,15 @@ export type MutateAIConfigAction =
   | UpdatePromptParametersAction
   | UpdateGlobalParametersAction;
 
+// Actions that appear when called via ConsolidateAIConfigAction
+export type ConsolidateAIConfigSubAction =
+  | AddPromptAction
+  | RunPromptAction
+  | UpdatePromptInputAction;
+
 export type ConsolidateAIConfigAction = {
   type: "CONSOLIDATE_AICONFIG";
-  action: MutateAIConfigAction;
+  action: ConsolidateAIConfigSubAction;
   config: AIConfig;
 };
 
@@ -159,7 +165,7 @@ function reduceInsertPromptAtIndex(
 
 function reduceConsolidateAIConfig(
   state: ClientAIConfig,
-  action: MutateAIConfigAction,
+  action: ConsolidateAIConfigSubAction,
   responseConfig: AIConfig
 ): ClientAIConfig {
   // Make sure prompt structure is properly updated. Client input and metadata takes precedence

--- a/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/components/aiconfigReducer.ts
@@ -29,7 +29,6 @@ export type MutateAIConfigAction =
 export type ConsolidateAIConfigSubAction =
   | AddPromptAction
   | RunPromptAction
-  | StreamAIConfigChunkAction
   | UpdatePromptInputAction;
 
 export type ConsolidateAIConfigAction = {
@@ -82,9 +81,8 @@ export type SetNameAction = {
 
 export type StreamAIConfigChunkAction = {
   type: "STREAM_AICONFIG_CHUNK";
-  id: string;
+  config: AIConfig;
   cancellationToken?: string;
-  isRunning?: boolean;
 };
 
 export type StreamOutputChunkAction = {
@@ -201,20 +199,16 @@ function reduceConsolidateAIConfig(
         consolidatePrompt
       );
     }
+    // Next PR: Split "RUN_PROMPT" into two actions:
+    // 1) "RUN_PROMPT_START"
+    // 2) "RUN_PROMPT_SUCCESS"
+    // 3) (Already exists) "RUN_PROMPT_ERROR"
     case "RUN_PROMPT": {
-      // Note: If we are calling "RUN_PROMPT" directly as a dispatched event
-      // type, we automatically set the state there to `isRunning` for that
-      // prompt. That logic does not happen here, it happens in
-      // `aiconfigReducer`.
-      // If we are calling "RUN_PROMPT" indirectly via the action of a
-      // "CONSOLIDATE_AICONFIG" dispatch, we end up here. We need to check
-      // if we actually want to set the prompt state to `isRunning`
-      const isRunning = action.isRunning ?? false;
       const stateWithUpdatedRunningPromptId = {
         ...state,
         _ui: {
           ...state._ui,
-          runningPromptId: isRunning ? action.id : undefined,
+          runningPromptId: undefined,
         },
       };
       return reduceReplacePrompt(
@@ -231,44 +225,7 @@ function reduceConsolidateAIConfig(
             ...prompt,
             _ui: {
               ...prompt._ui,
-              isRunning,
-            },
-            outputs,
-          };
-        }
-      );
-    }
-    case "STREAM_AICONFIG_CHUNK": {
-      // Note: If we are calling "RUN_PROMPT" directly as a dispatched event
-      // type, we automatically set the state there to `isRunning` for that
-      // prompt. That logic does not happen here, it happens in
-      // `aiconfigReducer`.
-      // If we are calling "RUN_PROMPT" indirectly via the action of a
-      // "CONSOLIDATE_AICONFIG" dispatch, we end up here. We need to check
-      // if we actually want to set the prompt state to `isRunning`
-      const isRunning = action.isRunning ?? false;
-      const stateWithUpdatedRunningPromptId = {
-        ...state,
-        _ui: {
-          ...state._ui,
-          runningPromptId: isRunning ? action.id : undefined,
-        },
-      };
-      return reduceReplacePrompt(
-        stateWithUpdatedRunningPromptId,
-        action.id,
-        (prompt) => {
-          const responsePrompt = responseConfig.prompts.find(
-            (resPrompt) => resPrompt.name === prompt.name
-          );
-
-          const outputs = responsePrompt?.outputs ?? prompt.outputs;
-
-          return {
-            ...prompt,
-            _ui: {
-              ...prompt._ui,
-              isRunning,
+              isRunning: false,
             },
             outputs,
           };
@@ -393,21 +350,22 @@ export default function aiconfigReducer(
       };
     }
     case "STREAM_AICONFIG_CHUNK": {
-      const runningState = {
-        ...dirtyState,
-        _ui: {
-          ...dirtyState._ui,
-          runningPromptId: action.id,
-        },
+      const replaceOutput = (statePrompt: ClientPrompt) => {
+        const responsePrompt = action.config.prompts.find(
+          (resPrompt) => resPrompt.name === statePrompt.name
+        );
+        return {
+          // Note: Don't need to set `isRunning` or `cancellationToken`
+          // because we already call RUN_PROMPT earlier in `onRunPrompt`
+          ...statePrompt,
+          outputs: responsePrompt?.outputs,
+        } as ClientPrompt;
       };
-      return reduceReplacePrompt(runningState, action.id, (prompt) => ({
-        ...prompt,
-        _ui: {
-          ...prompt._ui,
-          cancellationToken: action.cancellationToken,
-          isRunning: true,
-        },
-      }));
+      return reduceReplacePrompt(
+        dirtyState,
+        dirtyState._ui.runningPromptId as string,
+        replaceOutput
+      );
     }
     case "STREAM_OUTPUT_CHUNK": {
       return reduceReplacePrompt(dirtyState, action.id, (prompt) => ({

--- a/python/src/aiconfig/editor/client/src/reducers/actions.ts
+++ b/python/src/aiconfig/editor/client/src/reducers/actions.ts
@@ -1,0 +1,154 @@
+import { AIConfig, JSONObject, Output, PromptInput } from "aiconfig";
+import { ClientPrompt } from "../shared/types";
+
+export type AIConfigReducerAction =
+  | MutateAIConfigAction
+  | RunPromptAction
+  | ConsolidateAIConfigAction
+  | SaveConfigSuccessAction;
+
+// Actions the user can do to manually update the AIConfig
+export type MutateAIConfigAction =
+  | AddPromptAction
+  | ClearOutputsAction
+  | DeletePromptAction
+  | SetDescriptionAction
+  | SetNameAction
+  | UpdatePromptInputAction
+  | UpdatePromptNameAction
+  | UpdatePromptModelAction
+  | UpdatePromptModelSettingsAction
+  | UpdatePromptParametersAction
+  | UpdateGlobalParametersAction;
+
+// Action that can occur when user runs a prompt
+export type RunPromptAction =
+  | RunPromptStartAction
+  | RunPromptCancelAction
+  | RunPromptErrorAction
+  | RunPromptSuccessAction
+  | StreamAIConfigChunkAction
+  | StreamOutputChunkAction
+  | StopStreamingAction;
+
+// Actions that appear when called via ConsolidateAIConfigAction
+export type ConsolidateAIConfigSubAction =
+  | AddPromptAction
+  | UpdatePromptInputAction;
+
+export type ConsolidateAIConfigAction = {
+  type: "CONSOLIDATE_AICONFIG";
+  action: ConsolidateAIConfigSubAction;
+  config: AIConfig;
+};
+
+// Mutate AIConfig Actions
+export type AddPromptAction = {
+  type: "ADD_PROMPT_AT_INDEX";
+  index: number;
+  prompt: ClientPrompt;
+};
+
+export type ClearOutputsAction = {
+  type: "CLEAR_OUTPUTS";
+};
+
+export type DeletePromptAction = {
+  type: "DELETE_PROMPT";
+  id: string;
+};
+
+export type SetDescriptionAction = {
+  type: "SET_DESCRIPTION";
+  description: string;
+};
+
+export type SetNameAction = {
+  type: "SET_NAME";
+  name: string;
+};
+
+export type UpdatePromptInputAction = {
+  type: "UPDATE_PROMPT_INPUT";
+  id: string;
+  input: PromptInput;
+};
+
+export type UpdatePromptNameAction = {
+  type: "UPDATE_PROMPT_NAME";
+  id: string;
+  name: string;
+};
+
+export type UpdatePromptModelAction = {
+  type: "UPDATE_PROMPT_MODEL";
+  id: string;
+  modelName?: string;
+};
+
+export type UpdatePromptModelSettingsAction = {
+  type: "UPDATE_PROMPT_MODEL_SETTINGS";
+  id: string;
+  modelSettings: JSONObject;
+};
+
+export type UpdatePromptParametersAction = {
+  type: "UPDATE_PROMPT_PARAMETERS";
+  id: string;
+  parameters: JSONObject;
+};
+
+export type UpdateGlobalParametersAction = {
+  type: "UPDATE_GLOBAL_PARAMETERS";
+  parameters: JSONObject;
+};
+
+// Run Prompt Actions
+export type RunPromptStartAction = {
+  type: "RUN_PROMPT_START";
+  id: string;
+  cancellationToken?: string;
+  isRunning?: boolean;
+};
+
+export type RunPromptCancelAction = {
+  type: "RUN_PROMPT_CANCEL";
+  id: string;
+  config: AIConfig;
+  cancellationToken?: string;
+};
+
+export type RunPromptErrorAction = {
+  type: "RUN_PROMPT_ERROR";
+  id: string;
+  message?: string;
+};
+
+export type RunPromptSuccessAction = {
+  type: "RUN_PROMPT_SUCCESS";
+  id: string;
+  config: AIConfig;
+};
+
+export type StreamAIConfigChunkAction = {
+  type: "STREAM_AICONFIG_CHUNK";
+  config: AIConfig;
+  cancellationToken?: string;
+};
+
+export type StreamOutputChunkAction = {
+  type: "STREAM_OUTPUT_CHUNK";
+  id: string;
+  output: Output;
+};
+
+export type StopStreamingAction = {
+  type: "STOP_STREAMING";
+  id: string;
+};
+
+// Save Action --> In future, probably group this with other non-mutate
+// actions like setting logging preferences, share button action etc
+export type SaveConfigSuccessAction = {
+  type: "SAVE_CONFIG_SUCCESS";
+};

--- a/python/src/aiconfig/editor/client/src/reducers/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/reducers/aiconfigReducer.ts
@@ -1,149 +1,10 @@
+import { AIConfig } from "aiconfig";
 import { ClientAIConfig, ClientPrompt } from "../shared/types";
 import { getPromptModelName } from "../utils/promptUtils";
-import { AIConfig, JSONObject, Output, PromptInput } from "aiconfig";
-
-export type AIConfigReducerAction =
-  | MutateAIConfigAction
-  | ConsolidateAIConfigAction
-  | RunPromptErrorAction
-  | SaveConfigSuccessAction;
-
-export type MutateAIConfigAction =
-  | AddPromptAction
-  | ClearOutputsAction
-  | DeletePromptAction
-  | RunPromptStartAction
-  | RunPromptCancelAction
-  | RunPromptSuccessAction
-  | SetDescriptionAction
-  | SetNameAction
-  | StreamAIConfigChunkAction
-  | StreamOutputChunkAction
-  | StopStreamingAction
-  | UpdatePromptInputAction
-  | UpdatePromptNameAction
-  | UpdatePromptModelAction
-  | UpdatePromptModelSettingsAction
-  | UpdatePromptParametersAction
-  | UpdateGlobalParametersAction;
-
-// Actions that appear when called via ConsolidateAIConfigAction
-export type ConsolidateAIConfigSubAction =
-  | AddPromptAction
-  | UpdatePromptInputAction;
-
-export type ConsolidateAIConfigAction = {
-  type: "CONSOLIDATE_AICONFIG";
-  action: ConsolidateAIConfigSubAction;
-  config: AIConfig;
-};
-
-export type AddPromptAction = {
-  type: "ADD_PROMPT_AT_INDEX";
-  index: number;
-  prompt: ClientPrompt;
-};
-
-export type ClearOutputsAction = {
-  type: "CLEAR_OUTPUTS";
-};
-
-export type DeletePromptAction = {
-  type: "DELETE_PROMPT";
-  id: string;
-};
-
-export type RunPromptStartAction = {
-  type: "RUN_PROMPT_START";
-  id: string;
-  cancellationToken?: string;
-  isRunning?: boolean;
-};
-
-export type RunPromptCancelAction = {
-  type: "RUN_PROMPT_CANCEL";
-  id: string;
-  config: AIConfig;
-  cancellationToken?: string;
-};
-
-export type RunPromptErrorAction = {
-  type: "RUN_PROMPT_ERROR";
-  id: string;
-  message?: string;
-};
-
-export type RunPromptSuccessAction = {
-  type: "RUN_PROMPT_SUCCESS";
-  id: string;
-  config: AIConfig;
-};
-
-export type SaveConfigSuccessAction = {
-  type: "SAVE_CONFIG_SUCCESS";
-};
-
-export type SetDescriptionAction = {
-  type: "SET_DESCRIPTION";
-  description: string;
-};
-
-export type SetNameAction = {
-  type: "SET_NAME";
-  name: string;
-};
-
-export type StreamAIConfigChunkAction = {
-  type: "STREAM_AICONFIG_CHUNK";
-  config: AIConfig;
-  cancellationToken?: string;
-};
-
-export type StreamOutputChunkAction = {
-  type: "STREAM_OUTPUT_CHUNK";
-  id: string;
-  output: Output;
-};
-
-export type StopStreamingAction = {
-  type: "STOP_STREAMING";
-  id: string;
-};
-
-export type UpdatePromptInputAction = {
-  type: "UPDATE_PROMPT_INPUT";
-  id: string;
-  input: PromptInput;
-};
-
-export type UpdatePromptNameAction = {
-  type: "UPDATE_PROMPT_NAME";
-  id: string;
-  name: string;
-};
-
-export type UpdatePromptModelAction = {
-  type: "UPDATE_PROMPT_MODEL";
-  id: string;
-  modelName?: string;
-};
-
-export type UpdatePromptModelSettingsAction = {
-  type: "UPDATE_PROMPT_MODEL_SETTINGS";
-  id: string;
-  modelSettings: JSONObject;
-};
-
-export type UpdatePromptParametersAction = {
-  type: "UPDATE_PROMPT_PARAMETERS";
-  id: string;
-  parameters: JSONObject;
-};
-
-export type UpdateGlobalParametersAction = {
-  type: "UPDATE_GLOBAL_PARAMETERS";
-  parameters: JSONObject;
-};
+import type {
+  AIConfigReducerAction,
+  ConsolidateAIConfigSubAction,
+} from "./actions";
 
 function reduceReplacePrompt(
   state: ClientAIConfig,
@@ -156,17 +17,6 @@ function reduceReplacePrompt(
       prompt._ui.id === id ? replacerFn(prompt) : prompt
     ),
   };
-}
-
-function reduceReplaceInput(
-  state: ClientAIConfig,
-  id: string,
-  replacerFn: (input: PromptInput) => PromptInput
-): ClientAIConfig {
-  return reduceReplacePrompt(state, id, (prompt) => ({
-    ...prompt,
-    input: replacerFn(prompt.input),
-  }));
 }
 
 function reduceInsertPromptAtIndex(
@@ -442,7 +292,10 @@ export default function aiconfigReducer(
       );
     }
     case "UPDATE_PROMPT_INPUT": {
-      return reduceReplaceInput(dirtyState, action.id, () => action.input);
+      return reduceReplacePrompt(dirtyState, action.id, (prompt) => ({
+        ...prompt,
+        input: action.input,
+      }));
     }
     case "UPDATE_PROMPT_NAME": {
       // Validate that no prompt has a name that conflicts with this one:

--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -348,7 +348,7 @@ def run() -> FlaskResponse:
 
             aiconfig_json = aiconfig.model_dump(exclude=EXCLUDE_OPTIONS) if aiconfig is not None else None
             yield "["
-            yield json.dumps({"aiconfig": aiconfig_json})
+            yield json.dumps({"aiconfig_chunk": aiconfig_json})
             yield "]"
         
         yield "["


### PR DESCRIPTION
Split Action Types and AIConfigReducer into it's own folder

I just feel having the action type definitions vs. the reducer implementation make this a lot easier to read. You can now have file side by side instead of having to jump back and forth across the same one. I also merged the run commands together under the `RunPromptAction` type to make things cleaner as well. This will make it easier next diff once I merge logic together for the run prompts

I also cleaned up the `UPDATE_PROMPT_INPUT` implementation inside of the aiConfigReducer because it wasn't passing in the correct input type anyways, so now that's cleaner too.

## Test Plan
Everything works the same as before

https://github.com/lastmile-ai/aiconfig/assets/151060367/46c11941-c055-4307-99b2-3cd6202b78cb

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/926).
* #928
* __->__ #926
* #925
* #924
* #922
* #921
* #920
* #919
* #918
* #917