### PR TITLE
[2/n] Add to_string method to AIConfigRuntime

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -53,13 +53,16 @@ for model in dalle_image_generation_models:
 ModelParserRegistry.register_model_parser(
     DefaultAnyscaleEndpointParser("AnyscaleEndpoint")
 )
-ModelParserRegistry.register_model_parser(GeminiModelParser("gemini-pro"), ["gemini-pro"])
+ModelParserRegistry.register_model_parser(
+    GeminiModelParser("gemini-pro"), ["gemini-pro"]
+)
 ModelParserRegistry.register_model_parser(ClaudeBedrockModelParser())
 ModelParserRegistry.register_model_parser(HuggingFaceTextGenerationParser())
 for model in gpt_models_extra:
     ModelParserRegistry.register_model_parser(DefaultOpenAIParser(model))
 ModelParserRegistry.register_model_parser(PaLMChatParser())
 ModelParserRegistry.register_model_parser(PaLMTextParser())
+
 
 class AIConfigRuntime(AIConfig):
     # A mapping of model names to their respective parsers
@@ -116,14 +119,37 @@ class AIConfigRuntime(AIConfig):
             else:
                 data = file.read()
 
-        # load the file as bytes and let pydantic handle the parsing
-        # validated_data =  AIConfig.model_validate_json(file.read())
-        aiconfigruntime = cls.model_validate_json(data)
-        update_model_parser_registry_with_config_runtime(aiconfigruntime)
-
+        config_runtime = cls.load_json(data)
         # set the file path. This is used when saving the config
-        aiconfigruntime.file_path = config_filepath
-        return aiconfigruntime
+        config_runtime.file_path = config_filepath
+        return config_runtime
+
+    @classmethod
+    def load_json(cls, config_json: str) -> "AIConfigRuntime":
+        """
+        Constructs AIConfigRuntime from provided JSON and returns it.
+
+        Args:
+            config_json (str): The JSON representing the AIConfig.
+        """
+
+        config_runtime = cls.model_validate_json(config_json)
+        update_model_parser_registry_with_config_runtime(config_runtime)
+
+        return config_runtime
+
+    @classmethod
+    def load_yaml(cls, config_yaml: str) -> "AIConfigRuntime":
+        """
+        Constructs AIConfigRuntime from provided YAML and returns it.
+
+        Args:
+            config_yaml (str): The YAML representing the AIConfig.
+        """
+
+        yaml_data = yaml.safe_load(config_yaml)
+        config_json = json.dumps(yaml_data)
+        return cls.load_json(config_json)
 
     @classmethod
     def load_from_workbook(cls, workbook_id: str) -> "AIConfigRuntime":

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -233,12 +233,40 @@ export class AIConfigRuntime implements AIConfig {
    * Saves this AIConfig to a file.
    * @param filePath The path to the file to save to.
    * @param saveOptions Options that determine how to save the AIConfig to the file.
+   * @param mode Whether to save the AIConfig as JSON or YAML. If unspecified, the file extension will be used to determine the mode.
    */
   public save(
     filePath?: string,
     saveOptions?: SaveOptions,
     mode?: "json" | "yaml"
   ) {
+    const defaultFilePath = mode === "yaml" ? "aiconfig.yaml" : "aiconfig.json";
+    if (!filePath) {
+      filePath = this.filePath ?? defaultFilePath;
+    }
+
+    if (mode == null) {
+      if (isYamlExt(filePath)) {
+        mode = "yaml";
+      } else {
+        // Default to JSON
+        mode = "json";
+      }
+    }
+
+    const aiConfigString = this.toString(saveOptions, mode);
+    fs.writeFileSync(filePath, aiConfigString);
+  }
+
+  /**
+   * Returns this AIConfig as a string.
+   *
+   * Note that this doesn't return the full string representation of the AIConfig object,
+   * but rather the string representation of the AIConfig object that can be persisted to a file.
+   * @param saveOptions Options that determine how to serialize the AIConfig to string.
+   * @param mode Whether to save the AIConfig as JSON or YAML. Defaults to JSON.
+   */
+  public toString(saveOptions?: SaveOptions, mode: "json" | "yaml" = "json") {
     const keysToOmit = ["filePath", "callbackManager"] as const;
 
     try {
@@ -254,19 +282,9 @@ export class AIConfigRuntime implements AIConfig {
         aiConfigObj.prompts = prompts;
       }
 
-      const defaultFilePath =
-        mode === "yaml" ? "aiconfig.yaml" : "aiconfig.json";
-      if (!filePath) {
-        filePath = this.filePath ?? defaultFilePath;
-      }
-
-      if (mode == null) {
-        if (isYamlExt(filePath)) {
-          mode = "yaml";
-        } else {
-          // Default to JSON
-          mode = "json";
-        }
+      if (aiConfigObj["$schema"] == null) {
+        // Add the $schema property to the JSON object before saving it. In the future this can respect the version specified in the AIConfig.
+        aiConfigObj["$schema"] = "https://json.schemastore.org/aiconfig-1.0";
       }
 
       // TODO: saqadri - make sure that the object satisfies the AIConfig schema
@@ -274,12 +292,10 @@ export class AIConfigRuntime implements AIConfig {
       if (mode === "yaml") {
         aiConfigString = yaml.dump(aiConfigObj, { indent: 2 });
       } else {
-        // Add the $schema property to the JSON object before saving it. In the future this can respect the version specified in the AIConfig.
-        aiConfigObj["$schema"] = "https://json.schemastore.org/aiconfig-1.0";
         aiConfigString = JSON.stringify(aiConfigObj, null, 2);
       }
 
-      fs.writeFileSync(filePath, aiConfigString);
+      return aiConfigString;
     } catch (error) {
       console.error(error);
       throw error;

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -115,10 +115,24 @@ export class AIConfigRuntime implements AIConfig {
   }
 
   /**
+   * Loads an AIConfig from a YAML string.
+   * @param aiConfigYAML YAML string to load the AIConfig from.
+   */
+  public static loadYAML(aiConfigYAML: string) {
+    const aiConfigObj = yaml.load(aiConfigYAML);
+    return this.loadJSON(aiConfigObj);
+  }
+
+  /**
    * Loads an AIConfig from a JSON object.
    * @param aiConfigObj JSON object to load the AIConfig from.
    */
   public static loadJSON(aiConfigObj: any) {
+    if (typeof aiConfigObj === "string") {
+      // Parse the string as JSON
+      aiConfigObj = JSON.parse(aiConfigObj);
+    }
+
     // TODO: saqadri - validate that the type satisfies AIConfig interface
     const aiConfig = new AIConfigRuntime(
       aiConfigObj.name,


### PR DESCRIPTION
[2/n] Add to_string method to AIConfigRuntime



Allow saving an AIConfigRuntime to a string by creating a `to_string` method that encapsulates the core business logic of the `save` method.

This is needed for VSCode extension (top of stack), which sends the state of the AIConfigRuntime to the editor as a string for management (the IDE is responsible for managing the document, and for saving it to disk).

Test Plan:

Tested out getting started ipynb with:

save JSON:

```
config = AIConfigRuntime.load('travel.aiconfig.json')
config.save('travel2.aiconfig.json')
```

save YAML:
```
config.save('travel2.aiconfig.yaml', mode="yaml")
```

to JSON string:
```
config_str = config.to_string()
print(config_str)
```

to YAML string:
```
config_yaml = config.to_string(mode="yaml")
print(config_yaml)
```

For further sanity made sure that the generated strings could be loaded back as an AIConfig and `config.run` worked:

```
config = config.load_yaml(config_yaml)
config.run(...)
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1058).
* #1076
* #1060
* #1059
* __->__ #1058
* #1057