### PR TITLE
[editor] Default Theme ColorScheme to Match User System Settings

### DIFF
--- a/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
+++ b/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
@@ -3,6 +3,8 @@ import { AIConfigEditorMode } from "../shared/types";
 import { LOCAL_THEME } from "./LocalTheme";
 import { GRADIO_THEME } from "./GradioTheme";
 import ConditionalWrapper from "../components/ConditionalWrapper";
+import { useColorScheme } from "@mantine/hooks";
+import { useMemo } from "react";
 
 type Props = {
   children: React.ReactNode;
@@ -17,15 +19,20 @@ const THEMES = {
 };
 
 export default function AIConfigEditorThemeProvider({ children, mode }: Props) {
+  const preferredColorScheme = useColorScheme();
+  const theme = useMemo(
+    () => ({
+      colorScheme: preferredColorScheme,
+      ...THEMES[mode!],
+    }),
+    [mode, preferredColorScheme]
+  );
+
   return (
     <ConditionalWrapper
       condition={mode != null}
       wrapper={(children) => (
-        <MantineProvider
-          withGlobalStyles
-          withNormalizeCSS
-          theme={THEMES[mode!]}
-        >
+        <MantineProvider withGlobalStyles withNormalizeCSS theme={theme}>
           {children}
         </MantineProvider>
       )}


### PR DESCRIPTION
# [editor] Default Theme ColorSchema to Match User System Settings

The theme is always light by default unless passing in a colorScheme. We need to use this mantine hook `useColorScheme` which does the media query for system (browser) settings, same as in lastmile.

## Testing:
- Ensure local editor remains the same for branding, regardless of system color theme:
![Screenshot 2024-01-18 at 5 31 54 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/d44844ef-acf2-4025-bed9-3f6b7dc1be77)
![Screenshot 2024-01-18 at 5 32 51 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/ea48c670-2a03-41ca-a4aa-0aa26f7b285c)


- Ensure gradio properly reflects system theme now:
![Screenshot 2024-01-18 at 5 31 04 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/71e7d9fb-634a-41e1-9776-c520084b0ebc)
![Screenshot 2024-01-18 at 5 32 13 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/a0d4d7bb-06a5-4e8d-9794-53a28a47c97b)

