### PR TITLE
[editor] Fix AddPromptRow Hover Style

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -9,7 +9,6 @@ import {
   Tooltip,
   Alert,
   Group,
-  rem,
 } from "@mantine/core";
 import { Notifications, showNotification } from "@mantine/notifications";
 import {
@@ -137,28 +136,6 @@ export type AIConfigCallbacks = {
 type RequestCallbackError = { message?: string };
 
 const useStyles = createStyles((theme) => ({
-  addPromptRow: {
-    borderRadius: rem(4),
-    display: "flex",
-    justifyContent: "center",
-    align: "center",
-    width: "100%",
-    "&:hover": {
-      backgroundColor:
-        theme.colorScheme === "light"
-          ? theme.colors.gray[1]
-          : "rgba(255, 255, 255, 0.1)",
-    },
-    [theme.fn.smallerThan("sm")]: {
-      marginLeft: "0",
-      display: "block",
-      position: "static",
-      bottom: -10,
-      left: 0,
-      height: 28,
-      margin: "10px 0",
-    },
-  },
   promptsContainer: {
     [theme.fn.smallerThan("sm")]: {
       padding: "0 0 200px 0",
@@ -1019,12 +996,10 @@ export default function AIConfigEditor({
           />
           <Container maw="80rem" className={classes.promptsContainer}>
             {!readOnly && (
-              <div className={classes.addPromptRow}>
-                <AddPromptButton
-                  getModels={callbacks?.getModels}
-                  addPrompt={(model: string) => onAddPrompt(0, model)}
-                />
-              </div>
+              <AddPromptButton
+                getModels={callbacks?.getModels}
+                addPrompt={(model: string) => onAddPrompt(0, model)}
+              />
             )}
             {aiconfigState.prompts.map((prompt: ClientPrompt, i: number) => {
               const isAnotherPromptRunning =
@@ -1054,17 +1029,15 @@ export default function AIConfigEditor({
                     />
                   </Flex>
                   {!readOnly && (
-                    <div className={classes.addPromptRow}>
-                      <AddPromptButton
-                        getModels={callbacks?.getModels}
-                        addPrompt={(model: string) =>
-                          onAddPrompt(
-                            i + 1 /* insert below current prompt index */,
-                            model
-                          )
-                        }
-                      />
-                    </div>
+                    <AddPromptButton
+                      getModels={callbacks?.getModels}
+                      addPrompt={(model: string) =>
+                        onAddPrompt(
+                          i + 1 /* insert below current prompt index */,
+                          model
+                        )
+                      }
+                    />
                   )}
                 </Stack>
               );

--- a/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
@@ -4,6 +4,8 @@ import {
   ScrollArea,
   TextInput,
   Tooltip,
+  createStyles,
+  rem,
 } from "@mantine/core";
 import { IconPlus, IconSearch, IconTextCaption } from "@tabler/icons-react";
 import { memo, useCallback, useState } from "react";
@@ -13,6 +15,31 @@ type Props = {
   addPrompt: (prompt: string) => void;
   getModels?: (search: string) => Promise<string[]>;
 };
+
+const useStyles = createStyles((theme) => ({
+  addPromptRow: {
+    borderRadius: rem(4),
+    display: "flex",
+    justifyContent: "center",
+    align: "center",
+    width: "100%",
+    "&:hover": {
+      backgroundColor:
+        theme.colorScheme === "light"
+          ? theme.colors.gray[1]
+          : "rgba(255, 255, 255, 0.1)",
+    },
+    [theme.fn.smallerThan("sm")]: {
+      marginLeft: "0",
+      display: "block",
+      position: "static",
+      bottom: -10,
+      left: 0,
+      height: 28,
+      margin: "10px 0",
+    },
+  },
+}));
 
 function ModelMenuItems({
   models,
@@ -58,39 +85,42 @@ export default memo(function AddPromptButton({ addPrompt, getModels }: Props) {
   );
 
   const models = useLoadModels(modelSearch, getModels);
+  const { classes } = useStyles();
 
   return (
-    <Menu
-      position="bottom"
-      // Manually maintain open state to support ... expand button
-      closeOnItemClick={false}
-      opened={isOpen}
-      onChange={setIsOpen}
-    >
-      <Menu.Target>
-        <Tooltip label="Add prompt">
-          <ActionIcon w="100%">
-            <IconPlus size={20} />
-          </ActionIcon>
-        </Tooltip>
-      </Menu.Target>
+    <div className={classes.addPromptRow}>
+      <Menu
+        position="bottom"
+        // Manually maintain open state to support ... expand button
+        closeOnItemClick={false}
+        opened={isOpen}
+        onChange={setIsOpen}
+      >
+        <Menu.Target>
+          <Tooltip label="Add prompt">
+            <ActionIcon w="100%">
+              <IconPlus size={20} />
+            </ActionIcon>
+          </Tooltip>
+        </Menu.Target>
 
-      <Menu.Dropdown>
-        <TextInput
-          icon={<IconSearch size="16" />}
-          placeholder="Search"
-          value={modelSearch}
-          onChange={(e) => setModelSearch(e.currentTarget.value)}
-        />
-        <ModelMenuItems
-          models={models ?? []}
-          collapseLimit={5}
-          onSelectModel={onAddPrompt}
-        />
-        {/* TODO: Add back once we have custom model parsers fully supported
+        <Menu.Dropdown>
+          <TextInput
+            icon={<IconSearch size="16" />}
+            placeholder="Search"
+            value={modelSearch}
+            onChange={(e) => setModelSearch(e.currentTarget.value)}
+          />
+          <ModelMenuItems
+            models={models ?? []}
+            collapseLimit={5}
+            onSelectModel={onAddPrompt}
+          />
+          {/* TODO: Add back once we have custom model parsers fully supported
         <Menu.Divider />
         <Menu.Item icon={<IconPlus size="16" />}>Add New Model</Menu.Item> */}
-      </Menu.Dropdown>
-    </Menu>
+        </Menu.Dropdown>
+      </Menu>
+    </div>
   );
 });


### PR DESCRIPTION
# [editor] Fix AddPromptRow Hover Style

I noticed with the refactor for 'mode' with theme, that the hover styles aren't properly applied to the div around AddPromptButton. 

![Screenshot 2024-01-17 at 1 39 50 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/38c75838-f318-49a7-9395-eae1869a5c98)


The reason for this is because we're styling with `useStyles` at the top of AIConfig, which means the styles object is constructed immediately on import of AIConfigEditor. At that point, the `theme` passed into the styles function is the default mantine theme, which takes colorScheme from the system settings. For local editor we are hard-coding colorScheme to dark for now, but that happens within the MantineProvider that is rendered by the AIConfigEditor (so, excludes AIConfigEditor). To fix, we can just move the applicable styles to the AddPromptButton, which is cleaner anyway since they applied to a duplicated 'div' around the button.

<img width="1360" alt="Screenshot 2024-01-17 at 2 03 17 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/3e9a4d68-d09e-4d79-afe9-6bd5b08479ad">


A couple notes:
- this only affected the style due to use of 'theme' prop; the other styles still worked as expected
- this issue actually does not affect the theme.fn.smallerThan("sm") media query because we aren't overriding that in our themes. However, #953 still moves the other style into a new PromptsContainer component so that we don't end up in the same scenario if we change the promptsContainer style to use theme (or override theme.fn.smallerThan)



Note
---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/952).
* #953
* __->__ #952