### PR TITLE
[easy] [ts][sdk] export `AttachmentDataWithStringValue` type

### DIFF
--- a/typescript/types.ts
+++ b/typescript/types.ts
@@ -77,7 +77,7 @@ export type SchemaVersion =
  * both the `kind` field here and the `mime_type` in Attachment to convert
  * the string into the input format we want.
  */
-type AttachmentDataWithStringValue = {
+export type AttachmentDataWithStringValue = {
   kind: "file_uri" | "base64";
   value: string;
 };


### PR DESCRIPTION
[easy] [ts][sdk] export `AttachmentDataWithStringValue` type


`AttachmentDataWithStringValue` was created in #929

Wasn't exported. This diff exports it
