### PR TITLE
[3/n] Add /api/load_content and /api/to_string endpoints to aiconfig server

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -53,13 +53,16 @@ for model in dalle_image_generation_models:
 ModelParserRegistry.register_model_parser(
     DefaultAnyscaleEndpointParser("AnyscaleEndpoint")
 )
-ModelParserRegistry.register_model_parser(GeminiModelParser("gemini-pro"), ["gemini-pro"])
+ModelParserRegistry.register_model_parser(
+    GeminiModelParser("gemini-pro"), ["gemini-pro"]
+)
 ModelParserRegistry.register_model_parser(ClaudeBedrockModelParser())
 ModelParserRegistry.register_model_parser(HuggingFaceTextGenerationParser())
 for model in gpt_models_extra:
     ModelParserRegistry.register_model_parser(DefaultOpenAIParser(model))
 ModelParserRegistry.register_model_parser(PaLMChatParser())
 ModelParserRegistry.register_model_parser(PaLMTextParser())
+
 
 class AIConfigRuntime(AIConfig):
     # A mapping of model names to their respective parsers
@@ -116,14 +119,37 @@ class AIConfigRuntime(AIConfig):
             else:
                 data = file.read()
 
-        # load the file as bytes and let pydantic handle the parsing
-        # validated_data =  AIConfig.model_validate_json(file.read())
-        aiconfigruntime = cls.model_validate_json(data)
-        update_model_parser_registry_with_config_runtime(aiconfigruntime)
-
+        config_runtime = cls.load_json(data)
         # set the file path. This is used when saving the config
-        aiconfigruntime.file_path = config_filepath
-        return aiconfigruntime
+        config_runtime.file_path = config_filepath
+        return config_runtime
+
+    @classmethod
+    def load_json(cls, config_json: str) -> "AIConfigRuntime":
+        """
+        Constructs AIConfigRuntime from provided JSON and returns it.
+
+        Args:
+            config_json (str): The JSON representing the AIConfig.
+        """
+
+        config_runtime = cls.model_validate_json(config_json)
+        update_model_parser_registry_with_config_runtime(config_runtime)
+
+        return config_runtime
+
+    @classmethod
+    def load_yaml(cls, config_yaml: str) -> "AIConfigRuntime":
+        """
+        Constructs AIConfigRuntime from provided YAML and returns it.
+
+        Args:
+            config_yaml (str): The YAML representing the AIConfig.
+        """
+
+        yaml_data = yaml.safe_load(config_yaml)
+        config_json = json.dumps(yaml_data)
+        return cls.load_json(config_json)
 
     @classmethod
     def load_from_workbook(cls, workbook_id: str) -> "AIConfigRuntime":

--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -7,7 +7,7 @@ import threading
 import time
 import uuid
 import webbrowser
-from typing import Any, Dict, Type, Union
+from typing import Any, Dict, Literal, Type, Union
 
 import lastmile_utils.lib.core.api as core_utils
 import result
@@ -42,13 +42,14 @@ from flask import Flask, Response, request, stream_with_context
 from flask_cors import CORS
 from result import Err, Ok, Result
 
-from aiconfig.schema import ExecuteResult, Output, Prompt
+from aiconfig.schema import ExecuteResult, Output, Prompt, PromptMetadata
 
 logging.getLogger("werkzeug").disabled = True
 
 logging.basicConfig(format=core_utils.LOGGER_FMT)
 LOGGER = logging.getLogger(__name__)
 
+# TODO: saqadri - use logs directory to save logs
 log_handler = logging.FileHandler("editor_flask_server.log", mode="a")
 formatter = logging.Formatter(core_utils.LOGGER_FMT)
 log_handler.setFormatter(formatter)
@@ -188,6 +189,45 @@ def load() -> FlaskResponse:
                 ).to_flask_format()
 
 
+@app.route("/api/load_content", methods=["POST"])
+def load_content() -> FlaskResponse:
+    state = get_server_state(app)
+    request_json = request.get_json()
+
+    content = request_json.get("content", None)
+    mode = request_json.get("mode", "json")
+    if content is None:
+        # In this case let's create an empty AIConfig
+        aiconfig = AIConfigRuntime.create()  # type: ignore
+        model_ids = ModelParserRegistry.parser_ids()
+        if len(model_ids) > 0:
+            aiconfig.add_prompt(
+                "prompt_1",
+                Prompt(
+                    name="prompt_1",
+                    input="",
+                    metadata=PromptMetadata(model=model_ids[0]),
+                ),
+            )
+
+            state.aiconfig = aiconfig
+            return HttpResponseWithAIConfig(
+                message="Created", aiconfig=aiconfig
+            ).to_flask_format()
+
+    # If we have been provided with the aiconfig string, use it to instantiate
+    # an AIConfigRuntime object
+    if mode == "json":
+        aiconfig = AIConfigRuntime.load_json(content)
+    else:
+        aiconfig = AIConfigRuntime.load_yaml(content)
+
+    state.aiconfig = aiconfig
+    return HttpResponseWithAIConfig(
+        message="Loaded", aiconfig=aiconfig
+    ).to_flask_format()
+
+
 @app.route("/api/save", methods=["POST"])
 def save() -> FlaskResponse:
     state = get_server_state(app)
@@ -223,6 +263,30 @@ def save() -> FlaskResponse:
                 code=400,
                 aiconfig=None,
             ).to_flask_format()
+
+
+@app.route("/api/to_string", methods=["POST"])
+def to_string() -> FlaskResponse:
+    state = get_server_state(app)
+    aiconfig = state.aiconfig
+    request_json = request.get_json()
+    mode: Literal["json", "yaml"] = request_json.get("mode", "json")
+    include_outputs: bool = request_json.get("include_outputs", True)
+
+    if mode != "json" and mode != "yaml":
+        return HttpResponseWithAIConfig(
+            message=f"Invalid mode: {mode}", code=400, aiconfig=None
+        ).to_flask_format()
+
+    if aiconfig is None:
+        return HttpResponseWithAIConfig(
+            message="No AIConfig loaded", code=400, aiconfig=None
+        ).to_flask_format()
+    else:
+        aiconfig_string = aiconfig.to_string(
+            include_outputs=include_outputs, mode=mode
+        )
+        return FlaskResponse(({"aiconfig_string": aiconfig_string}, 200))
 
 
 @app.route("/api/create", methods=["POST"])

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -233,12 +233,40 @@ export class AIConfigRuntime implements AIConfig {
    * Saves this AIConfig to a file.
    * @param filePath The path to the file to save to.
    * @param saveOptions Options that determine how to save the AIConfig to the file.
+   * @param mode Whether to save the AIConfig as JSON or YAML. If unspecified, the file extension will be used to determine the mode.
    */
   public save(
     filePath?: string,
     saveOptions?: SaveOptions,
     mode?: "json" | "yaml"
   ) {
+    const defaultFilePath = mode === "yaml" ? "aiconfig.yaml" : "aiconfig.json";
+    if (!filePath) {
+      filePath = this.filePath ?? defaultFilePath;
+    }
+
+    if (mode == null) {
+      if (isYamlExt(filePath)) {
+        mode = "yaml";
+      } else {
+        // Default to JSON
+        mode = "json";
+      }
+    }
+
+    const aiConfigString = this.toString(saveOptions, mode);
+    fs.writeFileSync(filePath, aiConfigString);
+  }
+
+  /**
+   * Returns this AIConfig as a string.
+   *
+   * Note that this doesn't return the full string representation of the AIConfig object,
+   * but rather the string representation of the AIConfig object that can be persisted to a file.
+   * @param saveOptions Options that determine how to serialize the AIConfig to string.
+   * @param mode Whether to save the AIConfig as JSON or YAML. Defaults to JSON.
+   */
+  public toString(saveOptions?: SaveOptions, mode: "json" | "yaml" = "json") {
     const keysToOmit = ["filePath", "callbackManager"] as const;
 
     try {
@@ -254,19 +282,9 @@ export class AIConfigRuntime implements AIConfig {
         aiConfigObj.prompts = prompts;
       }
 
-      const defaultFilePath =
-        mode === "yaml" ? "aiconfig.yaml" : "aiconfig.json";
-      if (!filePath) {
-        filePath = this.filePath ?? defaultFilePath;
-      }
-
-      if (mode == null) {
-        if (isYamlExt(filePath)) {
-          mode = "yaml";
-        } else {
-          // Default to JSON
-          mode = "json";
-        }
+      if (aiConfigObj["$schema"] == null) {
+        // Add the $schema property to the JSON object before saving it. In the future this can respect the version specified in the AIConfig.
+        aiConfigObj["$schema"] = "https://json.schemastore.org/aiconfig-1.0";
       }
 
       // TODO: saqadri - make sure that the object satisfies the AIConfig schema
@@ -274,12 +292,10 @@ export class AIConfigRuntime implements AIConfig {
       if (mode === "yaml") {
         aiConfigString = yaml.dump(aiConfigObj, { indent: 2 });
       } else {
-        // Add the $schema property to the JSON object before saving it. In the future this can respect the version specified in the AIConfig.
-        aiConfigObj["$schema"] = "https://json.schemastore.org/aiconfig-1.0";
         aiConfigString = JSON.stringify(aiConfigObj, null, 2);
       }
 
-      fs.writeFileSync(filePath, aiConfigString);
+      return aiConfigString;
     } catch (error) {
       console.error(error);
       throw error;

--- a/typescript/lib/config.ts
+++ b/typescript/lib/config.ts
@@ -115,10 +115,24 @@ export class AIConfigRuntime implements AIConfig {
   }
 
   /**
+   * Loads an AIConfig from a YAML string.
+   * @param aiConfigYAML YAML string to load the AIConfig from.
+   */
+  public static loadYAML(aiConfigYAML: string) {
+    const aiConfigObj = yaml.load(aiConfigYAML);
+    return this.loadJSON(aiConfigObj);
+  }
+
+  /**
    * Loads an AIConfig from a JSON object.
    * @param aiConfigObj JSON object to load the AIConfig from.
    */
   public static loadJSON(aiConfigObj: any) {
+    if (typeof aiConfigObj === "string") {
+      // Parse the string as JSON
+      aiConfigObj = JSON.parse(aiConfigObj);
+    }
+
     // TODO: saqadri - validate that the type satisfies AIConfig interface
     const aiConfig = new AIConfigRuntime(
       aiConfigObj.name,


### PR DESCRIPTION
[3/n] Add /api/load_content and /api/to_string endpoints to aiconfig server


These endpoints allow loading an AIConfigRuntime from a string, and serializing it to a string. These will be used at the top of the stack by the VSCode extension.

Test Plan:
* At the top of the stack. Validated locally that these work.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1059).
* #1076
* #1060
* __->__ #1059
* #1058
* #1057