### PR TITLE
Fix UPDATE_MODEL action to retain settings

### DIFF
--- a/python/src/aiconfig/editor/client/src/reducers/aiconfigReducer.ts
+++ b/python/src/aiconfig/editor/client/src/reducers/aiconfigReducer.ts
@@ -167,18 +167,27 @@ export default function aiconfigReducer(
       }));
     }
     case "UPDATE_PROMPT_MODEL": {
-      return reduceReplacePrompt(dirtyState, action.id, (prompt) => ({
-        ...prompt,
-        metadata: {
-          ...prompt.metadata,
-          model: action.modelName
-            ? {
-                name: action.modelName,
-                // TODO: Consolidate settings based on schema union
-              }
-            : undefined,
-        },
-      }));
+      return reduceReplacePrompt(dirtyState, action.id, (prompt) => {
+        // TODO: Consolidate settings based on schema union, server-side
+        // For now, just keep all the settings to match the server-side implementation
+        let modelSettings;
+        const promptModel = prompt.metadata?.model;
+        if (promptModel && typeof promptModel !== "string") {
+          modelSettings = promptModel.settings;
+        }
+        return {
+          ...prompt,
+          metadata: {
+            ...prompt.metadata,
+            model: action.modelName
+              ? {
+                  name: action.modelName,
+                  settings: modelSettings,
+                }
+              : undefined,
+          },
+        };
+      });
     }
     case "UPDATE_PROMPT_MODEL_SETTINGS": {
       return reduceReplacePrompt(dirtyState, action.id, (prompt) => ({


### PR DESCRIPTION
# Fix UPDATE_MODEL action to retain settings

Currently, if you update the model for a prompt all settings are wiped out on the client. On the server (and in sdk), we actually retain all of the settings when the model name changes.

This PR updates the client to match that logic, retaining the existing prompt model settings.


https://github.com/lastmile-ai/aiconfig/assets/5060851/2c0f9c51-1f30-4247-98d4-0caaa59f6de9



In the future, both server/sdk and client should leverage the prompt schemas for the models to retain only the supported settings in order to prevent errors (example client code below for reference)
```
    case "UPDATE_PROMPT_MODEL": {
      return reduceReplacePrompt(dirtyState, action.id, (prompt) => {
        // When updating the model for a prompt, retain existing settings that
        // are supported by the new model (if a schema exists for the new model)
        // or retain all existing settings if the schema is not known
        let modelSettings;
        const existingPromptModel = prompt.metadata?.model;
        if (
          action.modelName &&
          typeof existingPromptModel !== "string" &&
          existingPromptModel?.settings
        ) {
          modelSettings = existingPromptModel.settings;
          const schema = PROMPT_SCHEMAS[action.modelName];

          if (schema) {
            modelSettings = Object.fromEntries(
              Object.entries(modelSettings).filter(
                ([key]) => schema.model_settings?.properties[key] !== undefined
              )
            );
          }
        }

        return {
          ...prompt,
          metadata: {
            ...prompt.metadata,
            model: action.modelName
              ? {
                  name: action.modelName,
                  settings: modelSettings,
                }
              : undefined,
          },
        };
      });
    }
```
