### PR TITLE
[hf inference] Update HuggingFaceTextGenerationParser to support api_token in InferenceOptions

### DIFF
--- a/cookbooks/Gradio/README.md
+++ b/cookbooks/Gradio/README.md
@@ -32,6 +32,7 @@ We have started by supporting the 6 most popular Hugging Face tasks (by number o
 In addition we support the following **HF inference API**:
 
 - text generation
+- text summarization
 
 ### Gradio custom component
 

--- a/extensions/HuggingFace/python/README.md
+++ b/extensions/HuggingFace/python/README.md
@@ -5,13 +5,13 @@ This extension contains AIConfig model parsers with two main subfolders:
 
 ## Usage
 
-### Part 1: Update and test this extention
+### Part 1: Update and test this extension
 
 If you are not testing locally (just using the published extension), ignore this and go to Part 2
 
-1. From the `aiconfig/HuggingFace`, run this command: `pip3 install build && cd python && python -m build && pip3 install dist/*.whl`
+1. From the `aiconfig/extensions/HuggingFace`, run this command: `pip3 install build && cd python && python -m build && pip3 install dist/*.whl`
 2. Link your local dev environment to the current dir: `pip3 install -e .`. Afterwards if you do `pip3 list | grep aiconfig`, you should see this linked to your local path. If you ever wish to use the published extension, you will need to first remove the extension: `pip3 uninstall aiconfig-extension-hugging-face && pip3 install aiconfig-extension-hugging-face`
-3. After you're done testing, be sure to delete the generated folder(s) in the `aiconfig/HuggingFace` dir. It'll probalby look something like `python/dist` and `python/<package_name>.egg-info`
+3. After you're done testing, be sure to delete the generated folder(s) in the `aiconfig/HuggingFace` dir. It'll probably look something like `python/dist` and `python/<package_name>.egg-info`
 
 ### Part 2: Importing and using this extension
 

--- a/extensions/HuggingFace/python/requirements.txt
+++ b/extensions/HuggingFace/python/requirements.txt
@@ -6,7 +6,7 @@ pylint
 python-aiconfig
 
 #Hugging Face Libraries - Remote Infernce Client 
-huggingface-hub
+huggingface-hub>=0.20.3
 
 #Hugging Face Libraries - Local Inference Tranformers & Diffusors
 accelerate # Used to help speed up image generation

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/__init__.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/__init__.py
@@ -17,6 +17,9 @@ from .local_inference.util import get_hf_model
 from .remote_inference_client.text_generation import (
     HuggingFaceTextGenerationParser,
 )
+from .remote_inference_client.text_summarization import (
+    HuggingFaceTextSummarizationParser,
+)
 
 UTILS = [get_hf_model]
 
@@ -29,5 +32,8 @@ LOCAL_INFERENCE_CLASSES = [
     "HuggingFaceTextSummarizationTransformer",
     "HuggingFaceTextTranslationTransformer",
 ]
-REMOTE_INFERENCE_CLASSES = ["HuggingFaceTextGenerationParser"]
+REMOTE_INFERENCE_CLASSES = [
+    "HuggingFaceTextGenerationParser",
+    "HuggingFaceTextSummarizationParser",
+]
 __ALL__ = LOCAL_INFERENCE_CLASSES + REMOTE_INFERENCE_CLASSES + UTILS

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/__init__.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/__init__.py
@@ -20,6 +20,9 @@ from .remote_inference_client.text_generation import (
 from .remote_inference_client.text_summarization import (
     HuggingFaceTextSummarizationParser,
 )
+from .remote_inference_client.text_translation import (
+    HuggingFaceTextTranslationParser,
+)
 
 UTILS = [get_hf_model]
 
@@ -35,5 +38,6 @@ LOCAL_INFERENCE_CLASSES = [
 REMOTE_INFERENCE_CLASSES = [
     "HuggingFaceTextGenerationParser",
     "HuggingFaceTextSummarizationParser",
+    "HuggingFaceTextTranslationParser",
 ]
 __ALL__ = LOCAL_INFERENCE_CLASSES + REMOTE_INFERENCE_CLASSES + UTILS

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_summarization.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_summarization.py
@@ -1,0 +1,310 @@
+import copy
+import json
+from typing import TYPE_CHECKING, Any, List, Optional
+
+# HuggingFace API imports
+from huggingface_hub import InferenceClient
+
+from aiconfig import CallbackEvent
+from aiconfig.default_parsers.parameterized_model_parser import (
+    ParameterizedModelParser,
+)
+from aiconfig.model_parser import InferenceOptions
+from aiconfig.schema import (
+    ExecuteResult,
+    Output,
+    Prompt,
+    PromptMetadata,
+)
+from aiconfig.util.config_utils import get_api_key_from_environment
+from aiconfig.util.params import resolve_prompt
+
+
+# Circuluar Dependency Type Hints
+if TYPE_CHECKING:
+    from aiconfig.Config import AIConfigRuntime
+
+
+# Step 1: define Helpers
+def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
+    """
+    Refines the completion params for the HF text summarization api. Removes any unsupported params.
+    See https://huggingface.co/docs/api-inference/detailed_parameters#summarization-task for supported params.
+    """
+
+    supported_keys = {
+        "model",
+        # "parameters" will contain dict of remaining completion params, see parameters_keys
+    }
+
+    parameters_keys = {
+        "min_length",
+        "max_length",
+        "top_k",
+        "top_p",
+        "temperature",
+        "repetition_penalty",
+        "max_time",
+        "options",  # sub-dict containing use_cache, wait_for_model (all optional)
+    }
+
+    completion_data = {}
+    for key in model_settings:
+        if key.lower() in supported_keys:
+            completion_data[key.lower()] = model_settings[key]
+        elif key.lower() in parameters_keys:
+            parameters = completion_data.get("parameters", {})
+            parameters[key.lower()] = model_settings[key]
+            completion_data["parameters"] = parameters
+
+    return completion_data
+
+
+def construct_output(response: str) -> Output:
+    metadata: dict[str, str] = {"raw_response": response}
+
+    output = ExecuteResult(
+        **{
+            "output_type": "execute_result",
+            "data": response,
+            "execution_count": 0,
+            "metadata": metadata,
+        }
+    )
+    return output
+
+
+class HuggingFaceTextSummarizationParser(ParameterizedModelParser):
+    """
+    A model parser for HuggingFace text summarization models.
+    """
+
+    def __init__(self, model_id: str = None, use_api_token=False):
+        """
+        Args:
+            model_id (str): The model ID of the model to use.
+            no_token (bool): Whether or not to require an API token. Set to False if you don't have an api key.
+
+        Returns:
+            HuggingFaceTextSummarizationParser: The HuggingFaceTextSummarizationParser object.
+
+        Usage:
+
+        1. Create a new model parser object with the model ID of the model to use.
+                parser = HuggingFaceTextSummarizationParser("facebook/bart-large-cnn", use_api_token=False)
+        2. Add the model parser to the registry.
+                config.register_model_parser(parser)
+
+        If use_api_token is set to True, then the model parser will require an API token to be set in the environment variable HUGGING_FACE_API_TOKEN.
+
+
+        """
+        super().__init__()
+
+        token = None
+
+        if use_api_token:
+            # You are allowed to use Hugging Face for a bit before you get
+            # rate limited, in which case you will receive a clear error
+            token = get_api_key_from_environment(
+                "HUGGING_FACE_API_TOKEN", required=False
+            ).unwrap()
+
+        self.client = InferenceClient(model_id, token=token)
+
+    def id(self) -> str:
+        """
+        Returns an identifier for the Model Parser
+        """
+        return "HuggingFaceTextSummarizationParser"
+
+    async def serialize(
+        self,
+        prompt_name: str,
+        data: Any,
+        ai_config: "AIConfigRuntime",
+        parameters: Optional[dict[Any, Any]] = None,
+        **kwargs,
+    ) -> list[Prompt]:
+        """
+        Defines how a prompt and model inference settings get serialized in the .aiconfig.
+
+        Args:
+            prompt (str): The prompt to be serialized.
+            inference_settings (dict): Model-specific inference settings to be serialized.
+
+        Returns:
+            str: Serialized representation of the prompt and inference settings.
+        """
+        await ai_config.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_serialize_start",
+                __name__,
+                {
+                    "prompt_name": prompt_name,
+                    "data": data,
+                    "parameters": parameters,
+                    "kwargs": kwargs,
+                },
+            )
+        )
+
+        # assume data is completion params for HF text generation
+        prompt_input = data["text"]
+
+        # actual completion params are nested under 'parameters' key, so
+        # extract them and merge them with the rest of the settings
+        settings = copy.deepcopy(data)
+        if "parameters" in settings:
+            completion_params = settings["parameters"]
+            settings.update(completion_params)
+            settings.pop("parameters", None)
+
+        # text is handled, remove from settings
+        settings.pop("text", None)
+
+        prompts = []
+
+        model_metadata = ai_config.get_model_metadata(settings, self.id())
+        prompt = Prompt(
+            name=prompt_name,
+            input=prompt_input,
+            metadata=PromptMetadata(
+                model=model_metadata, parameters=parameters, **kwargs
+            ),
+        )
+
+        prompts.append(prompt)
+
+        await ai_config.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_serialize_complete", __name__, {"result": prompts}
+            )
+        )
+
+        return prompts
+
+    async def deserialize(
+        self,
+        prompt: Prompt,
+        aiconfig: "AIConfigRuntime",
+        params: Optional[dict[Any, Any]] = {},
+    ) -> dict[Any, Any]:
+        """
+        Defines how to parse a prompt in the .aiconfig for a particular model
+        and constructs the completion params for that model.
+
+        Args:
+            serialized_data (str): Serialized data from the .aiconfig.
+
+        Returns:
+            dict: Model-specific completion parameters.
+        """
+        await aiconfig.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_deserialize_start",
+                __name__,
+                {"prompt": prompt, "params": params},
+            )
+        )
+
+        resolved_prompt = resolve_prompt(prompt, params, aiconfig)
+
+        # Build Completion data
+        model_settings = self.get_model_settings(prompt, aiconfig)
+
+        completion_data = refine_completion_params(model_settings)
+
+        completion_data["text"] = resolved_prompt
+
+        await aiconfig.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_deserialize_complete",
+                __name__,
+                {"output": completion_data},
+            )
+        )
+
+        return completion_data
+
+    async def run_inference(
+        self,
+        prompt: Prompt,
+        aiconfig: "AIConfigRuntime",
+        options: InferenceOptions,
+        parameters: dict[Any, Any],
+    ) -> List[Output]:
+        """
+        Invoked to run a prompt in the .aiconfig. This method should perform
+        the actual model inference based on the provided prompt and inference settings.
+
+        Args:
+            prompt (str): The input prompt.
+            inference_settings (dict): Model-specific inference settings.
+
+        Returns:
+            InferenceResponse: The response from the model.
+        """
+        sanitized_options = copy.deepcopy(options)
+        run_override_api_token = getattr(sanitized_options, "api_token", None)
+        # Redact api token from logs if it exists
+        if run_override_api_token:
+            setattr(sanitized_options, "api_token", "hf_********")
+
+        await aiconfig.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_run_start",
+                __name__,
+                {
+                    "prompt": prompt,
+                    "options": sanitized_options,
+                    "parameters": parameters,
+                },
+            )
+        )
+
+        # Summarization api doesn't support stream
+        completion_data = await self.deserialize(prompt, aiconfig, parameters)
+
+        # If api token is provided in the options, use it for the client
+        client = self.client
+        if run_override_api_token:
+            client = InferenceClient(
+                self.client.model, token=run_override_api_token
+            )
+
+        response = client.summarization(**completion_data)
+
+        # HF Text Summarization api doesn't support multiple outputs. Expect only one output.
+        # Output spec: response is literal string
+        outputs = [construct_output(response)]
+
+        prompt.outputs = outputs
+
+        await aiconfig.callback_manager.run_callbacks(
+            CallbackEvent("on_run_complete", __name__, {"result": outputs})
+        )
+
+        return outputs
+
+    def get_output_text(
+        self,
+        prompt: Prompt,
+        aiconfig: "AIConfigRuntime",
+        output: Optional[Output] = None,
+    ) -> str:
+        if not output:
+            output = aiconfig.get_latest_output(prompt)
+
+        if not output:
+            return ""
+
+        if output.output_type == "execute_result":
+            output_data = output.data
+            if isinstance(output_data, str):
+                return output_data
+
+            # HuggingFace summarization outputs should only ever be string
+            # format so shouldn't get here, but just being safe
+            return json.dumps(output_data, indent=2)
+        return ""

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_translation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_translation.py
@@ -1,0 +1,291 @@
+import copy
+import json
+from typing import TYPE_CHECKING, Any, List, Optional
+
+# HuggingFace API imports
+from huggingface_hub import InferenceClient
+
+from aiconfig import CallbackEvent
+from aiconfig.default_parsers.parameterized_model_parser import (
+    ParameterizedModelParser,
+)
+from aiconfig.model_parser import InferenceOptions
+from aiconfig.schema import (
+    ExecuteResult,
+    Output,
+    Prompt,
+    PromptMetadata,
+)
+from aiconfig.util.config_utils import get_api_key_from_environment
+from aiconfig.util.params import resolve_prompt
+
+
+# Circuluar Dependency Type Hints
+if TYPE_CHECKING:
+    from aiconfig.Config import AIConfigRuntime
+
+
+# Step 1: define Helpers
+def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
+    """
+    Refines the completion params for the HF text translation api. Removes any unsupported params.
+    See https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/inference/_client.py#L1703
+    for supported params. Note that client params DO NOT match API docs here:
+    https://huggingface.co/docs/api-inference/detailed_parameters#translation-task
+    """
+
+    supported_keys = {
+        "model",
+        "src_lang",
+        "tgt_lang",
+    }
+
+    completion_data = {}
+    for key in model_settings:
+        if key.lower() in supported_keys:
+            completion_data[key.lower()] = model_settings[key]
+
+    return completion_data
+
+
+def construct_output(response: str) -> Output:
+    metadata: dict[str, str] = {"raw_response": response}
+
+    output = ExecuteResult(
+        **{
+            "output_type": "execute_result",
+            "data": response,
+            "execution_count": 0,
+            "metadata": metadata,
+        }
+    )
+    return output
+
+
+class HuggingFaceTextTranslationParser(ParameterizedModelParser):
+    """
+    A model parser for HuggingFace text translation models.
+    """
+
+    def __init__(self, model_id: str = None, use_api_token=False):
+        """
+        Args:
+            model_id (str): The model ID of the model to use.
+            no_token (bool): Whether or not to require an API token. Set to False if you don't have an api key.
+
+        Returns:
+            HuggingFaceTextTranslationParser: The HuggingFaceTextTranslationParser object.
+
+        Usage:
+
+        1. Create a new model parser object with the model ID of the model to use.
+                parser = HuggingFaceTextTranslationParser("Helsinki-NLP/opus-mt-en-zh", use_api_token=False)
+        2. Add the model parser to the registry.
+                config.register_model_parser(parser)
+
+        If use_api_token is set to True, then the model parser will require an API token to be set in the environment variable HUGGING_FACE_API_TOKEN.
+
+
+        """
+        super().__init__()
+
+        token = None
+
+        if use_api_token:
+            # You are allowed to use Hugging Face for a bit before you get
+            # rate limited, in which case you will receive a clear error
+            token = get_api_key_from_environment(
+                "HUGGING_FACE_API_TOKEN", required=False
+            ).unwrap()
+
+        self.client = InferenceClient(model_id, token=token)
+
+    def id(self) -> str:
+        """
+        Returns an identifier for the Model Parser
+        """
+        return "HuggingFaceTextTranslationParser"
+
+    async def serialize(
+        self,
+        prompt_name: str,
+        data: Any,
+        ai_config: "AIConfigRuntime",
+        parameters: Optional[dict[Any, Any]] = None,
+        **kwargs,
+    ) -> list[Prompt]:
+        """
+        Defines how a prompt and model inference settings get serialized in the .aiconfig.
+
+        Args:
+            prompt (str): The prompt to be serialized.
+            inference_settings (dict): Model-specific inference settings to be serialized.
+
+        Returns:
+            str: Serialized representation of the prompt and inference settings.
+        """
+        await ai_config.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_serialize_start",
+                __name__,
+                {
+                    "prompt_name": prompt_name,
+                    "data": data,
+                    "parameters": parameters,
+                    "kwargs": kwargs,
+                },
+            )
+        )
+
+        # assume data is completion params for HF text translation
+        data = copy.deepcopy(data)
+        prompt_input = data["text"]
+
+        # text is handled, remove from data
+        data.pop("text", None)
+
+        prompts = []
+
+        model_metadata = ai_config.get_model_metadata(settings, self.id())
+        prompt = Prompt(
+            name=prompt_name,
+            input=prompt_input,
+            metadata=PromptMetadata(
+                model=model_metadata, parameters=parameters, **kwargs
+            ),
+        )
+
+        prompts.append(prompt)
+
+        await ai_config.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_serialize_complete", __name__, {"result": prompts}
+            )
+        )
+
+        return prompts
+
+    async def deserialize(
+        self,
+        prompt: Prompt,
+        aiconfig: "AIConfigRuntime",
+        params: Optional[dict[Any, Any]] = {},
+    ) -> dict[Any, Any]:
+        """
+        Defines how to parse a prompt in the .aiconfig for a particular model
+        and constructs the completion params for that model.
+
+        Args:
+            serialized_data (str): Serialized data from the .aiconfig.
+
+        Returns:
+            dict: Model-specific completion parameters.
+        """
+        await aiconfig.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_deserialize_start",
+                __name__,
+                {"prompt": prompt, "params": params},
+            )
+        )
+
+        resolved_prompt = resolve_prompt(prompt, params, aiconfig)
+
+        # Build Completion data
+        model_settings = self.get_model_settings(prompt, aiconfig)
+
+        completion_data = refine_completion_params(model_settings)
+
+        completion_data["text"] = resolved_prompt
+
+        await aiconfig.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_deserialize_complete",
+                __name__,
+                {"output": completion_data},
+            )
+        )
+
+        return completion_data
+
+    async def run_inference(
+        self,
+        prompt: Prompt,
+        aiconfig: "AIConfigRuntime",
+        options: InferenceOptions,
+        parameters: dict[Any, Any],
+    ) -> List[Output]:
+        """
+        Invoked to run a prompt in the .aiconfig. This method should perform
+        the actual model inference based on the provided prompt and inference settings.
+
+        Args:
+            prompt (str): The input prompt.
+            inference_settings (dict): Model-specific inference settings.
+
+        Returns:
+            InferenceResponse: The response from the model.
+        """
+        sanitized_options = copy.deepcopy(options)
+        run_override_api_token = getattr(sanitized_options, "api_token", None)
+        # Redact api token from logs if it exists
+        if run_override_api_token:
+            setattr(sanitized_options, "api_token", "hf_********")
+
+        await aiconfig.callback_manager.run_callbacks(
+            CallbackEvent(
+                "on_run_start",
+                __name__,
+                {
+                    "prompt": prompt,
+                    "options": sanitized_options,
+                    "parameters": parameters,
+                },
+            )
+        )
+
+        # Translation api doesn't support stream
+        completion_data = await self.deserialize(prompt, aiconfig, parameters)
+
+        # If api token is provided in the options, use it for the client
+        client = self.client
+        if run_override_api_token:
+            client = InferenceClient(
+                self.client.model, token=run_override_api_token
+            )
+
+        response = client.translation(**completion_data)
+
+        # HF Text Translation api doesn't support multiple outputs. Expect only one output.
+        # Output spec: response is literal string
+        outputs = [construct_output(response)]
+
+        prompt.outputs = outputs
+
+        await aiconfig.callback_manager.run_callbacks(
+            CallbackEvent("on_run_complete", __name__, {"result": outputs})
+        )
+
+        return outputs
+
+    def get_output_text(
+        self,
+        prompt: Prompt,
+        aiconfig: "AIConfigRuntime",
+        output: Optional[Output] = None,
+    ) -> str:
+        if not output:
+            output = aiconfig.get_latest_output(prompt)
+
+        if not output:
+            return ""
+
+        if output.output_type == "execute_result":
+            output_data = output.data
+            if isinstance(output_data, str):
+                return output_data
+
+            # HuggingFace translation outputs should only ever be string
+            # format so shouldn't get here, but just being safe
+            return json.dumps(output_data, indent=2)
+        return ""

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextSummarizationParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextSummarizationParserPromptSchema.ts
@@ -1,0 +1,69 @@
+import { PromptSchema } from "../../utils/promptUtils";
+
+export const HuggingFaceTextSummarizationParserPromptSchema: PromptSchema = {
+  // See https://huggingface.co/docs/api-inference/detailed_parameters#summarization-task for supported params.
+  // The settings below are supported settings specified in the HuggingFaceTextSummarizationParser
+  // refine_completion_params implementation.
+  input: {
+    type: "string",
+  },
+  model_settings: {
+    type: "object",
+    properties: {
+      model: {
+        type: "string",
+        description: `Hugging Face model to use`,
+      },
+      min_length: {
+        type: "integer",
+        description: `Integer to define the minimum length in tokens of the output summary.`,
+      },
+      max_length: {
+        type: "integer",
+        description: `Integer to define the maximum length in tokens of the output summary.`,
+      },
+      top_k: {
+        type: "integer",
+        description: `Integer to define the top tokens considered within the sample operation to create new text.`,
+      },
+      top_p: {
+        type: "number",
+        description: `Float to define the tokens that are within the sample operation of text generation. 
+        Add tokens in the sample for more probable to least probable until the sum of the probabilities is greater than top_p.`,
+      },
+      temperature: {
+        type: "number",
+        minimum: 0,
+        maximum: 100,
+        description: `The temperature of the sampling operation. 1 means regular sampling, 0 means always take the highest score, 
+        100.0 is getting closer to uniform probability.`,
+      },
+      repetition_penalty: {
+        type: "number",
+        minimum: 0,
+        maximum: 100,
+        description: `The more a token is used within generation the more it is penalized to not be picked in successive generation passes.`,
+      },
+      max_time: {
+        type: "number",
+        minimum: 0,
+        maximum: 120,
+        description: `The amount of time in seconds that the query should take maximum. 
+        Network can cause some overhead so it will be a soft limit.`,
+      },
+      use_cache: {
+        type: "boolean",
+        description: `There is a cache layer on the inference API to speedup requests we have already seen. 
+        Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). 
+        However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used 
+        resulting in a real new query.`,
+      },
+      wait_for_model: {
+        type: "boolean",
+        description: `If the model is not ready, wait for it instead of receiving 503. 
+        It limits the number of requests required to get your inference done. 
+        It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.`,
+      },
+    },
+  },
+};

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextTranslationParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextTranslationParserPromptSchema.ts
@@ -1,0 +1,30 @@
+import { PromptSchema } from "../../utils/promptUtils";
+
+export const HuggingFaceTextTranslationParserPromptSchema: PromptSchema = {
+  // See https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/inference/_client.py#L1704
+  // for supported params.
+  // The settings below are supported settings specified in the HuggingFaceTextTranslationParser
+  // refine_completion_params implementation.
+  input: {
+    type: "string",
+  },
+  model_settings: {
+    type: "object",
+    properties: {
+      model: {
+        type: "string",
+        description: `Hugging Face model to use`,
+      },
+      src_lang: {
+        type: "string",
+        description: `The source language of the text to translate, if the model supports multiple languages. 
+        Must be in locale format supported by the model (e.g. en_XX, fr_XX, etc.)`,
+      },
+      tgt_lang: {
+        type: "string",
+        description: `The target language of the translation, if the model supports multiple languages. 
+        Must be in locale format supported by the model (e.g. en_XX, fr_XX, etc.)`,
+      },
+    },
+  },
+};

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -13,6 +13,7 @@ import { HuggingFaceTextGenerationTransformerPromptSchema } from "../shared/prom
 import { HuggingFaceTextSummarizationTransformerPromptSchema } from "../shared/prompt_schemas/HuggingFaceTextSummarizationTransformerPromptSchema";
 import { HuggingFaceTextGenerationParserPromptSchema } from "../shared/prompt_schemas/HuggingFaceTextGenerationParserPromptSchema";
 import { HuggingFaceTextSummarizationParserPromptSchema } from "../shared/prompt_schemas/HuggingFaceTextSummarizationParserPromptSchema";
+import { HuggingFaceTextTranslationParserPromptSchema } from "../shared/prompt_schemas/HuggingFaceTextTranslationParserPromptSchema";
 
 /**
  * Get the name of the model for the specified prompt. The name will either be specified in the prompt's
@@ -80,8 +81,12 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   // hf core parser and keep it in the extension instead
   // HuggingFaceTextGenerationParser (Core parser and remote inference extension)
   HuggingFaceTextGenerationParser: HuggingFaceTextGenerationParserPromptSchema,
+
   HuggingFaceTextSummarizationParser:
     HuggingFaceTextSummarizationParserPromptSchema,
+
+  HuggingFaceTextTranslationParser:
+    HuggingFaceTextTranslationParserPromptSchema,
 
   // PaLMTextParser
   "models/text-bison-001": PaLMTextParserPromptSchema,

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -12,6 +12,7 @@ import { HuggingFaceText2SpeechTransformerPromptSchema } from "../shared/prompt_
 import { HuggingFaceTextGenerationTransformerPromptSchema } from "../shared/prompt_schemas/HuggingFaceTextGenerationTransformerPromptSchema";
 import { HuggingFaceTextSummarizationTransformerPromptSchema } from "../shared/prompt_schemas/HuggingFaceTextSummarizationTransformerPromptSchema";
 import { HuggingFaceTextGenerationParserPromptSchema } from "../shared/prompt_schemas/HuggingFaceTextGenerationParserPromptSchema";
+import { HuggingFaceTextSummarizationParserPromptSchema } from "../shared/prompt_schemas/HuggingFaceTextSummarizationParserPromptSchema";
 
 /**
  * Get the name of the model for the specified prompt. The name will either be specified in the prompt's
@@ -79,6 +80,8 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   // hf core parser and keep it in the extension instead
   // HuggingFaceTextGenerationParser (Core parser and remote inference extension)
   HuggingFaceTextGenerationParser: HuggingFaceTextGenerationParserPromptSchema,
+  HuggingFaceTextSummarizationParser:
+    HuggingFaceTextSummarizationParserPromptSchema,
 
   // PaLMTextParser
   "models/text-bison-001": PaLMTextParserPromptSchema,


### PR DESCRIPTION
[hf inference] Update HuggingFaceTextGenerationParser to support api_token in InferenceOptions

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1006).
* __->__ #1006
* #1005
* #1004
* #1003
* #997
* #993
* #992