### PR TITLE
[editor] 4/n refactor input attachments to use new input data type

### DIFF
--- a/cookbooks/Gradio/huggingface.aiconfig.json
+++ b/cookbooks/Gradio/huggingface.aiconfig.json
@@ -26,11 +26,17 @@
       "input": {
         "attachments": [
           {
-            "data": "https://s3.amazonaws.com/lastmileai.aiconfig.public/uploads/2024_1_10_18_41_31/1742/bear_with_honey.png",
+            "data": {
+              "kind": "file_uri",
+              "value": "https://s3.amazonaws.com/lastmileai.aiconfig.public/uploads/2024_1_16_20_22_54/7748/fox_in_forest.png"
+            },
             "mime_type": "image/png"
           },
           {
-            "data": "https://s3.amazonaws.com/lastmileai.aiconfig.public/uploads/2024_1_10_18_41_31/7275/fox_in_forest.png",
+            "data": {
+              "kind": "file_uri",
+              "value": "https://s3.amazonaws.com/lastmileai.aiconfig.public/uploads/2024_1_16_20_20_57/508/bear_with_honey.png"
+            },
             "mime_type": "image/png"
           }
         ]
@@ -49,13 +55,13 @@
         {
           "output_type": "execute_result",
           "execution_count": 0,
-          "data": "a bear sitting on a rock eating honey",
+          "data": "a red fox in the woods",
           "metadata": {}
         },
         {
           "output_type": "execute_result",
           "execution_count": 1,
-          "data": "a red fox in the woods",
+          "data": "a bear sitting on a rock eating honey",
           "metadata": {}
         }
       ]
@@ -207,7 +213,10 @@
       "input": {
         "attachments": [
           {
-            "data": "https://s3.amazonaws.com/lastmileai.aiconfig.public/uploads/2024_1_11_20_34_32/3386/hi.mp3",
+            "data": {
+              "kind": "file_uri",
+              "value": "https://s3.amazonaws.com/lastmileai.aiconfig.public/uploads/2024_1_16_20_21_10/1673/hi (1).mp3"
+            },
             "mime_type": "audio/mpeg"
           }
         ]
@@ -221,7 +230,14 @@
         },
         "parameters": {}
       },
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 0,
+          "data": " Hi.",
+          "metadata": {}
+        }
+      ]
     }
   ],
   "$schema": "https://json.schemastore.org/aiconfig-1.0"

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/image_2_text.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/image_2_text.py
@@ -17,6 +17,7 @@ from aiconfig.schema import (
     ExecuteResult,
     Output,
     Prompt,
+    AttachmentDataWithStringValue
 )
 
 # Circular Dependency Type Hints
@@ -248,18 +249,16 @@ def validate_and_retrieve_images_from_attachments(prompt: Prompt) -> list[Union[
     for i, attachment in enumerate(prompt.input.attachments):
         validate_attachment_type_is_image(prompt.name, attachment)
 
-        input_data = attachment.data
-        if not isinstance(input_data, str):
+        
+        if not isinstance(attachment.data, AttachmentDataWithStringValue):
             # See todo above, but for now only support uris and base64
-            raise ValueError(f"Attachment #{i} data is not a uri or base64 string. Please specify a uri or base64 encoded string for the image attachment in prompt '{prompt.name}'.")
-
-        # Really basic heurestic to check if the data is a base64 encoded str
-        # vs. uri. This will be fixed once we have standardized inputs
-        # See https://github.com/lastmile-ai/aiconfig/issues/829
-        if len(input_data) > 10000:
+            raise ValueError(f"""Attachment #{i} data must be of type `AttachmentDataWithStringValue` with a `kind` and `value` field.
+                         Please specify a uri or base64 encoded string for the image attachment in prompt '{prompt.name}'.""")
+        input_data = attachment.data.value
+        if attachment.data.kind == "base64":
             pil_image: Image = Image.open(BytesIO(base64.b64decode(input_data)))
             images.append(pil_image)
         else:
-            images.append(input_data)
+            images.append(input_data) # expect a uri
 
     return images

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/attachments/AttachmentContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/attachments/AttachmentContainer.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import type { Attachment as InputAttachment, JSONObject } from "aiconfig";
+import type { Attachment as InputAttachment, JSONObject, AttachmentDataWithStringValue } from "aiconfig";
 import { PromptInputObjectAttachmentsSchema } from "../../../../utils/promptUtils";
 import { ActionIcon, Container, Flex, Tooltip } from "@mantine/core";
 import { IconEdit, IconTrash } from "@tabler/icons-react";
@@ -41,7 +41,7 @@ export default memo(function AttachmentContainer({
       </Flex>
       <MimeTypeRenderer
         mimeType={attachment.mime_type}
-        content={attachment.data as string}
+        content={(attachment.data as AttachmentDataWithStringValue).value as string}
       />
       {schema.items.properties?.metadata && (
         <AttachmentMetadata

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/attachments/AttachmentUploader.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/attachments/AttachmentUploader.tsx
@@ -115,7 +115,7 @@ Props) {
 
       const attachments: Attachment[] = uploads.map((upload) => {
         return {
-          data: upload.url,
+          data: {value: upload.url, kind: "file_uri"},
           mime_type: upload.mimeType,
         };
       });


### PR DESCRIPTION
[editor] 4/n refactor input attachments to use new input data type








- update renderer to acknowledge new type
- On New attachment, update aiconfig to use new values to input data when new file is updated
- updated Gradio AIConfig by removing and adding files.

Note: This diff doesn't test or change base64 functionality but should techncially be possible. <audio> HTML taglets you pass base64 source. Unsure about image

## Testplan:
1. edit config
2. reupload files & run. note: the incorrect rendering is due to the old aiconfig with the now incorrect input attachment data type

https://github.com/lastmile-ai/aiconfig/assets/141073967/eff42748-e3e6-48df-b90b-34bac4e997c4

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/944).
* __->__ #944
* #940
* #932