### PR TITLE
[python] Update Parameterization to pull outputs regardless of input

### DIFF
--- a/python/src/aiconfig/util/params.py
+++ b/python/src/aiconfig/util/params.py
@@ -1,6 +1,6 @@
 import re
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Set
 
 from aiconfig.registry import ModelParserRegistry
 from pybars import Compiler
@@ -253,7 +253,7 @@ def get_prompt_template(
 
 def collect_prompt_references(
     current_prompt: Prompt, ai_config: "AIConfigRuntime"
-):
+) -> Dict[Any, Any]:
     """
     Collects references to all other prompts in the AIConfig. Only prompts that appear before the current prompt are collected.
     """
@@ -262,11 +262,9 @@ def collect_prompt_references(
         if current_prompt.name == previous_prompt.name:
             break
 
+        # Note: not all model inputs are parameterizable. This can be None.
         prompt_input = get_prompt_template(previous_prompt, ai_config)
-        if prompt_input is None:
-            # not all model inputs are parameterizable
-            continue
-
+        
         prompt_output = (
             ai_config.get_output_text(
                 previous_prompt, ai_config.get_latest_output(previous_prompt)
@@ -274,6 +272,8 @@ def collect_prompt_references(
             if previous_prompt.outputs
             else None
         )
+
+        # pybars will ignore None values when resolving the template
         prompt_references[previous_prompt.name] = {
             "input": prompt_input,
             "output": prompt_output,


### PR DESCRIPTION
[python] Update Parameterization to pull outputs regardless of input





Today parameterization will skip prompts if the input is not parameterizable. Instead, update to paramterize outputs even if the input is not parameterizable.

Typescript sdk already does something similar.


## Testplan
Run with HF Remote Inference models

<img width="1030" alt="Screenshot 2024-01-29 at 4 38 09 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/8b7c013f-2d7e-4df1-9cf4-98652d695e0c">
