### PR TITLE
[editor] Hardcode default models for HuggingFace Remote Inference schemas

### DIFF
--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema.ts
@@ -36,6 +36,7 @@ export const HuggingFaceAutomaticSpeechRecognitionRemoteInferencePromptSchema: P
       model: {
         type: "string",
         description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL to a deployed Inference Endpoint`,
+        default: "openai/whisper-large-v3"
       },
     },
   },

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceImage2TextRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceImage2TextRemoteInferencePromptSchema.ts
@@ -30,6 +30,7 @@ export const HuggingFaceImage2TextRemoteInferencePromptSchema: PromptSchema = {
         type: "string",
         description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL 
         to a deployed Inference Endpoint`,
+        default: "Salesforce/blip-image-captioning-base",
       },
     },
   },

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceText2ImageRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceText2ImageRemoteInferencePromptSchema.ts
@@ -13,6 +13,7 @@ export const HuggingFaceText2ImageRemoteInferencePromptSchema: PromptSchema = {
         type: "string",
         description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL 
         to a deployed Inference Endpoint`,
+        default: "CompVis/stable-diffusion-v1-4"
       },
       negative_prompt: {
         type: "string",

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceText2SpeechRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceText2SpeechRemoteInferencePromptSchema.ts
@@ -13,6 +13,7 @@ export const HuggingFaceText2SpeechRemoteInferencePromptSchema: PromptSchema = {
         type: "string",
         description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL 
         to a deployed Inference Endpoint`,
+        default: "suno/bark",
       },
     },
   },

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextGenerationRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextGenerationRemoteInferencePromptSchema.ts
@@ -16,6 +16,7 @@ export const HuggingFaceTextGenerationRemoteInferencePromptSchema: PromptSchema 
           type: "string",
           description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL 
         to a deployed Inference Endpoint`,
+          default: "HuggingFaceH4/zephyr-7b-beta",
         },
         temperature: {
           type: "number",

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextSummarizationRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextSummarizationRemoteInferencePromptSchema.ts
@@ -15,6 +15,7 @@ export const HuggingFaceTextSummarizationRemoteInferencePromptSchema: PromptSche
           type: "string",
           description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL 
         to a deployed Inference Endpoint`,
+          default: "sshleifer/distilbart-cnn-12-6",
         },
         min_length: {
           type: "integer",

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextTranslationRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextTranslationRemoteInferencePromptSchema.ts
@@ -16,6 +16,7 @@ export const HuggingFaceTextTranslationRemoteInferencePromptSchema: PromptSchema
           type: "string",
           description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL 
         to a deployed Inference Endpoint`,
+        default: "t5-small",
         },
         src_lang: {
           type: "string",


### PR DESCRIPTION
Hardcode default models for HuggingFace Remote Inference schemas

HuggingFace Remote Inference Model parsers utilized the Remote Inference endpoint.

When a model is not provided, it uses a default model. For now, hardcode the default model into the prompt schema, such that the user sees the "default model". This will help improve user experience

Found the models by calling the Inference Endpoint API:
<img width="383" alt="Screenshot 2024-01-26 at 4 16 10 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/82c5badf-d611-4e00-b258-e64cf4557c12">

There probably is a way to do something similar in Typescript and such implement it in the schema.


## Testplan:

Verify selecting the 7 tasks populates the model field

https://github.com/lastmile-ai/aiconfig/assets/141073967/69ed36f5-2259-41b9-a535-d0819bb91997
