### PR TITLE
[editor][ez] Readonly state for PromptName and ModelSelector

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -113,7 +113,7 @@ export type AIConfigCallbacks = {
     cancellationToken?: string
   ) => Promise<{ aiconfig: AIConfig }>;
   cancel: (cancellationToken: string) => Promise<void>;
-  save: (aiconfig: AIConfig) => Promise<void>;
+  save?: (aiconfig: AIConfig) => Promise<void>;
   setConfigDescription: (description: string) => Promise<void>;
   setConfigName: (name: string) => Promise<void>;
   setParameters: (parameters: JSONObject, promptName?: string) => Promise<void>;
@@ -950,7 +950,7 @@ export default function AIConfigEditor({
                     Clear Outputs
                   </Button>
                 )}
-                {!readOnly && (
+                {!readOnly && saveCallback && (
                   <Tooltip
                     label={
                       isDirty ? "Save changes to config" : "No unsaved changes"

--- a/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
@@ -1,9 +1,10 @@
 import { Autocomplete, AutocompleteItem, Button } from "@mantine/core";
-import { memo, useState } from "react";
+import { memo, useContext, useState } from "react";
 import { getPromptModelName } from "../../utils/promptUtils";
 import { Prompt } from "aiconfig";
 import useLoadModels from "../../hooks/useLoadModels";
 import { IconX } from "@tabler/icons-react";
+import AIConfigContext from "../../contexts/AIConfigContext";
 
 type Props = {
   prompt: Prompt;
@@ -18,6 +19,7 @@ export default memo(function ModelSelector({
   onSetModel,
   defaultConfigModelName,
 }: Props) {
+  const { readOnly } = useContext(AIConfigContext);
   const [selectedModel, setSelectedModel] = useState<string | undefined>(
     getPromptModelName(prompt, defaultConfigModelName)
   );
@@ -44,6 +46,7 @@ export default memo(function ModelSelector({
       label="Model"
       variant="unstyled"
       maxDropdownHeight={200}
+      disabled={readOnly}
       rightSection={
         selectedModel ? (
           <Button

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptName.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptName.tsx
@@ -9,6 +9,7 @@ type Props = {
 };
 
 export default memo(function PromptName({ promptId, name, onUpdate }: Props) {
+  const { readOnly } = useContext(AIConfigContext);
   const { getState } = useContext(AIConfigContext);
 
   // Use local component state to show error for duplicate names
@@ -28,6 +29,7 @@ export default memo(function PromptName({ promptId, name, onUpdate }: Props) {
       variant="unstyled"
       placeholder="Name this prompt"
       onChange={onChange}
+      disabled={readOnly}
       error={
         getState().prompts.some(
           (p) => p.name === nameInput && p._ui.id !== promptId


### PR DESCRIPTION
# [editor][ez] Readonly state for PromptName and ModelSelector

Implement readonly state for the prompt name and model selector inputs. Just disabling the text inputs since there's no styling/markdown that we'd want to apply with the TextRenderer

<img width="1277" alt="Screenshot 2024-01-25 at 1 56 46 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/a812a6c4-4769-4418-8132-91ceada518b4">


---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1027).
* #1029
* #1028
* __->__ #1027
* #1026