### PR TITLE
Change typo in huggingface-hub imports, remove pinned deps from llama-guard

### DIFF
--- a/extensions/HuggingFace/python/requirements.txt
+++ b/extensions/HuggingFace/python/requirements.txt
@@ -6,7 +6,7 @@ pylint
 python-aiconfig
 
 #Hugging Face Libraries - Remote Infernce Client 
-huggingface_hub
+huggingface-hub
 
 #Hugging Face Libraries - Local Inference Tranformers & Diffusors
 accelerate # Used to help speed up image generation

--- a/extensions/LLama-Guard/python/requirements.txt
+++ b/extensions/LLama-Guard/python/requirements.txt
@@ -1,7 +1,7 @@
 #Hugging Face Transformers
-accelerate==0.25.0
-transformers==4.35.2
-torch==2.1.0
+accelerate
+transformers
+torch
 
 #Other
 asyncio

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,7 @@ flask-cors
 flask[async]
 frozendict
 google-generativeai
-huggingface_hub
+huggingface-hub
 hypothesis==6.91.0
 lastmile-utils==0.0.21
 mock


### PR DESCRIPTION
Change typo in huggingface-hub imports, remove pinned deps from llama-guard

Got some issues before:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
aiconfig-extension-llama-guard 0.0.2 requires torch==2.1.0, but you have torch 2.1.2 which is incompatible.
aiconfig-extension-llama-guard 0.0.2 requires transformers==4.35.2, but you have transformers 4.36.2 which is incompatible.
```

Which are now fixed.


Also the `huggingface_hub` lib package uses hypen, not underscore: https://pypi.org/project/huggingface-hub/

## Test Plan
Ran the HuggingFace cookbook:
```bash
rossdancraig@Rossdans-MBP aiconfig % cd /Users/rossdancraig/Projects/aiconfig/cookbooks/HuggingFace/python               
rossdancraig@Rossdans-MBP python % python /Users/rossdancraig/Projects/aiconfig/cookbooks/HuggingFace/python/ask-mistral.py
/Users/rossdancraig/.pyenv/versions/3.11.6/lib/python3.11/site-packages/pydantic/_internal/_fields.py:128: UserWarning: Field "model_parsers" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(


Mustard is what keeps sandwiches together. Ketchup is an essential to a%
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/998).
* #1001
* __->__ #998