### PR TITLE
[ez] Share Button [7/n]: Add ShareError type

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -88,6 +88,13 @@ export type RunPromptStreamErrorEvent = {
   };
 };
 
+export type ShareError = {
+  error: {
+    message: string;
+    code: number | string;
+  };
+};
+
 export type RunPromptStreamCallback = (event: RunPromptStreamEvent) => void;
 
 export type RunPromptStreamErrorCallback = (
@@ -114,7 +121,7 @@ export type AIConfigCallbacks = {
   ) => Promise<{ aiconfig: AIConfig }>;
   cancel: (cancellationToken: string) => Promise<void>;
   save?: (aiconfig: AIConfig) => Promise<void>;
-  share?: () => Promise<{ share_url: string }>;
+  share?: () => Promise<{ error?: ShareError; share_url?: string }>;
   setConfigDescription: (description: string) => Promise<void>;
   setConfigName: (name: string) => Promise<void>;
   setParameters: (parameters: JSONObject, promptName?: string) => Promise<void>;


### PR DESCRIPTION
[ez] Share Button [7/n]: Add ShareError type


Just super simple so that we can display errors when we pass it from Gradio backend

We could probably just make this more generic and generalized in a future PR

I can also change this response type for `share` to be more generic `onError` and `onSuccess` handlers if you prefer

## Test Plan
No functional changes
