### PR TITLE
Fix GradioWorkbook Height

### DIFF
--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -20,7 +20,10 @@ export const GRADIO_THEME: MantineThemeOverride = {
     ".editorBackground": {
       background: theme.colorScheme === "light" ? "white" : "#0b0f19",
       margin: "0 auto",
-      minHeight: "100vh",
+      minHeight: "400px",
+      // Gradio component is iframed so height should be in relation to
+      // the height of the containing iframe, not the viewport
+      height: "100%",
     },
     ".monoFont": {
       fontFamily:


### PR DESCRIPTION
# Fix GradioWorkbook Height

Gradio components are rendered within an iframe in HF spaces. With the editorBackground minHeight currently set to 100vh, this makes the containing div's height expand outside the bounds of the iframe in gradio and result in an endless page.

To fix, just make the height 100% of the containing element (iframe in this case).

## Testing:
In styles.css in gradio-workbook, I set
```
div.editorBackground {
    min-height: 400px;
    height: 100%;
    background-color: green
}
```
to override the `editorBackground` styles with higher specificity. Then, publish the component to load in the workspace:

https://github.com/lastmile-ai/aiconfig/assets/5060851/f436bb87-a0d8-4887-95c0-68839237feb3


Note that we can now see the bottom of the page, as well as the notifications! Note that notifications are relative to the page itself so only visible if the bottom of the iframe is in view at the bottom of the page. I don't think we can really fix that in this scenario, since we would need to set the iframe height to a fixed size and scroll within it, instead of having it expand to fit the editor height and scroll the page to view the editor contents
