### PR TITLE
[easy][editor][client] 6/n Read-only mode: Global Parameters

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
@@ -10,8 +10,9 @@ import {
 } from "@mantine/core";
 import { IconTrash, IconPlus } from "@tabler/icons-react";
 import { debounce, uniqueId } from "lodash";
-import { useState, useCallback, memo, useMemo } from "react";
+import { memo, useCallback, useContext, useMemo, useState } from 'react';
 import { JSONValue, JSONObject } from "aiconfig";
+import AIConfigContext from "../contexts/AIConfigContext";
 
 type Parameter = { parameterName: string; parameterValue: JSONValue };
 
@@ -36,7 +37,7 @@ const ParameterInput = memo(function ParameterInput(props: {
 }) {
   const { initialItemValue, removeParameter, onUpdateParameter } = props;
   // TODO: saqadri - update this once we have a readonly mode
-  const { isReadonly } = { isReadonly: false };
+  const { readOnly } = useContext(AIConfigContext);
 
   const [parameterName, setParameterName] = useState(
     initialItemValue?.parameterName ?? ""
@@ -79,7 +80,7 @@ const ParameterInput = memo(function ParameterInput(props: {
       <Stack p="xs" spacing="xs" style={{ flexGrow: 1, borderBottom: border }}>
         <TextInput
           placeholder="Enter parameter name"
-          disabled={isReadonly}
+          disabled={readOnly}
           error={
             parameterName && !isValidParameterName(parameterName)
               ? "Name must contain only letters, numbers, and underscores"
@@ -100,7 +101,7 @@ const ParameterInput = memo(function ParameterInput(props: {
         />
         <Textarea
           placeholder="Enter parameter value"
-          disabled={isReadonly}
+          disabled={readOnly}
           radius="md"
           value={parameterValueString}
           autosize
@@ -111,12 +112,12 @@ const ParameterInput = memo(function ParameterInput(props: {
             debouncedCellParameterUpdate(parameterName, event.target.value);
           }}
         />
-        <ActionIcon
+       { !readOnly && <ActionIcon
           onClick={() => removeParameter(parameterName)}
-          disabled={isReadonly}
         >
-          <IconTrash size={16} color={isReadonly ? "grey" : "red"} />
+          <IconTrash size={16} color={"red"} />
         </ActionIcon>
+        }
       </Stack>
     </Group>
   );
@@ -149,8 +150,7 @@ export default memo(function ParametersRenderer(props: {
   maxHeight?: string | number;
 }) {
   const { initialValue, onUpdateParameters } = props;
-  // TODO: saqadri - update this when we have a readonly mode
-  const { isReadonly } = { isReadonly: false }; //useContext(WorkbookContext);
+  const { readOnly } = useContext(AIConfigContext);
 
   const [parameters, setParameters] = useState<ParametersArray>(
     initialValue && Object.keys(initialValue).length > 0
@@ -244,7 +244,7 @@ export default memo(function ParametersRenderer(props: {
           );
         })}
       </Stack>
-      {isReadonly ? null : (
+      {readOnly ? null : (
         <Tooltip label="Add parameter">
           <ActionIcon onClick={addParameter} className="addParameterButton">
             <IconPlus size={16} />


### PR DESCRIPTION
[easy][editor][client] 6/n Read-only mode: Global Parameters






- refactor `isReadonly` -> `readOnly` inside `ParametersRenderer.tsx`
- useState() to get readOnly bool

## Testplan

1. Pass readOnly=True prop in `AIConfigEditor`

| readOnly={false}  | readOnly={true} |
| ------------- | ------------- |
| <img width="981" alt="Screenshot 2024-01-18 at 11 29 08 AM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/07747d6a-37d1-4b00-a5fb-ae8475c19044">  | <img width="1044" alt="Screenshot 2024-01-18 at 11 32 28 AM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/673abdb3-7048-444c-9ba2-8ad746181478"> |

## Dependencies
Built ontop of #939

#961 is next on the stack