### PR TITLE
[hf inference] Prompt Schema ASR

### DIFF
--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema.ts
@@ -1,0 +1,42 @@
+import { PromptSchema } from "../../utils/promptUtils";
+
+export const HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema: PromptSchema = {
+  // See https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/inference/_client.py#L302for supported params.
+  // The settings below are supported settings specified in the HuggingFaceAutomaticSpeechRecognitionRemoteInference refine_completion_params implementation.
+  input: {
+    type: "object",
+    required: ["attachments"],
+    properties: {
+      attachments: {
+        type: "array",
+        items: {
+          type: "attachment",
+          required: ["data"],
+          mime_types: [
+            "audio/mpeg",
+            "audio/wav",
+            "audio/webm",
+            "audio/flac",
+            "audio/ogg",
+            "audio/ogg",
+          ],
+          properties: {
+            data: {
+              type: "string",
+            },
+          },
+        },
+        max_items: 1,
+      },
+    },
+  },
+  model_settings: {
+    type: "object",
+    properties: {
+      model: {
+        type: "string",
+        description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed Inference Endpoint`,
+      },
+    },
+  },
+};

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -6,6 +6,7 @@ import { PaLMTextParserPromptSchema } from "../shared/prompt_schemas/PaLMTextPar
 import { PaLMChatParserPromptSchema } from "../shared/prompt_schemas/PaLMChatParserPromptSchema";
 import { AnyscaleEndpointPromptSchema } from "../shared/prompt_schemas/AnyscaleEndpointPromptSchema";
 import { HuggingFaceAutomaticSpeechRecognitionPromptSchema } from "../shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionPromptSchema";
+import {HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema} from "../shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema";
 import { HuggingFaceImage2TextTransformerPromptSchema } from "../shared/prompt_schemas/HuggingFaceImage2TextTransformerPromptSchema";
 import { HuggingFaceText2ImageDiffusorPromptSchema } from "../shared/prompt_schemas/HuggingFaceText2ImageDiffusorPromptSchema";
 import { HuggingFaceText2ImageRemoteInferencePromptSchema } from "../shared/prompt_schemas/HuggingFaceText2ImageRemoteInferencePromptSchema";
@@ -82,6 +83,10 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
 
   HuggingFaceImage2TextRemoteInference:
     HuggingFaceImage2TextRemoteInferencePromptSchema,
+
+  "HuggingFaceAutomaticSpeechRecognitionRemoteInference":
+    HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema,
+
   HuggingFaceText2ImageRemoteInference:
     HuggingFaceText2ImageRemoteInferencePromptSchema,
 


### PR DESCRIPTION
[hf inference] Prompt Schema ASR

Prompt Schema for HuggingFaceAutomaticSpeechRecognition Model Parser using the inference endpoint

Surprisingly, the python api only supports one parameter: the model.

## Testplan
## Testplan
<img width="1000" alt="Screenshot 2024-01-24 at 10 37 05 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/808956ce-e3be-4528-9f34-c8d31d704ddb">

1. Temporarily add model parser to Gradio Cookbook model parser registry.
```
    asr = HuggingFaceAutomaticSpeechRecognitionRemoteInference()
    AIConfigRuntime.register_model_parser(
        asr, asr.id()
    )
```

2. run AIConfig Edit on Gradio example

`python3 -m 'aiconfig.scripts.aiconfig_cli' edit --aiconfig-path=cookbooks/Gradio/huggingface.aiconfig.json --parsers-module-path=cookbooks/Gradio/hf_model_parsers.py --server-mode=debug_servers`
