### PR TITLE
[editor] Support Task-based HF Model Names in Prompt Schema Mapping

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -113,7 +113,7 @@ export type AIConfigCallbacks = {
     cancellationToken?: string
   ) => Promise<{ aiconfig: AIConfig }>;
   cancel: (cancellationToken: string) => Promise<void>;
-  save: (aiconfig: AIConfig) => Promise<void>;
+  save?: (aiconfig: AIConfig) => Promise<void>;
   setConfigDescription: (description: string) => Promise<void>;
   setConfigName: (name: string) => Promise<void>;
   setParameters: (parameters: JSONObject, promptName?: string) => Promise<void>;
@@ -950,7 +950,7 @@ export default function AIConfigEditor({
                     Clear Outputs
                   </Button>
                 )}
-                {!readOnly && (
+                {!readOnly && saveCallback && (
                   <Tooltip
                     label={
                       isDirty ? "Save changes to config" : "No unsaved changes"

--- a/python/src/aiconfig/editor/client/src/components/SettingsPropertyRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/SettingsPropertyRenderer.tsx
@@ -12,14 +12,15 @@ import {
   AutocompleteItem,
   Select,
 } from "@mantine/core";
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useContext } from "react";
 import { uniqueId } from "lodash";
 import { IconHelp, IconPlus, IconTrash } from "@tabler/icons-react";
 import UnionPropertyControl, {
   UnionProperty,
 } from "./property_controls/UnionPropertyControl";
 import { JSONObject, JSONValue } from "aiconfig";
-import JSONEditor from "./JSONEditor";
+import AIConfigContext from "../contexts/AIConfigContext";
+import JSONRenderer from "./JSONRenderer";
 
 export type StateSetFromPrevFn = (prev: JSONValue) => void;
 export type SetStateFn = (val: StateSetFromPrevFn | JSONValue) => void;
@@ -59,6 +60,7 @@ export default function SettingsPropertyRenderer({
   initialValue = null,
   setValue,
 }: PropertyRendererProps) {
+  const { readOnly } = useContext(AIConfigContext);
   const propertyType = property.type;
   const defaultValue = property.default;
   const propertyDescription = property.description;
@@ -176,6 +178,7 @@ export default function SettingsPropertyRenderer({
             data={property.enum}
             value={propertyValue ?? ""}
             onChange={setAndPropagateValue}
+            disabled={readOnly}
           />
         );
       } else {
@@ -197,6 +200,7 @@ export default function SettingsPropertyRenderer({
             }
             autosize
             maxRows={20}
+            disabled={readOnly}
           />
         );
       }
@@ -218,6 +222,7 @@ export default function SettingsPropertyRenderer({
           value={propertyValue ?? ""}
           onChange={(event) => setAndPropagateValue(event.currentTarget.value)}
           autosize
+          disabled={readOnly}
         />
       );
       break;
@@ -240,6 +245,7 @@ export default function SettingsPropertyRenderer({
               value={propertyValue}
               onChange={setAndPropagateValue}
               style={{ padding: "0 0.5em" }}
+              disabled={readOnly}
             />
           </Stack>
         );
@@ -262,6 +268,7 @@ export default function SettingsPropertyRenderer({
             radius="md"
             value={propertyValue ?? ""}
             onChange={(val) => setAndPropagateValue(val)}
+            disabled={readOnly}
           />
         );
       }
@@ -285,6 +292,7 @@ export default function SettingsPropertyRenderer({
               value={propertyValue}
               onChange={setAndPropagateValue}
               style={{ padding: "0 0.5em" }}
+              disabled={readOnly}
             />
           </Stack>
         );
@@ -306,6 +314,7 @@ export default function SettingsPropertyRenderer({
             radius="md"
             value={propertyValue ?? ""}
             onChange={(val) => setAndPropagateValue(val)}
+            disabled={readOnly}
           />
         );
       }
@@ -324,6 +333,7 @@ export default function SettingsPropertyRenderer({
           onChange={(event) =>
             setAndPropagateValue(event.currentTarget.checked)
           }
+          disabled={readOnly}
         />
       );
       break;
@@ -398,9 +408,9 @@ export default function SettingsPropertyRenderer({
               propertyDescription={propertyDescription}
             />
             <div style={{ minWidth: "350px" }}>
-              <JSONEditor
+              <JSONRenderer
                 content={initialValue as JSONObject}
-                onChangeContent={setAndPropagateValue}
+                onChange={setAndPropagateValue}
               />
             </div>
           </Stack>
@@ -424,6 +434,7 @@ export default function SettingsPropertyRenderer({
               setAndPropagateValue(val);
             }}
             defaultValue={property.default}
+            disabled={readOnly}
           ></Select>
         );
       }
@@ -443,6 +454,7 @@ export default function SettingsPropertyRenderer({
             initialValue={initialValue}
             setValue={setAndPropagateValue}
             renderProperty={(props) => <SettingsPropertyRenderer {...props} />}
+            disabled={readOnly}
           />
         </Stack>
       );

--- a/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
@@ -1,9 +1,10 @@
 import { Autocomplete, AutocompleteItem, Button } from "@mantine/core";
-import { memo, useState } from "react";
+import { memo, useContext, useState } from "react";
 import { getPromptModelName } from "../../utils/promptUtils";
 import { Prompt } from "aiconfig";
 import useLoadModels from "../../hooks/useLoadModels";
 import { IconX } from "@tabler/icons-react";
+import AIConfigContext from "../../contexts/AIConfigContext";
 
 type Props = {
   prompt: Prompt;
@@ -18,6 +19,7 @@ export default memo(function ModelSelector({
   onSetModel,
   defaultConfigModelName,
 }: Props) {
+  const { readOnly } = useContext(AIConfigContext);
   const [selectedModel, setSelectedModel] = useState<string | undefined>(
     getPromptModelName(prompt, defaultConfigModelName)
   );
@@ -44,6 +46,7 @@ export default memo(function ModelSelector({
       label="Model"
       variant="unstyled"
       maxDropdownHeight={200}
+      disabled={readOnly}
       rightSection={
         selectedModel ? (
           <Button

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptName.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptName.tsx
@@ -9,6 +9,7 @@ type Props = {
 };
 
 export default memo(function PromptName({ promptId, name, onUpdate }: Props) {
+  const { readOnly } = useContext(AIConfigContext);
   const { getState } = useContext(AIConfigContext);
 
   // Use local component state to show error for duplicate names
@@ -28,6 +29,7 @@ export default memo(function PromptName({ promptId, name, onUpdate }: Props) {
       variant="unstyled"
       placeholder="Name this prompt"
       onChange={onChange}
+      disabled={readOnly}
       error={
         getState().prompts.some(
           (p) => p.name === nameInput && p._ui.id !== promptId

--- a/python/src/aiconfig/editor/client/src/components/property_controls/UnionPropertyControl.tsx
+++ b/python/src/aiconfig/editor/client/src/components/property_controls/UnionPropertyControl.tsx
@@ -14,6 +14,7 @@ export type UnionProperty = {
 };
 
 type Props = {
+  disabled?: boolean;
   property: UnionProperty;
   propertyName: string;
   initialValue?: JSONValue; // TODO: Handle initial value, selecting correct tab to show
@@ -23,7 +24,13 @@ type Props = {
 };
 
 export default memo(function UnionPropertyControl(props: Props) {
-  const { property, renderProperty, setValue, ...renderPropertyProps } = props;
+  const {
+    disabled,
+    property,
+    renderProperty,
+    setValue,
+    ...renderPropertyProps
+  } = props;
 
   const segmentedTabs = useMemo(
     () =>
@@ -62,6 +69,7 @@ export default memo(function UnionPropertyControl(props: Props) {
         data={segmentedTabs}
         value={activeTab}
         onChange={selectTab}
+        disabled={disabled}
       />
       <div style={{ marginLeft: "1em" }}>
         {renderProperty({

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -6,7 +6,7 @@ import { PaLMTextParserPromptSchema } from "../shared/prompt_schemas/PaLMTextPar
 import { PaLMChatParserPromptSchema } from "../shared/prompt_schemas/PaLMChatParserPromptSchema";
 import { AnyscaleEndpointPromptSchema } from "../shared/prompt_schemas/AnyscaleEndpointPromptSchema";
 import { HuggingFaceAutomaticSpeechRecognitionPromptSchema } from "../shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionPromptSchema";
-import {HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema} from "../shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema";
+import { HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema } from "../shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema";
 import { HuggingFaceImage2TextTransformerPromptSchema } from "../shared/prompt_schemas/HuggingFaceImage2TextTransformerPromptSchema";
 import { HuggingFaceText2ImageDiffusorPromptSchema } from "../shared/prompt_schemas/HuggingFaceText2ImageDiffusorPromptSchema";
 import { HuggingFaceText2ImageRemoteInferencePromptSchema } from "../shared/prompt_schemas/HuggingFaceText2ImageRemoteInferencePromptSchema";
@@ -84,7 +84,7 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   HuggingFaceImage2TextRemoteInference:
     HuggingFaceImage2TextRemoteInferencePromptSchema,
 
-  "HuggingFaceAutomaticSpeechRecognitionRemoteInference":
+  HuggingFaceAutomaticSpeechRecognitionRemoteInference:
     HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema,
 
   HuggingFaceText2ImageRemoteInference:
@@ -135,6 +135,17 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
     HuggingFaceTextSummarizationTransformerPromptSchema,
   HuggingFaceTextTranslationTransformer:
     HuggingFaceTextGenerationTransformerPromptSchema,
+
+  // Temporary mapping of HF model parsers to task names. This won't be needed
+  // once we have prompt schemas implemented at the parser layer
+  "Automatic Speech Recognition":
+    HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema,
+  "Image-to-Text": HuggingFaceImage2TextRemoteInferencePromptSchema,
+  "Text-to-Image": HuggingFaceText2ImageRemoteInferencePromptSchema,
+  "Text-to-Speech": HuggingFaceText2SpeechRemoteInferencePromptSchema,
+  "Text Generation": HuggingFaceTextGenerationRemoteInferencePromptSchema,
+  Summarization: HuggingFaceTextSummarizationRemoteInferencePromptSchema,
+  Translation: HuggingFaceTextTranslationRemoteInferencePromptSchema,
 };
 
 export type PromptInputSchema =


### PR DESCRIPTION
# [editor] Support Task-based HF Model Names in Prompt Schema Mapping

In Gradio, we'll register the remote model parsers with the task name and register local models to start. So, we need to have the prompt schema map from task name to the remote parser schemas:


https://github.com/lastmile-ai/aiconfig/assets/5060851/3cf7246c-58e2-42ca-9c61-ee9d5ffd644c



---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1029).
* __->__ #1029
* #1028
* #1027
* #1026