### PR TITLE
[3/n] Read-only mode: Connect context to Add Prompt button

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -918,12 +918,14 @@ export default function EditorContainer({
         onUpdateParameters={onUpdateGlobalParameters}
       />
       <Container maw="80rem" className={classes.promptsContainer}>
-        <div className={classes.addPromptRow}>
-          <AddPromptButton
-            getModels={callbacks.getModels}
-            addPrompt={(model: string) => onAddPrompt(0, model)}
-          />
-        </div>
+        {!readOnly && (
+          <div className={classes.addPromptRow}>
+            <AddPromptButton
+              getModels={callbacks.getModels}
+              addPrompt={(model: string) => onAddPrompt(0, model)}
+            />
+          </div>
+        )}
         {aiconfigState.prompts.map((prompt: ClientPrompt, i: number) => {
           const isAnotherPromptRunning =
             runningPromptId !== undefined && runningPromptId !== prompt._ui.id;
@@ -948,17 +950,19 @@ export default function EditorContainer({
                   isRunButtonDisabled={isAnotherPromptRunning}
                 />
               </Flex>
-              <div className={classes.addPromptRow}>
-                <AddPromptButton
-                  getModels={callbacks.getModels}
-                  addPrompt={(model: string) =>
-                    onAddPrompt(
-                      i + 1 /* insert below current prompt index */,
-                      model
-                    )
-                  }
-                />
-              </div>
+              {!readOnly && (
+                <div className={classes.addPromptRow}>
+                  <AddPromptButton
+                    getModels={callbacks.getModels}
+                    addPrompt={(model: string) =>
+                      onAddPrompt(
+                        i + 1 /* insert below current prompt index */,
+                        model
+                      )
+                    }
+                  />
+                </div>
+              )}
             </Stack>
           );
         })}


### PR DESCRIPTION
[3/n] Read-only mode: Connect context to Add Prompt button

For now I'm just returning empty component. It looks a bit weird to me right now, but I think that's becuase the background color of the prompt cells should be darker than the background color of the notebook itself. Once that's fixed it'll look better I think. From the Figma: https://www.figma.com/file/7YVa6KpEDgptj8DiAc5BaU/AiConfig-Editor?type=design&node-id=271-4785&mode=design

<img width="1391" alt="Screenshot 2024-01-16 at 08 52 01" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/625d14ae-0a57-45b4-8d83-471443dcdf79">


## Test Plan
Change `readOnly = false` to `readOnly = true`

Before
<img width="1512" alt="Screenshot 2024-01-16 at 10 29 00" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/38247da0-1393-4118-b743-3932a950c63a">


After
<img width="1512" alt="Screenshot 2024-01-16 at 10 28 34" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/5784b5f9-970c-4b46-bce3-155a30612c92">


## Old
Before
<img width="1512" alt="Screenshot 2024-01-16 at 08 55 58" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/f80433e1-9824-4cf4-adb2-811d2ce41774">


After

<img width="1512" alt="Screenshot 2024-01-16 at 08 52 46" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/b6938002-ca20-468f-8481-d716a7e3fc3e">
