### PR TITLE
wip default model for hf remote inference parsers

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/automatic_speech_recognition.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/automatic_speech_recognition.py
@@ -20,6 +20,10 @@ from aiconfig.schema import (
 # HuggingFace API imports
 from huggingface_hub import InferenceClient
 
+from aiconfig_extension_hugging_face.remote_inference_client.util import (
+    add_default_model_if_not_set,
+)
+
 if TYPE_CHECKING:
     from aiconfig import AIConfigRuntime
 
@@ -68,6 +72,7 @@ class HuggingFaceAutomaticSpeechRecognitionRemoteInference(ModelParser):
 
     Uses the Inference Endpoint for inference.
     """
+    HF_TASK = "automatic-speech-recognition"
 
     def __init__(self, model_id: str = None, use_api_token: bool = False):
         """
@@ -214,6 +219,8 @@ class HuggingFaceAutomaticSpeechRecognitionRemoteInference(ModelParser):
         audio_input = validate_and_retrieve_audio_from_attachments(prompt)
 
         completion_data["audio"] = audio_input
+
+        add_default_model_if_not_set(completion_data, self.HF_TASK)
 
         await aiconfig.callback_manager.run_callbacks(
             CallbackEvent(

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/image_2_text.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/image_2_text.py
@@ -26,6 +26,10 @@ from PIL.Image import Image as ImageType
 # image is Union[bytes, BinaryIO, Path, str] where str could be path or uri
 RequestImageType = Union[Path, str, bytes, BinaryIO]
 
+from aiconfig_extension_hugging_face.remote_inference_client.util import (
+    add_default_model_if_not_set,
+)
+
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
     from aiconfig.Config import AIConfigRuntime
@@ -67,6 +71,7 @@ class HuggingFaceImage2TextRemoteInference(ModelParser):
     """
     A model parser for HuggingFace image-to-text models.
     """
+    HF_TASK = "image-to-text"
 
     def __init__(self, model_id: str = None, use_api_token=False):
         """
@@ -221,6 +226,8 @@ class HuggingFaceImage2TextRemoteInference(ModelParser):
         # Build Completion data
         model_settings = self.get_model_settings(prompt, aiconfig)
         completion_data = refine_completion_params(model_settings)
+
+        add_default_model_if_not_set(completion_data, self.HF_TASK)
 
         # Add image input
         completion_data[

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_2_image.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_2_image.py
@@ -23,6 +23,10 @@ from aiconfig.util.config_utils import get_api_key_from_environment
 from aiconfig.util.params import resolve_prompt
 from PIL.Image import Image as ImageType
 
+from aiconfig_extension_hugging_face.remote_inference_client.util import (
+    add_default_model_if_not_set,
+)
+
 
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
@@ -82,6 +86,7 @@ class HuggingFaceText2ImageRemoteInference(ParameterizedModelParser):
     """
     A model parser for HuggingFace text-to-image models.
     """
+    HF_TASK = "text-to-image"
 
     def __init__(self, model_id: str = None, use_api_token=False):
         """
@@ -211,6 +216,8 @@ class HuggingFaceText2ImageRemoteInference(ParameterizedModelParser):
         model_settings = self.get_model_settings(prompt, aiconfig)
 
         completion_data = refine_completion_params(model_settings)
+
+        add_default_model_if_not_set(completion_data, self.HF_TASK)
 
         completion_data["prompt"] = resolved_prompt
 

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_2_speech.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_2_speech.py
@@ -24,6 +24,10 @@ from aiconfig.util.config_utils import get_api_key_from_environment
 from aiconfig.util.params import resolve_prompt
 from scipy.io.wavfile import write as write_wav
 
+from aiconfig_extension_hugging_face.remote_inference_client.util import (
+    add_default_model_if_not_set,
+)
+
 
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
@@ -78,6 +82,7 @@ class HuggingFaceText2SpeechRemoteInference(ParameterizedModelParser):
     """
     A model parser for HuggingFace text-to-speech models.
     """
+    HF_TASK = "text-to-speech"
 
     def __init__(
         self,
@@ -211,6 +216,8 @@ class HuggingFaceText2SpeechRemoteInference(ParameterizedModelParser):
         model_settings = self.get_model_settings(prompt, aiconfig)
 
         completion_data = refine_completion_params(model_settings)
+
+        add_default_model_if_not_set(completion_data, self.HF_TASK)
 
         completion_data["text"] = resolved_prompt
 

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
@@ -19,6 +19,10 @@ from huggingface_hub.inference._text_generation import (
 from aiconfig import CallbackEvent
 from aiconfig.schema import ExecuteResult, Output, Prompt, PromptMetadata
 
+from aiconfig_extension_hugging_face.remote_inference_client.util import (
+    add_default_model_if_not_set,
+)
+
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
     from aiconfig.Config import AIConfigRuntime
@@ -124,6 +128,7 @@ class HuggingFaceTextGenerationRemoteInference(ParameterizedModelParser):
     """
     A model parser for HuggingFace text generation models.
     """
+    HF_TASK = "text-generation"
 
     def __init__(self, model_id: str = None, use_api_token=False):
         """
@@ -254,6 +259,8 @@ class HuggingFaceTextGenerationRemoteInference(ParameterizedModelParser):
         model_settings = self.get_model_settings(prompt, aiconfig)
 
         completion_data = refine_completion_params(model_settings)
+
+        add_default_model_if_not_set(completion_data, self.HF_TASK)
 
         completion_data["prompt"] = resolved_prompt
 

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_summarization.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_summarization.py
@@ -19,6 +19,10 @@ from aiconfig.schema import (
 from aiconfig.util.config_utils import get_api_key_from_environment
 from aiconfig.util.params import resolve_prompt
 
+from aiconfig_extension_hugging_face.remote_inference_client.util import (
+    add_default_model_if_not_set,
+)
+
 
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
@@ -78,6 +82,7 @@ class HuggingFaceTextSummarizationRemoteInference(ParameterizedModelParser):
     """
     A model parser for HuggingFace text summarization models.
     """
+    HF_TASK = "summarization"
 
     def __init__(self, model_id: str = None, use_api_token=False):
         """
@@ -214,6 +219,8 @@ class HuggingFaceTextSummarizationRemoteInference(ParameterizedModelParser):
         model_settings = self.get_model_settings(prompt, aiconfig)
 
         completion_data = refine_completion_params(model_settings)
+        
+        add_default_model_if_not_set(completion_data, self.HF_TASK)
 
         completion_data["text"] = resolved_prompt
 

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_translation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_translation.py
@@ -19,6 +19,10 @@ from aiconfig.schema import (
 from aiconfig.util.config_utils import get_api_key_from_environment
 from aiconfig.util.params import resolve_prompt
 
+from aiconfig_extension_hugging_face.remote_inference_client.util import (
+    add_default_model_if_not_set,
+)
+
 
 # Circuluar Dependency Type Hints
 if TYPE_CHECKING:
@@ -66,6 +70,7 @@ class HuggingFaceTextTranslationRemoteInference(ParameterizedModelParser):
     """
     A model parser for HuggingFace text translation models.
     """
+    HF_TASK = "translation"
 
     def __init__(self, model_id: str = None, use_api_token=False):
         """
@@ -195,6 +200,8 @@ class HuggingFaceTextTranslationRemoteInference(ParameterizedModelParser):
         model_settings = self.get_model_settings(prompt, aiconfig)
 
         completion_data = refine_completion_params(model_settings)
+
+        add_default_model_if_not_set(completion_data, self.HF_TASK)
 
         completion_data["text"] = resolved_prompt
 

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/util.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/util.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from huggingface_hub import InferenceClient
+
+
+def add_default_model_if_not_set(
+    completion_data: dict[Any, Any], hf_task: str
+):
+    """
+    add default model from task based on Remote Inference Default model
+
+    Takes a dictionary of completion data and adds a default model if it is not
+    already set.
+
+    Most tasks have a default model specified for a task. Skip any that don't
+    """
+    default_model = None
+
+    try:
+        default_model = InferenceClient.get_recommended_model(task=hf_task)
+    except Exception:
+        # No default model, don't set one
+        pass
+
+    if default_model is not None and "model" not in completion_data:
+        completion_data["model"] = default_model
+
+    return completion_data


### PR DESCRIPTION
rfc wip default model for hf remote inference parsers


- added huggingface task to each remote inference model parser as a static variable
- defined a method that will add defeault model to completion params if "model" is not set.
- - Note: we need to think about how to set the model name if its specified in the aiconfig.
- - we should have something similar to the [local inference `get_model`](https://github.com/lastmile-ai/aiconfig/blob/main/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/local_inference/util.py#L11) but right now as a workaround we have the model parser id's set to a task in gradio.
- This diff is to improve the Gradio workbook ux


## Testplan:

Verified that the 7 tasks we are supporting have default models:

<img width="383" alt="Screenshot 2024-01-26 at 4 16 10 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/82c5badf-d611-4e00-b258-e64cf4557c12">
