### PR TITLE
[rfc][sdk] 1/n Standardize Input Schema - Input Attachment Data

### DIFF
--- a/python/src/aiconfig/__init__.py
+++ b/python/src/aiconfig/__init__.py
@@ -17,6 +17,7 @@ from .schema import (
     AIConfig,
     ConfigMetadata,
     ExecuteResult,
+    AttachmentDataWithStringValue,
     JSONObject,
     ModelMetadata,
     Output,

--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -79,6 +79,15 @@ OutputDataWithValue = Union[
     OutputDataWithToolCallsValue,
 ]
 
+class AttachmentDataWithStringValue(BaseModel):
+    """
+    This represents the attachment data that is stored as a string, but we use
+    both the `kind` field here and the `mime_type` in Attachment to convert
+    the string into the input format we want.
+    """
+
+    kind: Literal["file_uri", "base64"]
+    value: str
 
 class ExecuteResult(BaseModel):
     """
@@ -152,7 +161,7 @@ class Attachment(BaseModel):
     """
 
     # The data representing the attachment
-    data: Any
+    data: Union[AttachmentDataWithStringValue, str, Any]
     # The MIME type of the result. If not specified, the MIME type will be assumed to be text/plain
     mime_type: Optional[str] = None
     # Output metadata

--- a/typescript/types.ts
+++ b/typescript/types.ts
@@ -72,11 +72,22 @@ export type SchemaVersion =
   | "v1"
   | "latest";
 
+/**
+ * This represents the attachment data that is stored as a string, but we use
+ * both the `kind` field here and the `mime_type` in Attachment to convert
+ * the string into the input format we want.
+ */
+type AttachmentDataWithStringValue = {
+  kind: "file_uri" | "base64";
+  value: string;
+};
+
+
 export type Attachment = {
   /**
    * The data representing the attachment
    */
-  data: JSONValue;
+  data: JSONValue | AttachmentDataWithStringValue;
 
   /**
    * The MIME type of the result. If not specified, the MIME type will be


### PR DESCRIPTION
[rfc][sdk] 1/n Standardize Input Schema - Input Attachment Data




Starting point of standardizing Input Schema for prompts

This diff introduces the type `AttachmentDataWithStringValue` to python and typescript sdk which will allow attachments to have structure as well as validation in python (pydantic validation).

## testplan

<img width="1273" alt="Screenshot 2024-01-15 at 5 52 11 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/0e5b1c83-cf94-4b2e-b267-8e45b4296593">
