### PR TITLE
[ez] Rename logEvent handler to logEventHandler

### DIFF
--- a/python/src/aiconfig/editor/client/src/LocalEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/LocalEditor.tsx
@@ -204,13 +204,16 @@ export default function Editor() {
     return await ufetch.get(ROUTE_TABLE.SERVER_STATUS);
   }, []);
 
-  const logEvent = useCallback((event: LogEvent, data?: LogEventData) => {
-    try {
-      datadogLogs.logger.info(event, data);
-    } catch (e) {
-      // Ignore logger errors for now
-    }
-  }, []);
+  const logEventHandler = useCallback(
+    (event: LogEvent, data?: LogEventData) => {
+      try {
+        datadogLogs.logger.info(event, data);
+      } catch (e) {
+        // Ignore logger errors for now
+      }
+    },
+    []
+  );
 
   const callbacks: AIConfigCallbacks = useMemo(
     () => ({
@@ -220,7 +223,7 @@ export default function Editor() {
       deletePrompt,
       getModels,
       getServerStatus,
-      logEvent,
+      logEventHandler,
       runPrompt,
       save,
       setConfigDescription,
@@ -236,7 +239,7 @@ export default function Editor() {
       deletePrompt,
       getModels,
       getServerStatus,
-      logEvent,
+      logEventHandler,
       runPrompt,
       save,
       setConfigDescription,

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -106,7 +106,7 @@ export type AIConfigCallbacks = {
   deletePrompt: (promptName: string) => Promise<void>;
   getModels: (search: string) => Promise<string[]>;
   getServerStatus?: () => Promise<{ status: "OK" | "ERROR" }>;
-  logEvent?: (event: LogEvent, data?: LogEventData) => void;
+  logEventHandler?: (event: LogEvent, data?: LogEventData) => void;
   runPrompt: (
     promptName: string,
     onStream: RunPromptStreamCallback,
@@ -177,7 +177,7 @@ export default function EditorContainer({
   const stateRef = useRef(aiconfigState);
   stateRef.current = aiconfigState;
 
-  const logEventCallback = callbacks.logEvent;
+  const logEventHandler = callbacks.logEventHandler;
 
   const saveCallback = callbacks.save;
   const onSave = useCallback(async () => {
@@ -527,7 +527,7 @@ export default function EditorContainer({
       };
 
       dispatch(action);
-      logEventCallback?.("ADD_PROMPT", { model, promptIndex });
+      logEventHandler?.("ADD_PROMPT", { model, promptIndex });
 
       try {
         const serverConfigRes = await addPromptCallback(
@@ -549,7 +549,7 @@ export default function EditorContainer({
         });
       }
     },
-    [addPromptCallback, logEventCallback]
+    [addPromptCallback, logEventHandler]
   );
 
   const deletePromptCallback = callbacks.deletePrompt;
@@ -780,10 +780,10 @@ export default function EditorContainer({
   const contextValue = useMemo(
     () => ({
       getState,
-      logEvent: logEventCallback,
+      logEventHandler,
       readOnly,
     }),
-    [getState, logEventCallback, readOnly]
+    [getState, logEventHandler, readOnly]
   );
 
   const isDirty = aiconfigState._ui.isDirty !== false;
@@ -893,7 +893,7 @@ export default function EditorContainer({
                 loading={isSaving}
                 onClick={() => {
                   onSave();
-                  logEventCallback?.("SAVE_BUTTON_CLICKED");
+                  logEventHandler?.("SAVE_BUTTON_CLICKED");
                 }}
                 disabled={!isDirty}
                 size="xs"

--- a/python/src/aiconfig/editor/client/src/contexts/AIConfigContext.tsx
+++ b/python/src/aiconfig/editor/client/src/contexts/AIConfigContext.tsx
@@ -7,7 +7,7 @@ import { ClientAIConfig, LogEvent, LogEventData } from "../shared/types";
  */
 const AIConfigContext = createContext<{
   getState: () => ClientAIConfig;
-  logEvent?: (event: LogEvent, data?: LogEventData) => void;
+  logEventHandler?: (event: LogEvent, data?: LogEventData) => void;
   readOnly?: boolean;
 }>({
   getState: () => ({ prompts: [], _ui: { isDirty: false } }),


### PR DESCRIPTION
[ez] Rename logEvent handler to logEventHandler

There's the type `logEvent` and the handler `logEvent` which can be confusing. Having this as it's own separate variable name names it clear that this is a handler, not a type.

## Test Plan
no functional changes
