### PR TITLE
Add 'mode' Prop to AIConfigEditor & Map to Associated Theme

### DIFF
--- a/python/src/aiconfig/editor/client/src/LocalEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/LocalEditor.tsx
@@ -4,7 +4,7 @@ import AIConfigEditor, {
   RunPromptStreamErrorCallback,
   RunPromptStreamErrorEvent,
 } from "./components/AIConfigEditor";
-import { Flex, Loader, MantineProvider, Image } from "@mantine/core";
+import { Flex, Loader, Image, createStyles } from "@mantine/core";
 import {
   AIConfig,
   InferenceSettings,
@@ -19,8 +19,27 @@ import { streamingApiChain } from "./utils/oboeHelpers";
 import { datadogLogs } from "@datadog/browser-logs";
 import { LogEvent, LogEventData } from "./shared/types";
 
-export default function Editor() {
+const useStyles = createStyles(() => ({
+  editorBackground: {
+    background:
+      "radial-gradient(ellipse at top,#08122d,#030712),radial-gradient(ellipse at bottom,#030712,#030712)",
+    margin: "0 auto",
+    minHeight: "100vh",
+  },
+
+  logo: {
+    maxWidth: "80rem",
+    margin: "0 auto",
+    padding: "32px 0 0 32px",
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+}));
+
+export default function LocalEditor() {
   const [aiconfig, setAiConfig] = useState<AIConfig | undefined>();
+  const { classes } = useStyles();
 
   const loadConfig = useCallback(async () => {
     const res = await ufetch.post(ROUTE_TABLE.LOAD, {});
@@ -251,200 +270,26 @@ export default function Editor() {
   );
 
   return (
-    <div className="editorBackground">
-      <MantineProvider
-        withGlobalStyles
-        withNormalizeCSS
-        theme={{
-          colorScheme: "dark",
-
-          headings: {
-            fontFamily:
-              "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, Arial, sans-serif",
-            sizes: {
-              h1: { fontSize: "2rem" },
-            },
-          },
-
-          defaultGradient: {
-            from: "pink",
-            to: "pink",
-            deg: 45,
-          },
-          // local editor theme
-          globalStyles: () => ({
-            ".editorBackground": {
-              background:
-                "radial-gradient(ellipse at top,#08122d,#030712),radial-gradient(ellipse at bottom,#030712,#030712)",
-              margin: "0 auto",
-              minHeight: "100vh",
-            },
-            ".monoFont": {
-              fontFamily:
-                "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
-            },
-            ".ghost": {
-              border: "none",
-              borderRadius: "4px",
-              padding: "4px",
-              margin: "0px",
-              backgroundColor: "transparent",
-              ":hover": {
-                backgroundColor: "rgba(226,232,255,.1)",
-              },
-              input: {
-                maxHeight: "16px",
-                fontFamily:
-                  "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
-                border: "none",
-                borderRadius: "4px",
-                padding: "4px",
-                margin: "0px",
-                backgroundColor: "transparent",
-              },
-            },
-            ".cellStyle": {
-              border: "1px solid rgba(226,232,255,.1) !important",
-              background: "rgb(12 21 57 / 10%)",
-              flex: 1,
-              borderTopRightRadius: "0px",
-              borderBottomRightRadius: "0px",
-              ":hover": {
-                background: "rgba(255, 255, 255, 0.03) !important",
-              },
-              textarea: {
-                border: "1px solid rgba(226,232,255,.1)",
-                backgroundColor: "#060c21",
-                ":focus": {
-                  outline: "solid 1px #ff1cf7 !important",
-                  outlineOffset: "-1px",
-                },
-              },
-              ".mantine-InputWrapper-label": {
-                display: "none",
-              },
-            },
-            ".sidePanel": {
-              border: "1px solid rgba(226,232,255,.1)",
-              borderLeft: "none",
-              borderTopRightRadius: "4px",
-              borderBottomRightRadius: "4px",
-              input: {
-                border: "1px solid rgba(226,232,255,.1)",
-                backgroundColor: "#060c21",
-                ":focus": {
-                  outline: "solid 1px #ff1cf7 !important",
-                  outlineOffset: "-1px",
-                },
-              },
-              textarea: {
-                border: "1px solid rgba(226,232,255,.1)",
-                backgroundColor: "#060c21",
-                ":focus": {
-                  outline: "solid 1px #ff1cf7 !important",
-                  outlineOffset: "-1px",
-                },
-              },
-            },
-            ".divider": {
-              borderTopWidth: "1px",
-              borderTopColor: "rgba(226,232,255,.1)",
-              marginBottom: "0.5em",
-            },
-            ".runPromptButton": {
-              background: "#ff1cf7",
-              color: "white",
-              height: "auto",
-              "&:hover": {
-                background: "#ff46f8",
-              },
-            },
-            ".actionTabsPanel": {
-              width: "400px",
-            },
-            ".logo": {
-              maxWidth: "80rem",
-              margin: "0 auto",
-              padding: "32px 0 0 32px",
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-            },
-
-            ".parametersContainer": {
-              maxWidth: "1250px",
-              maxHeight: "-webkit-fill-available",
-              margin: "16px auto",
-              padding: "0",
-              backgroundColor: "rgba(226,232,255,.1)",
-              borderRadius: "4px",
-              border: "1px solid rgba(226,232,255,.1) !important",
-              button: {
-                ":hover": {
-                  backgroundColor: "rgba(226,232,255,.1)",
-                },
-              },
-              input: {
-                border: "1px solid rgba(226,232,255,.1)",
-                backgroundColor: "#060c21",
-                borderRadius: "4px",
-                ":focus": {
-                  outline: "solid 1px #ff1cf7 !important",
-                  outlineOffset: "-1px",
-                },
-              },
-              textarea: {
-                border: "1px solid rgba(226,232,255,.1)",
-                backgroundColor: "#060c21",
-                borderRadius: "4px",
-                ":focus": {
-                  outline: "solid 1px #ff1cf7 !important",
-                  outlineOffset: "-1px",
-                },
-              },
-            },
-            ".addParameterButton": {
-              position: "sticky",
-              left: "0",
-              bottom: "0",
-              margin: "16px 0 0 0",
-              background: "#ff1cf7",
-              "&:hover": {
-                background: "#ff46f8",
-              },
-            },
-            ".mantine-Slider-thumb": {
-              border: "0.25rem solid #ff1cf7",
-              backgroundColor: "white",
-            },
-            ".mantine-Slider-bar": {
-              backgroundColor: "#ff1cf7",
-            },
-            ".mantine-Tabs-tab[data-active]": {
-              borderBottom: "solid 1px #ff1cf7",
-              ":hover": {
-                borderBottom: "solid 1px #ff1cf7",
-              },
-            },
-          }),
-        }}
-      >
-        <div className="logo">
-          <Image
-            withPlaceholder
-            maw={140}
-            src="images/aiconfigLogo.png"
-            alt="AiConfig Logo"
-          />
-        </div>
-        {!aiconfig ? (
-          <Flex justify="center" mt="xl">
-            <Loader size="xl" />
-          </Flex>
-        ) : (
-          <AIConfigEditor aiconfig={aiconfig} callbacks={callbacks} />
-        )}
-      </MantineProvider>
+    <div className={classes.editorBackground}>
+      <div className={classes.logo}>
+        <Image
+          withPlaceholder
+          maw={140}
+          src="images/aiconfigLogo.png"
+          alt="AiConfig Logo"
+        />
+      </div>
+      {!aiconfig ? (
+        <Flex justify="center" mt="xl">
+          <Loader size="xl" />
+        </Flex>
+      ) : (
+        <AIConfigEditor
+          aiconfig={aiconfig}
+          callbacks={callbacks}
+          mode="local"
+        />
+      )}
     </div>
   );
 }

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -32,6 +32,7 @@ import { v4 as uuidv4 } from "uuid";
 import aiconfigReducer from "../reducers/aiconfigReducer";
 import type { AIConfigReducerAction } from "../reducers/actions";
 import {
+  AIConfigEditorMode,
   ClientPrompt,
   LogEvent,
   LogEventData,
@@ -61,10 +62,12 @@ import {
 } from "../utils/promptUtils";
 import { IconDeviceFloppy } from "@tabler/icons-react";
 import CopyButton from "./CopyButton";
+import AIConfigEditorThemeProvider from "../themes/AIConfigEditorThemeProvider";
 
 type Props = {
   aiconfig: AIConfig;
   callbacks?: AIConfigCallbacks;
+  mode?: AIConfigEditorMode;
   readOnly?: boolean;
 };
 
@@ -164,9 +167,10 @@ const useStyles = createStyles((theme) => ({
   },
 }));
 
-export default function EditorContainer({
+export default function AIConfigEditor({
   aiconfig: initialAIConfig,
   callbacks,
+  mode,
   readOnly = false,
 }: Props) {
   const [isSaving, setIsSaving] = useState(false);
@@ -931,134 +935,143 @@ export default function EditorContainer({
   const runningPromptId: string | undefined = aiconfigState._ui.runningPromptId;
 
   return (
-    <AIConfigContext.Provider value={contextValue}>
-      <Notifications />
-      {serverStatus !== "OK" && (
-        <>
-          {/* // Simple placeholder block div to make sure the banner does not overlap page contents until scrolling past its height */}
-          <div style={{ height: "100px" }} />
-          <Alert
-            color="red"
-            title="Server Connection Error"
-            w="100%"
-            style={{ position: "fixed", top: 0, zIndex: 999 }}
-          >
-            <Text>
-              There is a problem with the editor server connection. Please copy
-              important changes somewhere safe and then try reloading the page
-              or restarting the editor.
-            </Text>
-            <Flex align="center">
-              <CopyButton
-                value={JSON.stringify(
-                  clientConfigToAIConfig(aiconfigState),
-                  null,
-                  2
-                )}
-                contentLabel="AIConfig JSON"
-              />
-              <Text color="dimmed">Click to copy current AIConfig JSON</Text>
-            </Flex>
-          </Alert>
-        </>
-      )}
-      <Container maw="80rem">
-        <Flex justify="flex-end" mt="md" mb="xs">
-          <Group>
-            {!readOnly && (
-              <Button
-                loading={undefined}
-                onClick={onClearOutputs}
-                size="xs"
-                variant="gradient"
+    <AIConfigEditorThemeProvider mode={mode}>
+      <AIConfigContext.Provider value={contextValue}>
+        <Notifications />
+        <div className="editorBackground">
+          {serverStatus !== "OK" && (
+            <>
+              {/* // Simple placeholder block div to make sure the banner does not overlap page contents until scrolling past its height */}
+              <div style={{ height: "100px" }} />
+              <Alert
+                color="red"
+                title="Server Connection Error"
+                w="100%"
+                style={{ position: "fixed", top: 0, zIndex: 999 }}
               >
-                Clear Outputs
-              </Button>
-            )}
-            {!readOnly && (
-              <Tooltip
-                label={
-                  isDirty ? "Save changes to config" : "No unsaved changes"
-                }
-              >
-                <Button
-                  leftIcon={<IconDeviceFloppy />}
-                  loading={isSaving}
-                  onClick={() => {
-                    onSave();
-                    logEventHandler?.("SAVE_BUTTON_CLICKED");
-                  }}
-                  disabled={!isDirty}
-                  size="xs"
-                  variant="gradient"
-                >
-                  Save
-                </Button>
-              </Tooltip>
-            )}
-          </Group>
-        </Flex>
-        <ConfigNameDescription
-          name={aiconfigState.name}
-          description={aiconfigState.description}
-          setDescription={onSetDescription}
-          setName={onSetName}
-        />
-      </Container>
-      <GlobalParametersContainer
-        initialValue={aiconfigState?.metadata?.parameters ?? {}}
-        onUpdateParameters={onUpdateGlobalParameters}
-      />
-      <Container maw="80rem" className={classes.promptsContainer}>
-        {!readOnly && (
-          <div className={classes.addPromptRow}>
-            <AddPromptButton
-              getModels={callbacks?.getModels}
-              addPrompt={(model: string) => onAddPrompt(0, model)}
-            />
-          </div>
-        )}
-        {aiconfigState.prompts.map((prompt: ClientPrompt, i: number) => {
-          const isAnotherPromptRunning =
-            runningPromptId !== undefined && runningPromptId !== prompt._ui.id;
-          return (
-            <Stack key={prompt._ui.id}>
-              <Flex mt="md">
-                <PromptMenuButton
-                  promptId={prompt._ui.id}
-                  onDeletePrompt={() => onDeletePrompt(prompt._ui.id)}
-                />
-                <PromptContainer
-                  prompt={prompt}
-                  getModels={callbacks?.getModels}
-                  onChangePromptInput={onChangePromptInput}
-                  onChangePromptName={onChangePromptName}
-                  cancel={callbacks?.cancel}
-                  onRunPrompt={onRunPrompt}
-                  onUpdateModel={onUpdatePromptModel}
-                  onUpdateModelSettings={onUpdatePromptModelSettings}
-                  onUpdateParameters={onUpdatePromptParameters}
-                  defaultConfigModelName={aiconfigState.metadata.default_model}
-                  isRunButtonDisabled={isAnotherPromptRunning}
-                />
-              </Flex>
-              {!readOnly && (
-                <div className={classes.addPromptRow}>
-                  <AddPromptButton
-                    getModels={callbacks?.getModels}
-                    addPrompt={(model: string) =>
-                      onAddPrompt(
-                        i + 1 /* insert below current prompt index */,
-                        model
-                      )
-                    }
+                <Text>
+                  There is a problem with the editor server connection. Please
+                  copy important changes somewhere safe and then try reloading
+                  the page or restarting the editor.
+                </Text>
+                <Flex align="center">
+                  <CopyButton
+                    value={JSON.stringify(
+                      clientConfigToAIConfig(aiconfigState),
+                      null,
+                      2
+                    )}
+                    contentLabel="AIConfig JSON"
                   />
-                </div>
-              )}
-            </Stack>
-          );
-        })}
-      </Container>
-    </AIConfigContext.Provider>
+                  <Text color="dimmed">
+                    Click to copy current AIConfig JSON
+                  </Text>
+                </Flex>
+              </Alert>
+            </>
+          )}
+          <Container maw="80rem">
+            <Flex justify="flex-end" mt="md" mb="xs">
+              <Group>
+                {!readOnly && (
+                  <Button
+                    loading={undefined}
+                    onClick={onClearOutputs}
+                    size="xs"
+                    variant="gradient"
+                  >
+                    Clear Outputs
+                  </Button>
+                )}
+                {!readOnly && (
+                  <Tooltip
+                    label={
+                      isDirty ? "Save changes to config" : "No unsaved changes"
+                    }
+                  >
+                    <Button
+                      leftIcon={<IconDeviceFloppy />}
+                      loading={isSaving}
+                      onClick={() => {
+                        onSave();
+                        logEventHandler?.("SAVE_BUTTON_CLICKED");
+                      }}
+                      disabled={!isDirty}
+                      size="xs"
+                      variant="gradient"
+                    >
+                      Save
+                    </Button>
+                  </Tooltip>
+                )}
+              </Group>
+            </Flex>
+            <ConfigNameDescription
+              name={aiconfigState.name}
+              description={aiconfigState.description}
+              setDescription={onSetDescription}
+              setName={onSetName}
+            />
+          </Container>
+          <GlobalParametersContainer
+            initialValue={aiconfigState?.metadata?.parameters ?? {}}
+            onUpdateParameters={onUpdateGlobalParameters}
+          />
+          <Container maw="80rem" className={classes.promptsContainer}>
+            {!readOnly && (
+              <div className={classes.addPromptRow}>
+                <AddPromptButton
+                  getModels={callbacks?.getModels}
+                  addPrompt={(model: string) => onAddPrompt(0, model)}
+                />
+              </div>
+            )}
+            {aiconfigState.prompts.map((prompt: ClientPrompt, i: number) => {
+              const isAnotherPromptRunning =
+                runningPromptId !== undefined &&
+                runningPromptId !== prompt._ui.id;
+              return (
+                <Stack key={prompt._ui.id}>
+                  <Flex mt="md">
+                    <PromptMenuButton
+                      promptId={prompt._ui.id}
+                      onDeletePrompt={() => onDeletePrompt(prompt._ui.id)}
+                    />
+                    <PromptContainer
+                      prompt={prompt}
+                      getModels={callbacks?.getModels}
+                      onChangePromptInput={onChangePromptInput}
+                      onChangePromptName={onChangePromptName}
+                      cancel={callbacks?.cancel}
+                      onRunPrompt={onRunPrompt}
+                      onUpdateModel={onUpdatePromptModel}
+                      onUpdateModelSettings={onUpdatePromptModelSettings}
+                      onUpdateParameters={onUpdatePromptParameters}
+                      defaultConfigModelName={
+                        aiconfigState.metadata.default_model
+                      }
+                      isRunButtonDisabled={isAnotherPromptRunning}
+                    />
+                  </Flex>
+                  {!readOnly && (
+                    <div className={classes.addPromptRow}>
+                      <AddPromptButton
+                        getModels={callbacks?.getModels}
+                        addPrompt={(model: string) =>
+                          onAddPrompt(
+                            i + 1 /* insert below current prompt index */,
+                            model
+                          )
+                        }
+                      />
+                    </div>
+                  )}
+                </Stack>
+              );
+            })}
+          </Container>
+        </div>
+      </AIConfigContext.Provider>
+    </AIConfigEditorThemeProvider>
   );
 }

--- a/python/src/aiconfig/editor/client/src/components/ConditionalWrapper.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ConditionalWrapper.tsx
@@ -1,0 +1,17 @@
+type Props = {
+  children: React.ReactNode;
+  condition: boolean;
+  wrapper: (children: React.ReactNode) => React.ReactElement | null;
+};
+
+export default function ConditionalWrapper({
+  children,
+  condition,
+  wrapper,
+}: Props): React.ReactElement | null {
+  if (condition) {
+    return wrapper(children);
+  } else {
+    return <>{children}</>;
+  }
+}

--- a/python/src/aiconfig/editor/client/src/shared/types.ts
+++ b/python/src/aiconfig/editor/client/src/shared/types.ts
@@ -66,3 +66,5 @@ export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
 export type LogEvent = "ADD_PROMPT" | "SAVE_BUTTON_CLICKED";
 // TODO: schematize this
 export type LogEventData = JSONObject;
+
+export type AIConfigEditorMode = "local" | "gradio" | "vscode";

--- a/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
+++ b/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
@@ -1,0 +1,36 @@
+import { MantineProvider } from "@mantine/core";
+import { AIConfigEditorMode } from "../shared/types";
+import { LOCAL_THEME } from "./LocalTheme";
+import { GRADIO_THEME } from "./GradioTheme";
+import ConditionalWrapper from "../components/ConditionalWrapper";
+
+type Props = {
+  children: React.ReactNode;
+  mode?: AIConfigEditorMode;
+};
+
+const THEMES = {
+  local: LOCAL_THEME,
+  gradio: GRADIO_THEME,
+  // TODO: Implement VSCODE_THEME
+  vscode: LOCAL_THEME,
+};
+
+export default function AIConfigEditorThemeProvider({ children, mode }: Props) {
+  return (
+    <ConditionalWrapper
+      condition={mode != null}
+      wrapper={(children) => (
+        <MantineProvider
+          withGlobalStyles
+          withNormalizeCSS
+          theme={THEMES[mode!]}
+        >
+          {children}
+        </MantineProvider>
+      )}
+    >
+      {children}
+    </ConditionalWrapper>
+  );
+}

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -1,0 +1,195 @@
+import { MantineThemeOverride } from "@mantine/core";
+
+export const GRADIO_THEME: MantineThemeOverride = {
+  headings: {
+    fontFamily:
+      "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, Arial, sans-serif",
+    sizes: {
+      h1: { fontSize: "2rem" },
+    },
+  },
+
+  defaultGradient: {
+    from: "#E88949",
+    to: "#E85921",
+    deg: 90,
+  },
+
+  //gradio light theme
+  globalStyles: (theme) => ({
+    ".editorBackground": {
+      background: theme.colorScheme === "light" ? "white" : "#0b0f19",
+      margin: "0 auto",
+      minHeight: "100vh",
+    },
+    ".monoFont": {
+      fontFamily:
+        "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+    },
+    ".ghost": {
+      input: {
+        maxHeight: "16px",
+        fontFamily:
+          "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+        borderRadius: "8px",
+        margin: "8px 0px 0px 0px",
+        backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
+        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+        ":focus": {
+          outline: "solid 1px #E85921 !important",
+          outlineOffset: "-1px",
+        },
+      },
+    },
+    ".cellStyle": {
+      border: "1px solid",
+      borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
+      background: theme.colorScheme === "light" ? "white" : "#1f2938",
+      flex: 1,
+      borderTopRightRadius: "0px",
+      borderBottomRightRadius: "0px",
+      borderTopLeftRadius: "8px",
+      borderBottomLeftRadius: "8px",
+      ":hover": {
+        background:
+          theme.colorScheme === "light"
+            ? "rgba(249, 250, 251, 0.5) !important"
+            : "#1f2938",
+      },
+      textarea: {
+        border: "1px solid !important",
+        borderColor:
+          theme.colorScheme === "light"
+            ? "#E5E7EB !important"
+            : "#384152 !important",
+        borderRadius: "8px",
+        margin: "8px 0px 0px 0px",
+        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+        backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
+        ":focus": {
+          outline: "solid 1px #E85921 !important",
+          outlineOffset: "-1px",
+        },
+      },
+    },
+    ".sidePanel": {
+      border: "1px solid",
+      borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
+      borderLeft: "none",
+      borderTopRightRadius: "8px",
+      borderBottomRightRadius: "8px",
+      background:
+        theme.colorScheme === "light"
+          ? "linear-gradient(90deg, #F6F6F6, #FFFFFF)"
+          : "transparent",
+      input: {
+        border: "1px solid #E5E7EB !important",
+        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+        backgroundColor: "#ffffff",
+        ":focus": {
+          outline: "solid 1px #E85921 !important",
+          outlineOffset: "-1px",
+        },
+      },
+    },
+    ".divider": {
+      borderTopWidth: "1px",
+      borderTopColor: "rgba(226,232,255,.1)",
+      marginBottom: "0.5em",
+    },
+    ".runPromptButton": {
+      borderRadius: "8px",
+      border: "1px solid #FDD7AD",
+      background: "linear-gradient(180deg, #FEE1C0 0%, #FCC792 100%)",
+      boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05)",
+      margin: "4px",
+      height: "auto",
+      color: "#E85921",
+      path: {
+        color: "#E85921",
+      },
+      ":hover": {
+        background: "linear-gradient(180deg, #FEE1C0 0%, #FF9E3D 100%)",
+      },
+    },
+    ".actionTabsPanel": {
+      width: "400px",
+    },
+    ".logo": {
+      maxWidth: "80rem",
+      margin: "0 auto",
+      padding: "32px 0 0 32px",
+      display: "flex",
+      justifyContent: "space-between",
+      alignItems: "center",
+    },
+
+    ".parametersContainer": {
+      maxWidth: "1250px",
+      maxHeight: "-webkit-fill-available",
+      margin: "16px auto",
+      padding: "0",
+      backgroundColor: theme.colorScheme === "light" ? "#F9FAFB" : "#1f2938",
+      borderRadius: "8px",
+      border: "1px solid",
+      borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
+      button: {
+        ":hover": {
+          backgroundColor:
+            theme.colorScheme === "light" ? "#F0F1F1" : "transparent",
+        },
+      },
+      input: {
+        border: "1px solid !important",
+        borderColor:
+          theme.colorScheme === "light"
+            ? "#E5E7EB !important"
+            : "#384152 !important",
+        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+        borderRadius: "8px",
+        backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
+        ":focus": {
+          outline: "solid 1px #E85921 !important",
+          outlineOffset: "-1px",
+        },
+      },
+      textarea: {
+        border: "1px solid !important",
+        borderColor:
+          theme.colorScheme === "light"
+            ? "#E5E7EB !important"
+            : "#384152 !important",
+        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+        borderRadius: "8px",
+        backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
+        ":focus": {
+          outline: "solid 1px #E85921 !important",
+          outlineOffset: "-1px",
+        },
+      },
+      ".addParameterButton": {
+        position: "sticky",
+        left: "0",
+        bottom: "0",
+        margin: "16px 0 0 0",
+        background: "linear-gradient(180deg, #FEE1C0 0%, #FCC792 100%)",
+        path: {
+          color: "#E85921",
+        },
+      },
+    },
+
+    ".mantine-Slider-thumb": {
+      border: "0.25rem solid #E85921",
+    },
+    ".mantine-Slider-bar": {
+      backgroundColor: "#E85921",
+    },
+    ".mantine-Tabs-tab[data-active]": {
+      borderBottom: "solid 1px #E85921",
+      ":hover": {
+        borderBottom: "solid 1px #E85921",
+      },
+    },
+  }),
+};

--- a/python/src/aiconfig/editor/client/src/themes/LocalTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/LocalTheme.ts
@@ -1,0 +1,167 @@
+import { MantineThemeOverride } from "@mantine/core";
+
+export const LOCAL_THEME: MantineThemeOverride = {
+  colorScheme: "dark",
+
+  headings: {
+    fontFamily:
+      "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, Arial, sans-serif",
+    sizes: {
+      h1: { fontSize: "2rem" },
+    },
+  },
+
+  defaultGradient: {
+    from: "pink",
+    to: "pink",
+    deg: 45,
+  },
+  // local editor theme
+  globalStyles: () => ({
+    ".editorBackground": {
+      background:
+        "radial-gradient(ellipse at top,#08122d,#030712),radial-gradient(ellipse at bottom,#030712,#030712)",
+      margin: "0 auto",
+      minHeight: "100vh",
+    },
+    ".monoFont": {
+      fontFamily:
+        "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+    },
+    ".ghost": {
+      border: "none",
+      borderRadius: "4px",
+      padding: "4px",
+      margin: "0px",
+      backgroundColor: "transparent",
+      ":hover": {
+        backgroundColor: "rgba(226,232,255,.1)",
+      },
+      input: {
+        maxHeight: "16px",
+        fontFamily:
+          "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+        border: "none",
+        borderRadius: "4px",
+        padding: "4px",
+        margin: "0px",
+        backgroundColor: "transparent",
+      },
+    },
+    ".cellStyle": {
+      border: "1px solid rgba(226,232,255,.1) !important",
+      background: "rgb(12 21 57 / 10%)",
+      flex: 1,
+      borderTopRightRadius: "0px",
+      borderBottomRightRadius: "0px",
+      ":hover": {
+        background: "rgba(255, 255, 255, 0.03) !important",
+      },
+      textarea: {
+        border: "1px solid rgba(226,232,255,.1)",
+        backgroundColor: "#060c21",
+        ":focus": {
+          outline: "solid 1px #ff1cf7 !important",
+          outlineOffset: "-1px",
+        },
+      },
+      ".mantine-InputWrapper-label": {
+        display: "none",
+      },
+    },
+    ".sidePanel": {
+      border: "1px solid rgba(226,232,255,.1)",
+      borderLeft: "none",
+      borderTopRightRadius: "4px",
+      borderBottomRightRadius: "4px",
+      input: {
+        border: "1px solid rgba(226,232,255,.1)",
+        backgroundColor: "#060c21",
+        ":focus": {
+          outline: "solid 1px #ff1cf7 !important",
+          outlineOffset: "-1px",
+        },
+      },
+      textarea: {
+        border: "1px solid rgba(226,232,255,.1)",
+        backgroundColor: "#060c21",
+        ":focus": {
+          outline: "solid 1px #ff1cf7 !important",
+          outlineOffset: "-1px",
+        },
+      },
+    },
+    ".divider": {
+      borderTopWidth: "1px",
+      borderTopColor: "rgba(226,232,255,.1)",
+      marginBottom: "0.5em",
+    },
+    ".runPromptButton": {
+      background: "#ff1cf7",
+      color: "white",
+      height: "auto",
+      "&:hover": {
+        background: "#ff46f8",
+      },
+    },
+    ".actionTabsPanel": {
+      width: "400px",
+    },
+
+    ".parametersContainer": {
+      maxWidth: "1250px",
+      maxHeight: "-webkit-fill-available",
+      margin: "16px auto",
+      padding: "0",
+      backgroundColor: "rgba(226,232,255,.1)",
+      borderRadius: "4px",
+      border: "1px solid rgba(226,232,255,.1) !important",
+      button: {
+        ":hover": {
+          backgroundColor: "rgba(226,232,255,.1)",
+        },
+      },
+      input: {
+        border: "1px solid rgba(226,232,255,.1)",
+        backgroundColor: "#060c21",
+        borderRadius: "4px",
+        ":focus": {
+          outline: "solid 1px #ff1cf7 !important",
+          outlineOffset: "-1px",
+        },
+      },
+      textarea: {
+        border: "1px solid rgba(226,232,255,.1)",
+        backgroundColor: "#060c21",
+        borderRadius: "4px",
+        ":focus": {
+          outline: "solid 1px #ff1cf7 !important",
+          outlineOffset: "-1px",
+        },
+      },
+    },
+    ".addParameterButton": {
+      position: "sticky",
+      left: "0",
+      bottom: "0",
+      margin: "16px 0 0 0",
+      background: "#ff1cf7",
+      "&:hover": {
+        background: "#ff46f8",
+      },
+    },
+    ".mantine-Slider-thumb": {
+      border: "0.25rem solid #ff1cf7",
+      backgroundColor: "white",
+    },
+    ".mantine-Slider-bar": {
+      backgroundColor: "#ff1cf7",
+    },
+    ".mantine-Tabs-tab[data-active]": {
+      borderBottom: "solid 1px #ff1cf7",
+      ":hover": {
+        borderBottom: "solid 1px #ff1cf7",
+      },
+    },
+  }),
+};


### PR DESCRIPTION
# Add 'mode' Prop to AIConfigEditor & Map to Associated Theme

Add an optional 'mode' prop to the AIConfigEditor to use for telemetry and predefined styling (for 'local' editor, 'gradio' or 'vscode') which can be used when we package the editor for external use. I decided to make this optional so that we can support custom styles for external deployments (we can document the classes to use), rather than defaulting to 'local', but we can revisit if we don't want to support that level of customizability.

## Local
![Screenshot 2024-01-16 at 7 14 41 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/b412bb0d-aa8d-49a3-a2ab-e9a9268c6ff4)

## Gradio
![Screenshot 2024-01-16 at 7 14 18 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/ff1d0ae1-efc3-40d2-801b-87140c42c436)

## No Mode
![Screenshot 2024-01-16 at 7 22 56 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/3543e37f-de7b-4fcd-ae27-39c51fe7b2c7)

