### PR TITLE
Set Model Selector Label to 'HuggingFace Task' for 'gradio' Mode

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -862,9 +862,10 @@ export default function AIConfigEditor({
     () => ({
       getState,
       logEventHandler,
+      mode,
       readOnly,
     }),
-    [getState, logEventHandler, readOnly]
+    [getState, logEventHandler, mode, readOnly]
   );
 
   const isDirty = aiconfigState._ui.isDirty !== false;

--- a/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
@@ -19,6 +19,7 @@ export default memo(function ModelSelector({
   onSetModel,
   defaultConfigModelName,
 }: Props) {
+  const { mode } = useContext(AIConfigContext);
   const { readOnly } = useContext(AIConfigContext);
   const [selectedModel, setSelectedModel] = useState<string | undefined>(
     getPromptModelName(prompt, defaultConfigModelName)
@@ -40,10 +41,10 @@ export default memo(function ModelSelector({
 
   return (
     <Autocomplete
-      placeholder="Select model"
+      placeholder={`Select ${mode === "gradio" ? "task" : "model"}`}
       limit={100}
       className="ghost"
-      label="Model"
+      label={mode === "gradio" ? "HuggingFace Task" : "Model"}
       variant="unstyled"
       maxDropdownHeight={200}
       disabled={readOnly}

--- a/python/src/aiconfig/editor/client/src/contexts/AIConfigContext.tsx
+++ b/python/src/aiconfig/editor/client/src/contexts/AIConfigContext.tsx
@@ -1,5 +1,10 @@
 import { createContext } from "react";
-import { ClientAIConfig, LogEvent, LogEventData } from "../shared/types";
+import {
+  AIConfigEditorMode,
+  ClientAIConfig,
+  LogEvent,
+  LogEventData,
+} from "../shared/types";
 
 /**
  * Context for overall editor config state. This context should
@@ -8,6 +13,7 @@ import { ClientAIConfig, LogEvent, LogEventData } from "../shared/types";
 const AIConfigContext = createContext<{
   getState: () => ClientAIConfig;
   logEventHandler?: (event: LogEvent, data?: LogEventData) => void;
+  mode?: AIConfigEditorMode;
   readOnly?: boolean;
 }>({
   getState: () => ({ prompts: [], _ui: { isDirty: false } }),

--- a/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
+++ b/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
@@ -23,7 +23,9 @@ export default function AIConfigEditorThemeProvider({ children, mode }: Props) {
   const theme = useMemo(
     () => ({
       colorScheme: preferredColorScheme,
-      ...THEMES[mode!],
+      ...THEMES[
+        mode!
+      ] /* mode must be nonnull per conditional wrapper condition */,
     }),
     [mode, preferredColorScheme]
   );


### PR DESCRIPTION
Set Model Selector Label to 'HuggingFace Task' for 'gradio' Mode

# Set Model Selector Label to 'HuggingFace Task' for 'gradio' Mode

Per dogfood feedback, it's confusing for the model selector label and placeholder to say 'Model' while the parser is registered based on task name. As a temporary improvement, this PR uses 'HuggingFace Task" terminology instead of model. Long-term, once the model -> model parser mapping UX is available, we should undo this and have the model copy back in the selector.

## Updated for 'gradio' Mode:
<img width="230" alt="Screenshot 2024-01-26 at 4 35 27 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/ab6ee0d1-bf46-4fae-a098-e79f1487ef1b">

## Local / non-gradio is unchanged:
<img width="1304" alt="Screenshot 2024-01-26 at 4 35 09 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/9cbc21a9-9ddf-4ac8-96cc-effe1deae353">

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1046).
* #1047
* __->__ #1046