### PR TITLE
Dynamically Set Settings/Parameters Height to Match Prompt Input/Output Height

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/GlobalParametersContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/GlobalParametersContainer.tsx
@@ -37,6 +37,7 @@ export default memo(function GlobalParametersContainer({
               <ParametersRenderer
                 initialValue={initialValue}
                 onUpdateParameters={onUpdateParameters}
+                maxHeight="300px"
               />
             )}
           </Accordion.Panel>

--- a/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
@@ -10,7 +10,7 @@ import {
 } from "@mantine/core";
 import { IconTrash, IconPlus } from "@tabler/icons-react";
 import { debounce, uniqueId } from "lodash";
-import { memo, useCallback, useContext, useMemo, useState } from 'react';
+import { memo, useCallback, useContext, useMemo, useState } from "react";
 import { JSONValue, JSONObject } from "aiconfig";
 import AIConfigContext from "../contexts/AIConfigContext";
 
@@ -112,12 +112,11 @@ const ParameterInput = memo(function ParameterInput(props: {
             debouncedCellParameterUpdate(parameterName, event.target.value);
           }}
         />
-       { !readOnly && <ActionIcon
-          onClick={() => removeParameter(parameterName)}
-        >
-          <IconTrash size={16} color={"red"} />
-        </ActionIcon>
-        }
+        {!readOnly && (
+          <ActionIcon onClick={() => removeParameter(parameterName)}>
+            <IconTrash size={16} color={"red"} />
+          </ActionIcon>
+        )}
       </Stack>
     </Group>
   );
@@ -199,7 +198,7 @@ export default memo(function ParametersRenderer(props: {
   return (
     <div
       style={{
-        maxHeight: props.maxHeight ?? "300px",
+        maxHeight: props.maxHeight,
         overflow: "auto",
         width: "100%",
       }}

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
@@ -5,11 +5,12 @@ import {
   PromptSchema,
   checkParametersSupported,
 } from "../../utils/promptUtils";
-import { ActionIcon, Container, Flex, Tabs } from "@mantine/core";
+import { ActionIcon, Container, Flex, ScrollArea, Tabs } from "@mantine/core";
 import { IconClearAll } from "@tabler/icons-react";
 import { memo, useState } from "react";
 import ParametersRenderer from "../ParametersRenderer";
 import { JSONObject } from "aiconfig";
+import { PROMPT_CONTAINER_HEIGHT_MAP } from "./PromptContainer";
 
 type Props = {
   prompt: ClientPrompt;
@@ -30,6 +31,14 @@ function getPromptParameters(prompt: ClientPrompt) {
   return prompt.metadata?.parameters;
 }
 
+// This height accounts for all height within the action bar except the contents of the Panel
+// items. This is important to have correct, otherwise the cellInputOutputRef height would
+// itself be updated by the height of the action bar contents, which would cause the action
+// bar content height to increase each time the input changes (even if the change would not
+// normally affect the cellInputOutput container height)
+const ACTION_CONTENT_SURROUNDING_HEIGHT = 84;
+const MIN_ACTION_BAR_HEIGHT = 300;
+
 export default memo(function PromptActionBar({
   prompt,
   promptSchema,
@@ -41,29 +50,37 @@ export default memo(function PromptActionBar({
   const modelSettingsSchema = promptSchema?.model_settings;
   const promptMetadataSchema = promptSchema?.prompt_metadata;
 
-  return (
-    <Flex direction="column" justify="space-between" h="100%">
-      {isExpanded ? (
-        <>
-          <Container miw="400px">
-            <ActionIcon
-              size="sm"
-              onClick={() => setIsExpanded(false)}
-              mt="0.5em"
-            >
-              <IconClearAll />
-            </ActionIcon>
-            <Tabs defaultValue="settings" mb="1em">
-              <Tabs.List>
-                <Tabs.Tab value="settings">Settings</Tabs.Tab>
-                {checkParametersSupported(prompt) && (
-                  <Tabs.Tab value="parameters">
-                    Local Parameters
-                  </Tabs.Tab>
-                )}
-              </Tabs.List>
+  const promptContainerHeight = PROMPT_CONTAINER_HEIGHT_MAP.get(prompt._ui.id);
+  let maxContentHeight;
+  if (promptContainerHeight) {
+    const maxHeight = Math.max(
+      promptContainerHeight - ACTION_CONTENT_SURROUNDING_HEIGHT,
+      MIN_ACTION_BAR_HEIGHT
+    );
+    maxContentHeight = `${maxHeight}px`;
+  }
 
-              <Tabs.Panel value="settings" className="actionTabsPanel">
+  return (
+    <Flex direction="column" justify="space-between">
+      {isExpanded ? (
+        <Container miw="400px">
+          <ActionIcon size="sm" onClick={() => setIsExpanded(false)} mt="0.5em">
+            <IconClearAll />
+          </ActionIcon>
+          <Tabs defaultValue="settings" mb="1em">
+            <Tabs.List>
+              <Tabs.Tab value="settings">Settings</Tabs.Tab>
+              {checkParametersSupported(prompt) && (
+                <Tabs.Tab value="parameters">Local Parameters</Tabs.Tab>
+              )}
+            </Tabs.List>
+
+            <Tabs.Panel value="settings" className="actionTabsPanel">
+              <ScrollArea
+                h={maxContentHeight}
+                type="auto"
+                style={{ overflowY: "auto" }}
+              >
                 <ModelSettingsRenderer
                   settings={getModelSettings(prompt)}
                   schema={modelSettingsSchema}
@@ -73,19 +90,20 @@ export default memo(function PromptActionBar({
                   prompt={prompt}
                   schema={promptMetadataSchema}
                 />
-              </Tabs.Panel>
+              </ScrollArea>
+            </Tabs.Panel>
 
-              {checkParametersSupported(prompt) && (
-                <Tabs.Panel value="parameters" className="actionTabsPanel">
-                  <ParametersRenderer
-                    initialValue={getPromptParameters(prompt)}
-                    onUpdateParameters={onUpdateParameters}
-                  />
-                </Tabs.Panel>
-              )}
-            </Tabs>
-          </Container>
-        </>
+            {checkParametersSupported(prompt) && (
+              <Tabs.Panel value="parameters" className="actionTabsPanel">
+                <ParametersRenderer
+                  initialValue={getPromptParameters(prompt)}
+                  onUpdateParameters={onUpdateParameters}
+                  maxHeight={maxContentHeight}
+                />
+              </Tabs.Panel>
+            )}
+          </Tabs>
+        </Container>
       ) : (
         <Flex direction="column" justify="space-between" h="100%">
           <Flex direction="row" justify="center" mt="0.5em">

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
@@ -5,10 +5,12 @@ import { ClientPrompt } from "../../shared/types";
 import { getPromptSchema } from "../../utils/promptUtils";
 import { Flex, Card } from "@mantine/core";
 import { PromptInput as AIConfigPromptInput, JSONObject } from "aiconfig";
-import { memo, useCallback } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import PromptOutputBar from "./PromptOutputBar";
 import PromptName from "./PromptName";
 import ModelSelector from "./ModelSelector";
+import { DEBOUNCE_MS } from "../../utils/constants";
+import { debounce } from "lodash";
 
 type Props = {
   prompt: ClientPrompt;
@@ -32,6 +34,8 @@ type Props = {
   defaultConfigModelName?: string;
   isRunButtonDisabled?: boolean;
 };
+
+export const PROMPT_CONTAINER_HEIGHT_MAP = new Map<string, number>();
 
 export default memo(function PromptContainer({
   prompt,
@@ -93,6 +97,32 @@ export default memo(function PromptContainer({
     [promptId, onUpdateModel]
   );
 
+  const cellInputOutputRef = useRef<HTMLDivElement | null>(null);
+  const debouncedSetHeight = useMemo(
+    () =>
+      debounce((entries: ResizeObserverEntry[]) => {
+        if (entries.length > 0) {
+          const height = entries[0].target.getBoundingClientRect().height;
+          PROMPT_CONTAINER_HEIGHT_MAP.set(promptId, height);
+        }
+      }, DEBOUNCE_MS),
+    [promptId]
+  );
+
+  // Whenever the cell input/output container resizes, we want to track its height so that we can bound
+  // the action bar contents (settings, parameters, etc.) to the height of the prompt input and
+  // output container
+  useEffect(() => {
+    if (!cellInputOutputRef.current) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(debouncedSetHeight);
+    resizeObserver.observe(cellInputOutputRef.current!);
+
+    return () => resizeObserver.disconnect();
+  }, [debouncedSetHeight]);
+
   // TODO: When adding support for custom PromptContainers, implement a PromptContainerRenderer which
   // will take in the promptId and callback and render the appropriate PromptContainer with new memoized
   // callback and not having to pass promptId down to PromptContainer
@@ -102,7 +132,7 @@ export default memo(function PromptContainer({
 
   return (
     <Flex justify="space-between" w="100%">
-      <Card withBorder className="cellStyle">
+      <Card withBorder className="cellStyle" ref={cellInputOutputRef}>
         <Flex direction="column">
           <Flex justify="space-between" mb="0.5em">
             <PromptName

--- a/python/src/aiconfig/editor/client/src/components/prompt/model_settings/ModelSettingsRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/model_settings/ModelSettingsRenderer.tsx
@@ -15,8 +15,6 @@ type Props = {
 
 const useStyles = createStyles(() => ({
   settingsContainer: {
-    // TODO: Fix max height to be full height if input/output is larger than settings
-    // otherwise bound to some reasonable height
     overflow: "auto",
     paddingTop: "0.5em",
     width: "100%",


### PR DESCRIPTION
Dynamically Set Settings/Parameters Height to Match Prompt Input/Output Height

# Dynamically Set Settings/Parameters Height to Match Prompt Input/Output Height

This PR implements dynamic max height for the model settings and parameters contents to be bounded by the height of the prompt input/output cell container. I wasn't able to get anything working with pure css so this implementation requires some javascript -- not ideal, due to potential perf hit, but it works.

The main idea is that:
1. In PromptContainer, use a ref for the element containing the input/outputs and calculate its height whenever input or outputs change (using debounce so we don't do this constantly). Set this height in an exported const map, mapped under the prompt id
2. In the PromptActionBar, set the max height of the contents to one of:
a) the calculated height minus height of surrounding action bar contents (84px, found with some trial/error logging)
b) 300px if a) is less than 300px since we want the minimum height to be reasonable enough to show sufficient settings

## Testing:
Min height of 300px for empty new prompt
<img width="1375" alt="Screenshot 2024-01-28 at 3 46 35 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/ac42a05a-fc3d-430d-bf8e-86775396aa8c">


Dynamic resizing:

https://github.com/lastmile-ai/aiconfig/assets/5060851/591fe137-edfb-4c7b-9b6d-be6d282efb15

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1051).
* #1084
* __->__ #1051