### PR TITLE
[editor] Support ThemeMode Override

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -31,6 +31,7 @@ import {
   AIConfigEditorMode,
   LogEvent,
   LogEventData,
+  ThemeMode,
   aiConfigToClientConfig,
   clientConfigToAIConfig,
   clientPromptToAIConfigPrompt,
@@ -64,6 +65,12 @@ type Props = {
   callbacks?: AIConfigCallbacks;
   mode?: AIConfigEditorMode;
   readOnly?: boolean;
+  /**
+   * Theme mode override for the editor. By default, the editor will use the system
+   * theme variant for the theme associated with the EditorMode. This prop allows
+   * overriding that behavior.
+   */
+  themeMode?: ThemeMode;
 };
 
 export type RunPromptStreamEvent =
@@ -137,6 +144,7 @@ export default function AIConfigEditor({
   callbacks,
   mode,
   readOnly = false,
+  themeMode,
 }: Props) {
   const [isSaving, setIsSaving] = useState(false);
   const [serverStatus, setServerStatus] = useState<"OK" | "ERROR">("OK");
@@ -923,7 +931,7 @@ export default function AIConfigEditor({
   const runningPromptId: string | undefined = aiconfigState._ui.runningPromptId;
 
   return (
-    <AIConfigEditorThemeProvider mode={mode}>
+    <AIConfigEditorThemeProvider mode={mode} themeMode={themeMode}>
       <AIConfigContext.Provider value={contextValue}>
         <Notifications />
         <div className="editorBackground">

--- a/python/src/aiconfig/editor/client/src/shared/types.ts
+++ b/python/src/aiconfig/editor/client/src/shared/types.ts
@@ -63,15 +63,17 @@ export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
   };
 }
 
-export type LogEvent = 
+export type LogEvent =
   | "ADD_PROMPT"
-  | "SAVE_BUTTON_CLICKED" 
+  | "SAVE_BUTTON_CLICKED"
   | "RUN_PROMPT_START"
-  | "RUN_PROMPT_CANCELED" 
-  | "RUN_PROMPT_ERROR" 
+  | "RUN_PROMPT_CANCELED"
+  | "RUN_PROMPT_ERROR"
   | "RUN_PROMPT_SUCCESS";
 
 // TODO: schematize this
 export type LogEventData = JSONObject;
 
 export type AIConfigEditorMode = "local" | "gradio" | "vscode";
+
+export type ThemeMode = "light" | "dark";

--- a/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
+++ b/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
@@ -1,5 +1,5 @@
 import { MantineProvider } from "@mantine/core";
-import { AIConfigEditorMode } from "../shared/types";
+import { AIConfigEditorMode, ThemeMode } from "../shared/types";
 import { LOCAL_THEME } from "./LocalTheme";
 import { GRADIO_THEME } from "./GradioTheme";
 import ConditionalWrapper from "../components/ConditionalWrapper";
@@ -9,6 +9,7 @@ import { useMemo } from "react";
 type Props = {
   children: React.ReactNode;
   mode?: AIConfigEditorMode;
+  themeMode?: ThemeMode;
 };
 
 const THEMES = {
@@ -18,8 +19,18 @@ const THEMES = {
   vscode: LOCAL_THEME,
 };
 
-export default function AIConfigEditorThemeProvider({ children, mode }: Props) {
-  const preferredColorScheme = useColorScheme();
+export default function AIConfigEditorThemeProvider({
+  children,
+  mode,
+  themeMode,
+}: Props) {
+  // Use system color scheme by default (don't conditionally call hooks!)
+  let preferredColorScheme = useColorScheme();
+  if (themeMode) {
+    // if provided, themeMode overrides system color scheme
+    preferredColorScheme = themeMode;
+  }
+
   const theme = useMemo(
     () => ({
       colorScheme: preferredColorScheme,


### PR DESCRIPTION
# [editor] Support ThemeMode Override

In Gradio, the theme/colors for the UI can be specified as part of the user's HuggingFace account settings. That theme value is propagated through gradio custom components as a theme_mode='system' | 'dark' | 'light' value (system by default). Our aiconfig-editor code already dynamically changes colors for gradio theme based on system theme. However, it doesn't currently have a way to dynamically change based on HF theme settings. This PR adds a 'themeMode' prop to the AIConfigEditor with which root components can override the dark/light theme used by the editor.

With this landed, we'll then be able to pass the prop from the Gradio component and fix the HF space theme issues


https://github.com/lastmile-ai/aiconfig/assets/5060851/f6141e64-ea83-44e5-bc5c-60aa1997d16a

## Testing
- In LocalEditor, set mode="gradio"
- Set themeMode to light/dark and ensure it overrides system theme

