### PR TITLE
[easy][editor][client] 6/n Read-only mode: Global Parameters

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
@@ -10,7 +10,7 @@ import {
 } from "@mantine/core";
 import { IconTrash, IconPlus } from "@tabler/icons-react";
 import { debounce, uniqueId } from "lodash";
-import { useState, useCallback, memo, useMemo, useContext } from "react";
+import { memo, useCallback, useContext, useMemo, useState } from 'react';
 import { JSONValue, JSONObject } from "aiconfig";
 import AIConfigContext from "../contexts/AIConfigContext";
 


### PR DESCRIPTION
[easy][editor][client] 6/n Read-only mode: Global Parameters







- refactor `isReadonly` -> `readOnly` inside `ParametersRenderer.tsx`
- useState() to get readOnly bool

## Testplan

1. Pass readOnly=True prop in `AIConfigEditor`

| readOnly={false}  | readOnly={true} |
| ------------- | ------------- |
| <img width="981" alt="Screenshot 2024-01-18 at 11 29 08 AM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/07747d6a-37d1-4b00-a5fb-ae8475c19044">  | <img width="1044" alt="Screenshot 2024-01-18 at 11 32 28 AM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/673abdb3-7048-444c-9ba2-8ad746181478"> |

## Dependencies
Built ontop of #939

#961 is next on the stack

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/967).
* #962
* __->__ #967