### PR TITLE
[AIC-py][eval][1/n] generalize to take params dict input

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,10 +3,11 @@ black
 flake8
 flask-cors
 flask[async]
+frozendict
 google-generativeai
 huggingface_hub
 hypothesis==6.91.0
-lastmile-utils==0.0.20
+lastmile-utils==0.0.21
 mock
 nest_asyncio
 nltk

--- a/python/tests/test_eval.py
+++ b/python/tests/test_eval.py
@@ -9,7 +9,7 @@ import lastmile_utils.lib.core.api as core_utils
 import pandas as pd
 import pytest
 from aiconfig.eval.api import TestSuiteWithInputsSettings, metrics, run_test_suite_outputs_only, run_test_suite_with_inputs
-from aiconfig.eval.lib import MetricList, TestSuiteGeneralSettings, TestSuiteWithInputsSpec, run_test_suite_helper
+from aiconfig.eval.lib import MetricList, TestSuiteGeneralSettings, TestSuiteWithInputsSpec, run_test_suite_helper, text_eval_res_to_df
 from result import Err, Ok
 
 from . import mocks
@@ -154,7 +154,9 @@ async def test_run_test_suite_with_inputs(data: st.DataObject):
         )
     )
 
-    match out:
+    df_out = out.map(text_eval_res_to_df)
+
+    match df_out:
         case Ok(df):
             assert isinstance(df, pd.DataFrame)
             assert df.shape[0] == (len(user_test_suite_with_inputs))


### PR DESCRIPTION
[AIC-py][eval][1/n] generalize to take params dict input

We should be able to take an arbitrary params dict, not just a single input
associated with "{{the_query}}".

This generalizes UserTestSuiteWithInputs to allow a dict, and makes the necessary
internal changes to respect that (while being near-perfectly type safe :D)

lib: unit tests. The tests are pretty thorough, checking dynamic types that are
not checkable statically, and fuzzy testing the possible inputs using
the hypothesis library.


This also affects this script which is not e2e tested, so I did that manually.

run_aiconfig script:

`python -m 'aiconfig.scripts.run_aiconfig' travel_aiconfig_test_suite_settings.json food`

...
```
1. Savour culinary delights at Chelsea Market.
2. Sample diverse food at Smorgasburg weekend market.
3. Explore immersive exhibits at the Museum of Ice Cream.
```
