### PR TITLE
[extensions] Update Public release of HuggingFace Extension 0.0.4 ->0.0.5

### DIFF
--- a/extensions/HuggingFace/python/README.md
+++ b/extensions/HuggingFace/python/README.md
@@ -7,13 +7,15 @@ This extension contains AIConfig model parsers with two main subfolders:
 
 ### Part 1: Update and test this extension
 
-If you are not testing locally (just using the published extension), ignore this and go to Part 2
+If you are not testing and developing locally (just using the published extension), ignore this and go to Part 2
 
 1. From the `aiconfig/extensions/HuggingFace`, run this command: `pip3 install build && cd python && python -m build && pip3 install dist/*.whl`
 2. Link your local dev environment to the current dir: `pip3 install -e .`. Afterwards if you do `pip3 list | grep aiconfig`, you should see this linked to your local path. If you ever wish to use the published extension, you will need to first remove the extension: `pip3 uninstall aiconfig-extension-hugging-face && pip3 install aiconfig-extension-hugging-face`
 3. After you're done testing, be sure to delete the generated folder(s) in the `aiconfig/HuggingFace` dir. It'll probably look something like `python/dist` and `python/<package_name>.egg-info`
 
 ### Part 2: Importing and using this extension
+
+``pip3 install aiconfig-extension-hugging-face``
 
 1. Import the library to your code: `from aiconfig_extension_hugging_face import <EXTENSION>`.
 2. Import the AIConfig model registery: `from aiconfig import ModelRegistryParser`

--- a/extensions/HuggingFace/python/pyproject.toml
+++ b/extensions/HuggingFace/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "aiconfig_extension_hugging_face"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
   { name="LastMile AI" },
   { name="Rossdan Craig", email="rossdan@lastmileai.dev" },


### PR DESCRIPTION
[extensions] Update Public release of HuggingFace Extension 0.0.4 ->0.0.5

With the recent addition of the Inference Endpoint (Remote Inference) Model parsers, this extension is in need of a new public publish.

0.0.4 -> 0.0.5
https://pypi.org/project/aiconfig-extension-hugging-face/0.0.5/
