### PR TITLE
[editor] Support Updating AIConfig State when aiconfig Prop Changes

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -750,7 +750,7 @@ export default function AIConfigEditor({
         onPromptError(message);
       }
     },
-    [runPromptCallback]
+    [logEventHandler, runPromptCallback]
   );
 
   const setNameCallback = callbacks?.setConfigName;

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -131,7 +131,7 @@ export type AIConfigCallbacks = {
 type RequestCallbackError = { message?: string };
 
 export default function AIConfigEditor({
-  aiconfig: initialAIConfig,
+  aiconfig: providedAIConfig,
   callbacks,
   mode,
   readOnly = false,
@@ -140,8 +140,20 @@ export default function AIConfigEditor({
   const [serverStatus, setServerStatus] = useState<"OK" | "ERROR">("OK");
   const [aiconfigState, dispatch] = useReducer(
     aiconfigReducer,
-    aiConfigToClientConfig(initialAIConfig)
+    aiConfigToClientConfig(providedAIConfig)
   );
+
+  const [prevProvidedConfig, setPrevProvidedConfig] =
+    useState<AIConfig>(providedAIConfig);
+  // After initializing the aiconfigState, we should also support updating the
+  // state if the provided AIConfig changes externally
+  if (prevProvidedConfig !== providedAIConfig) {
+    setPrevProvidedConfig(providedAIConfig);
+    dispatch({
+      type: "PROVIDED_AICONFIG_UPDATE",
+      config: providedAIConfig,
+    });
+  }
 
   const stateRef = useRef(aiconfigState);
   stateRef.current = aiconfigState;

--- a/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
@@ -87,7 +87,7 @@ export default memo(function ConfigNameDescription({
         setInitialFocus("description");
       }
     },
-    []
+    [readOnly]
   );
 
   return (

--- a/python/src/aiconfig/editor/client/src/reducers/actions.ts
+++ b/python/src/aiconfig/editor/client/src/reducers/actions.ts
@@ -12,6 +12,7 @@ export type MutateAIConfigAction =
   | AddPromptAction
   | ClearOutputsAction
   | DeletePromptAction
+  | ProvidedAIConfigUpdateAction
   | SetDescriptionAction
   | SetNameAction
   | UpdatePromptInputAction
@@ -55,6 +56,11 @@ export type ClearOutputsAction = {
 export type DeletePromptAction = {
   type: "DELETE_PROMPT";
   id: string;
+};
+
+export type ProvidedAIConfigUpdateAction = {
+  type: "PROVIDED_AICONFIG_UPDATE";
+  config: AIConfig;
 };
 
 export type SetDescriptionAction = {

--- a/python/src/aiconfig/editor/client/src/utils/api.ts
+++ b/python/src/aiconfig/editor/client/src/utils/api.ts
@@ -1,4 +1,3 @@
-import { url } from "inspector";
 import urlJoin from "url-join";
 
 // For development, run the python server at port 8080


### PR DESCRIPTION
# Support Updating AIConfig State when aiconfig Prop Changes

For gradio, events get dispatched and result in propagating aiconfig updates through a `value` which is passed as a prop to the top-level gradio component. From there, we will need to update the AIConfigEditor state with the updated value (e.g. for outputs after running prompts).

To support that, add a new action, `PROVIDED_AICONFIG_UPDATE` and dispatch it whenever the `aiconfig` prop to AIConfigEditor changes.

## Testing:
Updated LocalEditor to leverage state instead of callbacks for streaming:
```
          output_chunk: (data) => {
            //onStream({ type: "output_chunk", data: data as Output });
            const output = data as Output;
            setAiConfig(
              (prev) =>
                ({
                  ...prev,
                  prompts: prev!.prompts.map((prompt) => {
                    if (prompt.name === "get_activities") {
                      return { ...prompt, outputs: [output] };
                    }
                    return prompt;
                  }),
                } as AIConfig)
            );
          },
          aiconfig_chunk: (data) => {
            //onStream({ type: "aiconfig_chunk", data: data as AIConfig });
            setAiConfig(data as AIConfig);
          },
```

Then ensure streaming works:

https://github.com/lastmile-ai/aiconfig/assets/5060851/f7cfc694-2815-4901-a76c-c0ce5458c462


We'll probably need to handle runningPromptId in a similar way so that the spinners don't show indefinitely in gradio

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/960).
* __->__ #960
* #959