### PR TITLE
[4/n] Read-only mode:  Remove Clear Output and Save buttons

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -878,32 +878,37 @@ export default function EditorContainer({
       <Container maw="80rem">
         <Flex justify="flex-end" mt="md" mb="xs">
           <Group>
-            <Button
-              loading={undefined}
-              onClick={onClearOutputs}
-              size="xs"
-              variant="gradient"
-            >
-              Clear Outputs
-            </Button>
-
-            <Tooltip
-              label={isDirty ? "Save changes to config" : "No unsaved changes"}
-            >
+            {!readOnly && (
               <Button
-                leftIcon={<IconDeviceFloppy />}
-                loading={isSaving}
-                onClick={() => {
-                  onSave();
-                  logEventHandler?.("SAVE_BUTTON_CLICKED");
-                }}
-                disabled={!isDirty}
+                loading={undefined}
+                onClick={onClearOutputs}
                 size="xs"
                 variant="gradient"
               >
-                Save
+                Clear Outputs
               </Button>
-            </Tooltip>
+            )}
+            {!readOnly && (
+              <Tooltip
+                label={
+                  isDirty ? "Save changes to config" : "No unsaved changes"
+                }
+              >
+                <Button
+                  leftIcon={<IconDeviceFloppy />}
+                  loading={isSaving}
+                  onClick={() => {
+                    onSave();
+                    logEventHandler?.("SAVE_BUTTON_CLICKED");
+                  }}
+                  disabled={!isDirty}
+                  size="xs"
+                  variant="gradient"
+                >
+                  Save
+                </Button>
+              </Tooltip>
+            )}
           </Group>
         </Flex>
         <ConfigNameDescription


### PR DESCRIPTION
[4/n] Read-only mode:  Remove Clear Output and Save buttons

TSIA


## Test Plan
Change `readOnly = false` to `readOnly = true`
Before
<img width="1512" alt="Screenshot 2024-01-16 at 08 52 46" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/0fdb11b4-e618-4e93-a1d4-261597d99680">


After
<img width="1512" alt="Screenshot 2024-01-16 at 11 14 05" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/3737af31-036c-487d-894d-6d47083c0f4c">

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/936).
* __->__ #936
* #935