### PR TITLE
Default to 400 max_new_tokens for HF Text Generation Remote Inference Parser

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_generation.py
@@ -56,6 +56,13 @@ def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
         if key.lower() in supported_keys:
             completion_data[key.lower()] = model_settings[key]
 
+    # Default max_new_tokens is set to 20 at the api layer if not specified. We
+    # increase that to 400 for an improved user experience.
+    # TODO: Once prompt schemas are implemented in the parser, obtain this
+    # default value from the schema.
+    if completion_data.get("max_new_tokens") is None:
+        completion_data["max_new_tokens"] = 400
+
     return completion_data
 
 

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -862,9 +862,10 @@ export default function AIConfigEditor({
     () => ({
       getState,
       logEventHandler,
+      mode,
       readOnly,
     }),
-    [getState, logEventHandler, readOnly]
+    [getState, logEventHandler, mode, readOnly]
   );
 
   const isDirty = aiconfigState._ui.isDirty !== false;

--- a/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
@@ -19,6 +19,7 @@ export default memo(function ModelSelector({
   onSetModel,
   defaultConfigModelName,
 }: Props) {
+  const { mode } = useContext(AIConfigContext);
   const { readOnly } = useContext(AIConfigContext);
   const [selectedModel, setSelectedModel] = useState<string | undefined>(
     getPromptModelName(prompt, defaultConfigModelName)
@@ -40,10 +41,10 @@ export default memo(function ModelSelector({
 
   return (
     <Autocomplete
-      placeholder="Select model"
+      placeholder={`Select ${mode === "gradio" ? "task" : "model"}`}
       limit={100}
       className="ghost"
-      label="Model"
+      label={mode === "gradio" ? "HuggingFace Task" : "Model"}
       variant="unstyled"
       maxDropdownHeight={200}
       disabled={readOnly}

--- a/python/src/aiconfig/editor/client/src/contexts/AIConfigContext.tsx
+++ b/python/src/aiconfig/editor/client/src/contexts/AIConfigContext.tsx
@@ -1,5 +1,10 @@
 import { createContext } from "react";
-import { ClientAIConfig, LogEvent, LogEventData } from "../shared/types";
+import {
+  AIConfigEditorMode,
+  ClientAIConfig,
+  LogEvent,
+  LogEventData,
+} from "../shared/types";
 
 /**
  * Context for overall editor config state. This context should
@@ -8,6 +13,7 @@ import { ClientAIConfig, LogEvent, LogEventData } from "../shared/types";
 const AIConfigContext = createContext<{
   getState: () => ClientAIConfig;
   logEventHandler?: (event: LogEvent, data?: LogEventData) => void;
+  mode?: AIConfigEditorMode;
   readOnly?: boolean;
 }>({
   getState: () => ({ prompts: [], _ui: { isDirty: false } }),

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextGenerationRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextGenerationRemoteInferencePromptSchema.ts
@@ -50,6 +50,7 @@ export const HuggingFaceTextGenerationRemoteInferencePromptSchema: PromptSchema 
         },
         max_new_tokens: {
           type: "integer",
+          default: 400,
           description: `The amount of new tokens to be generated, this does not include the input length 
         it is a estimate of the size of generated text you want. Each new tokens slows down the request, 
         so look for balance between response times and length of text generated.`,

--- a/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
+++ b/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
@@ -23,7 +23,9 @@ export default function AIConfigEditorThemeProvider({ children, mode }: Props) {
   const theme = useMemo(
     () => ({
       colorScheme: preferredColorScheme,
-      ...THEMES[mode!],
+      ...THEMES[
+        mode!
+      ] /* mode must be nonnull per conditional wrapper condition */,
     }),
     [mode, preferredColorScheme]
   );


### PR DESCRIPTION
# Default to 400 max_new_tokens for HF Text Generation Remote Inference Parser

Per gradio dogfooding. The default value for max_new_tokens is set to 20 by the hugging face text_generation API. This isn't a good default limit for use in gradio workbooks, so set to a more reasonable 400. Note that we set the default in 2 places here:
1. In the PromptSchema, default is set to 400 to show in the UI what the default is. This default, if untouched, *does not* propagate to the parser since otherwise any default setting value in the schemas would be persisted to the config
2. In the parser implementation itself -- this is where the default is set/used for the run call. In the future once we have prompt schemas moved to the parser layer we can have a common process of grabbing all defaults from the schemas to use

## Testing:
- Ensure default is now 400 (and not persisted to config if not changed)
![Screenshot 2024-01-26 at 5 09 14 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/0974703a-30b0-4422-a5fb-d0417dc2f300)

- Ensure changing the setting works as expected (and persists to config)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1047).
* __->__ #1047
* #1046 

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1047).
* __->__ #1047
* #1046