### PR TITLE
[editor][ez] Don't show Save button if no save callback provided

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -113,7 +113,7 @@ export type AIConfigCallbacks = {
     cancellationToken?: string
   ) => Promise<{ aiconfig: AIConfig }>;
   cancel: (cancellationToken: string) => Promise<void>;
-  save: (aiconfig: AIConfig) => Promise<void>;
+  save?: (aiconfig: AIConfig) => Promise<void>;
   setConfigDescription: (description: string) => Promise<void>;
   setConfigName: (name: string) => Promise<void>;
   setParameters: (parameters: JSONObject, promptName?: string) => Promise<void>;
@@ -950,7 +950,7 @@ export default function AIConfigEditor({
                     Clear Outputs
                   </Button>
                 )}
-                {!readOnly && (
+                {!readOnly && saveCallback && (
                   <Tooltip
                     label={
                       isDirty ? "Save changes to config" : "No unsaved changes"


### PR DESCRIPTION
# [editor][ez] Don't show Save button if no save callback provided

If no save callback is provided to the editor (e.g. Gradio) we shouldn't show the save button at all

<img width="1431" alt="Screenshot 2024-01-25 at 1 42 44 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/86974432-efdc-4e5a-8593-2ff290bc7d9a">


---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1026).
* #1029
* #1028
* #1027
* __->__ #1026