### PR TITLE
[editor] Move PromptsContainer to its Own Component to Prevent Future useStyles Issues

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -9,7 +9,6 @@ import {
   Tooltip,
   Alert,
   Group,
-  rem,
 } from "@mantine/core";
 import { Notifications, showNotification } from "@mantine/notifications";
 import {
@@ -137,28 +136,6 @@ export type AIConfigCallbacks = {
 type RequestCallbackError = { message?: string };
 
 const useStyles = createStyles((theme) => ({
-  addPromptRow: {
-    borderRadius: rem(4),
-    display: "flex",
-    justifyContent: "center",
-    align: "center",
-    width: "100%",
-    "&:hover": {
-      backgroundColor:
-        theme.colorScheme === "light"
-          ? theme.colors.gray[1]
-          : "rgba(255, 255, 255, 0.1)",
-    },
-    [theme.fn.smallerThan("sm")]: {
-      marginLeft: "0",
-      display: "block",
-      position: "static",
-      bottom: -10,
-      left: 0,
-      height: 28,
-      margin: "10px 0",
-    },
-  },
   promptsContainer: {
     [theme.fn.smallerThan("sm")]: {
       padding: "0 0 200px 0",
@@ -1019,12 +996,10 @@ export default function AIConfigEditor({
           />
           <Container maw="80rem" className={classes.promptsContainer}>
             {!readOnly && (
-              <div className={classes.addPromptRow}>
-                <AddPromptButton
-                  getModels={callbacks?.getModels}
-                  addPrompt={(model: string) => onAddPrompt(0, model)}
-                />
-              </div>
+              <AddPromptButton
+                getModels={callbacks?.getModels}
+                addPrompt={(model: string) => onAddPrompt(0, model)}
+              />
             )}
             {aiconfigState.prompts.map((prompt: ClientPrompt, i: number) => {
               const isAnotherPromptRunning =
@@ -1054,17 +1029,15 @@ export default function AIConfigEditor({
                     />
                   </Flex>
                   {!readOnly && (
-                    <div className={classes.addPromptRow}>
-                      <AddPromptButton
-                        getModels={callbacks?.getModels}
-                        addPrompt={(model: string) =>
-                          onAddPrompt(
-                            i + 1 /* insert below current prompt index */,
-                            model
-                          )
-                        }
-                      />
-                    </div>
+                    <AddPromptButton
+                      getModels={callbacks?.getModels}
+                      addPrompt={(model: string) =>
+                        onAddPrompt(
+                          i + 1 /* insert below current prompt index */,
+                          model
+                        )
+                      }
+                    />
                   )}
                 </Stack>
               );

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -1,9 +1,6 @@
-import PromptContainer from "./prompt/PromptContainer";
 import {
   Container,
   Button,
-  createStyles,
-  Stack,
   Flex,
   Text,
   Tooltip,
@@ -32,21 +29,18 @@ import aiconfigReducer from "../reducers/aiconfigReducer";
 import type { AIConfigReducerAction } from "../reducers/actions";
 import {
   AIConfigEditorMode,
-  ClientPrompt,
   LogEvent,
   LogEventData,
   aiConfigToClientConfig,
   clientConfigToAIConfig,
   clientPromptToAIConfigPrompt,
 } from "../shared/types";
-import AddPromptButton from "./prompt/AddPromptButton";
 import {
   getDefaultNewPromptName,
   getModelSettingsStream,
   getPrompt,
 } from "../utils/aiconfigStateUtils";
 import { debounce, uniqueId } from "lodash";
-import PromptMenuButton from "./prompt/PromptMenuButton";
 import GlobalParametersContainer from "./GlobalParametersContainer";
 import AIConfigContext from "../contexts/AIConfigContext";
 import ConfigNameDescription from "./ConfigNameDescription";
@@ -62,6 +56,7 @@ import {
 import { IconDeviceFloppy } from "@tabler/icons-react";
 import CopyButton from "./CopyButton";
 import AIConfigEditorThemeProvider from "../themes/AIConfigEditorThemeProvider";
+import PromptsContainer from "./prompt/PromptsContainer";
 
 type Props = {
   aiconfig: AIConfig;
@@ -134,15 +129,6 @@ export type AIConfigCallbacks = {
 };
 
 type RequestCallbackError = { message?: string };
-
-const useStyles = createStyles((theme) => ({
-  promptsContainer: {
-    [theme.fn.smallerThan("sm")]: {
-      padding: "0 0 200px 0",
-    },
-    paddingBottom: 400,
-  },
-}));
 
 export default function AIConfigEditor({
   aiconfig: initialAIConfig,
@@ -844,8 +830,6 @@ export default function AIConfigEditor({
     [debouncedSetDescription]
   );
 
-  const { classes } = useStyles();
-
   const getState = useCallback(() => stateRef.current, []);
   const contextValue = useMemo(
     () => ({
@@ -994,55 +978,21 @@ export default function AIConfigEditor({
             initialValue={aiconfigState?.metadata?.parameters ?? {}}
             onUpdateParameters={onUpdateGlobalParameters}
           />
-          <Container maw="80rem" className={classes.promptsContainer}>
-            {!readOnly && (
-              <AddPromptButton
-                getModels={callbacks?.getModels}
-                addPrompt={(model: string) => onAddPrompt(0, model)}
-              />
-            )}
-            {aiconfigState.prompts.map((prompt: ClientPrompt, i: number) => {
-              const isAnotherPromptRunning =
-                runningPromptId !== undefined &&
-                runningPromptId !== prompt._ui.id;
-              return (
-                <Stack key={prompt._ui.id}>
-                  <Flex mt="md">
-                    <PromptMenuButton
-                      promptId={prompt._ui.id}
-                      onDeletePrompt={() => onDeletePrompt(prompt._ui.id)}
-                    />
-                    <PromptContainer
-                      prompt={prompt}
-                      getModels={callbacks?.getModels}
-                      onChangePromptInput={onChangePromptInput}
-                      onChangePromptName={onChangePromptName}
-                      cancel={callbacks?.cancel}
-                      onRunPrompt={onRunPrompt}
-                      onUpdateModel={onUpdatePromptModel}
-                      onUpdateModelSettings={onUpdatePromptModelSettings}
-                      onUpdateParameters={onUpdatePromptParameters}
-                      defaultConfigModelName={
-                        aiconfigState.metadata.default_model
-                      }
-                      isRunButtonDisabled={isAnotherPromptRunning}
-                    />
-                  </Flex>
-                  {!readOnly && (
-                    <AddPromptButton
-                      getModels={callbacks?.getModels}
-                      addPrompt={(model: string) =>
-                        onAddPrompt(
-                          i + 1 /* insert below current prompt index */,
-                          model
-                        )
-                      }
-                    />
-                  )}
-                </Stack>
-              );
-            })}
-          </Container>
+          <PromptsContainer
+            cancelRunPrompt={callbacks?.cancel}
+            defaultModel={aiconfigState.metadata.default_model}
+            getModels={callbacks?.getModels}
+            onAddPrompt={onAddPrompt}
+            onChangePromptInput={onChangePromptInput}
+            onChangePromptName={onChangePromptName}
+            onDeletePrompt={onDeletePrompt}
+            onRunPrompt={onRunPrompt}
+            onUpdatePromptModel={onUpdatePromptModel}
+            onUpdatePromptModelSettings={onUpdatePromptModelSettings}
+            onUpdatePromptParameters={onUpdatePromptParameters}
+            prompts={aiconfigState.prompts}
+            runningPromptId={runningPromptId}
+          />
         </div>
       </AIConfigContext.Provider>
     </AIConfigEditorThemeProvider>

--- a/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
@@ -4,6 +4,8 @@ import {
   ScrollArea,
   TextInput,
   Tooltip,
+  createStyles,
+  rem,
 } from "@mantine/core";
 import { IconPlus, IconSearch, IconTextCaption } from "@tabler/icons-react";
 import { memo, useCallback, useState } from "react";
@@ -13,6 +15,31 @@ type Props = {
   addPrompt: (prompt: string) => void;
   getModels?: (search: string) => Promise<string[]>;
 };
+
+const useStyles = createStyles((theme) => ({
+  addPromptRow: {
+    borderRadius: rem(4),
+    display: "flex",
+    justifyContent: "center",
+    align: "center",
+    width: "100%",
+    "&:hover": {
+      backgroundColor:
+        theme.colorScheme === "light"
+          ? theme.colors.gray[1]
+          : "rgba(255, 255, 255, 0.1)",
+    },
+    [theme.fn.smallerThan("sm")]: {
+      marginLeft: "0",
+      display: "block",
+      position: "static",
+      bottom: -10,
+      left: 0,
+      height: 28,
+      margin: "10px 0",
+    },
+  },
+}));
 
 function ModelMenuItems({
   models,
@@ -58,39 +85,42 @@ export default memo(function AddPromptButton({ addPrompt, getModels }: Props) {
   );
 
   const models = useLoadModels(modelSearch, getModels);
+  const { classes } = useStyles();
 
   return (
-    <Menu
-      position="bottom"
-      // Manually maintain open state to support ... expand button
-      closeOnItemClick={false}
-      opened={isOpen}
-      onChange={setIsOpen}
-    >
-      <Menu.Target>
-        <Tooltip label="Add prompt">
-          <ActionIcon w="100%">
-            <IconPlus size={20} />
-          </ActionIcon>
-        </Tooltip>
-      </Menu.Target>
+    <div className={classes.addPromptRow}>
+      <Menu
+        position="bottom"
+        // Manually maintain open state to support ... expand button
+        closeOnItemClick={false}
+        opened={isOpen}
+        onChange={setIsOpen}
+      >
+        <Menu.Target>
+          <Tooltip label="Add prompt">
+            <ActionIcon w="100%">
+              <IconPlus size={20} />
+            </ActionIcon>
+          </Tooltip>
+        </Menu.Target>
 
-      <Menu.Dropdown>
-        <TextInput
-          icon={<IconSearch size="16" />}
-          placeholder="Search"
-          value={modelSearch}
-          onChange={(e) => setModelSearch(e.currentTarget.value)}
-        />
-        <ModelMenuItems
-          models={models ?? []}
-          collapseLimit={5}
-          onSelectModel={onAddPrompt}
-        />
-        {/* TODO: Add back once we have custom model parsers fully supported
+        <Menu.Dropdown>
+          <TextInput
+            icon={<IconSearch size="16" />}
+            placeholder="Search"
+            value={modelSearch}
+            onChange={(e) => setModelSearch(e.currentTarget.value)}
+          />
+          <ModelMenuItems
+            models={models ?? []}
+            collapseLimit={5}
+            onSelectModel={onAddPrompt}
+          />
+          {/* TODO: Add back once we have custom model parsers fully supported
         <Menu.Divider />
         <Menu.Item icon={<IconPlus size="16" />}>Add New Model</Menu.Item> */}
-      </Menu.Dropdown>
-    </Menu>
+        </Menu.Dropdown>
+      </Menu>
+    </div>
   );
 });

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptsContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptsContainer.tsx
@@ -1,0 +1,97 @@
+import { Container, Flex, Stack, createStyles } from "@mantine/core";
+import { memo, useContext } from "react";
+import AIConfigContext from "../../contexts/AIConfigContext";
+import AddPromptButton from "./AddPromptButton";
+import { ClientPrompt } from "../../shared/types";
+import PromptMenuButton from "./PromptMenuButton";
+import PromptContainer from "./PromptContainer";
+import { JSONObject, PromptInput } from "aiconfig";
+
+type Props = {
+  cancelRunPrompt?: (cancellationToken: string) => Promise<void>;
+  defaultModel?: string;
+  getModels?: (search: string) => Promise<string[]>;
+  onAddPrompt: (promptIndex: number, model: string) => Promise<void>;
+  onChangePromptInput: (
+    promptId: string,
+    newPromptInput: PromptInput
+  ) => Promise<void>;
+  onChangePromptName: (promptId: string, newName: string) => Promise<void>;
+  onDeletePrompt: (promptId: string) => Promise<void>;
+  onRunPrompt: (promptId: string) => Promise<void>;
+  onUpdatePromptModel: (promptId: string, newModel?: string) => Promise<void>;
+  onUpdatePromptModelSettings: (
+    promptId: string,
+    newModelSettings: JSONObject
+  ) => Promise<void>;
+  onUpdatePromptParameters: (
+    promptId: string,
+    newParameters: JSONObject
+  ) => Promise<void>;
+  prompts: ClientPrompt[];
+  runningPromptId?: string;
+};
+
+const useStyles = createStyles((theme) => ({
+  promptsContainer: {
+    [theme.fn.smallerThan("sm")]: {
+      padding: "0 0 200px 0",
+    },
+    paddingBottom: 400,
+  },
+}));
+
+export default memo(function PromptsContainer(props: Props) {
+  const { classes } = useStyles();
+  const { readOnly } = useContext(AIConfigContext);
+
+  return (
+    <Container maw="80rem" className={classes.promptsContainer}>
+      {!readOnly && (
+        <AddPromptButton
+          getModels={props.getModels}
+          addPrompt={(model: string) => props.onAddPrompt(0, model)}
+        />
+      )}
+      {props.prompts.map((prompt: ClientPrompt, i: number) => {
+        const isAnotherPromptRunning =
+          props.runningPromptId !== undefined &&
+          props.runningPromptId !== prompt._ui.id;
+        return (
+          <Stack key={prompt._ui.id}>
+            <Flex mt="md">
+              <PromptMenuButton
+                promptId={prompt._ui.id}
+                onDeletePrompt={() => props.onDeletePrompt(prompt._ui.id)}
+              />
+              <PromptContainer
+                prompt={prompt}
+                getModels={props.getModels}
+                onChangePromptInput={props.onChangePromptInput}
+                onChangePromptName={props.onChangePromptName}
+                cancel={props.cancelRunPrompt}
+                onRunPrompt={props.onRunPrompt}
+                onUpdateModel={props.onUpdatePromptModel}
+                onUpdateModelSettings={props.onUpdatePromptModelSettings}
+                onUpdateParameters={props.onUpdatePromptParameters}
+                defaultConfigModelName={props.defaultModel}
+                isRunButtonDisabled={isAnotherPromptRunning}
+              />
+            </Flex>
+            {!readOnly && (
+              <AddPromptButton
+                getModels={props.getModels}
+                addPrompt={(model: string) =>
+                  props.onAddPrompt(
+                    i + 1 /* insert below current prompt index */,
+                    model
+                  )
+                }
+              />
+            )}
+          </Stack>
+        );
+      })}
+    </Container>
+  );
+});


### PR DESCRIPTION
[editor] Move PromptsContainer to its Own Component to Prevent Future useStyles Issues

See #953 for additional context, but the gist is that this is functionally a no-op, but moving the PromptsContainer div into a component so that useStyles can be used with the correct theme overrides if we do update the styles to leverage theme overrides in the future, rather than re-debugging why it doesn't work from within AIConfigEditor.

## Testing:
- Tested functionality of all actions/callbacks within the editor to make sure everything works as expected
- Ensure the 'sm' styles are applied when my browser window is small:
![Screenshot 2024-01-17 at 2 54 54 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/2432cde3-93f2-446a-a0f5-873122907a0d)



---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/953).
* __->__ #953
* #952