### PR TITLE
[editor] add telemetry for more events

### DIFF
--- a/python/src/aiconfig/editor/client/src/LocalEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/LocalEditor.tsx
@@ -37,6 +37,9 @@ const useStyles = createStyles(() => ({
   },
 }));
 
+
+const MODE = "local";
+
 export default function LocalEditor() {
   const [aiconfig, setAiConfig] = useState<AIConfig | undefined>();
   const { classes } = useStyles();
@@ -71,6 +74,8 @@ export default function LocalEditor() {
         forwardErrorsToLogs: true,
         sessionSampleRate: 100,
       });
+
+      datadogLogs.setGlobalContextProperty('mode', MODE);
     }
   }, []);
 
@@ -287,7 +292,7 @@ export default function LocalEditor() {
         <AIConfigEditor
           aiconfig={aiconfig}
           callbacks={callbacks}
-          mode="local"
+          mode={MODE}
         />
       )}
     </div>

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -681,6 +681,7 @@ export default function AIConfigEditor({
         promptId,
         cancellationToken,
       });
+      logEventHandler?.("RUN_PROMPT_START");
 
       const onPromptError = (message: string | null) => {
         dispatch({
@@ -688,6 +689,7 @@ export default function AIConfigEditor({
           promptId,
           message: message ?? undefined,
         });
+        logEventHandler?.("RUN_PROMPT_ERROR");
 
         const promptName = getPrompt(stateRef.current, promptId)?.name;
 
@@ -732,6 +734,7 @@ export default function AIConfigEditor({
                 type: "RUN_PROMPT_SUCCESS",
                 promptId,
               });
+              logEventHandler?.("RUN_PROMPT_SUCCESS");
             }
           },
           (event) => {
@@ -748,6 +751,7 @@ export default function AIConfigEditor({
                   // Returned config output is reset to before running RUN_PROMPT
                   config: event.data.data,
                 });
+                logEventHandler?.("RUN_PROMPT_CANCELED");
 
                 const promptName = getPrompt(stateRef.current, promptId)?.name;
 
@@ -770,11 +774,13 @@ export default function AIConfigEditor({
         // Keep this here in case any server implementations don't return
         // aiconfig as a streaming format
         if (serverConfigResponse?.aiconfig) {
+          // Do we need to log here
           dispatch({
             type: "RUN_PROMPT_SUCCESS",
             promptId,
             config: serverConfigResponse.aiconfig,
           });
+          logEventHandler?.("RUN_PROMPT_SUCCESS");
         }
       } catch (err: unknown) {
         const message = (err as RequestCallbackError).message ?? null;

--- a/python/src/aiconfig/editor/client/src/shared/types.ts
+++ b/python/src/aiconfig/editor/client/src/shared/types.ts
@@ -63,7 +63,14 @@ export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
   };
 }
 
-export type LogEvent = "ADD_PROMPT" | "SAVE_BUTTON_CLICKED";
+export type LogEvent = 
+  | "ADD_PROMPT"
+  | "SAVE_BUTTON_CLICKED" 
+  | "RUN_PROMPT_START"
+  | "RUN_PROMPT_CANCELED" 
+  | "RUN_PROMPT_ERROR" 
+  | "RUN_PROMPT_SUCCESS";
+
 // TODO: schematize this
 export type LogEventData = JSONObject;
 


### PR DESCRIPTION
[editor] add telemetry for more events









As discussed offline, we want to enable telemetry in the local editor for the following events:

- RUN_PROMPT_START
- RUN_PROMPT_CANCEL
- RUN_PROMPT_ERROR
- RUN_PROMPT_SUCCESS

This diff implements the logging telemetry for those events.
- Add mode "local" to all telemetry sent from local editor in prod mode
- Send telemetry log events after dispatching rather than before, so that the client render action gets called first.
- - This technically shouldn't matter since these are all async calls.
- Note: This only implements logging for Local Editor. Next up is to add the datadog initialization to Gradio Workbook


## Testplan

1. yarn build -> run editor in 'prod' mode
2. run prompt, cancel, rerun to success. Check telemetry sent to datadog.

https://github.com/lastmile-ai/aiconfig/assets/141073967/52043456-3682-4dd7-b95b-846ad7480019
