### PR TITLE
[editor] Fix Padding on Parameters Bar

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -953,7 +953,7 @@ export default function AIConfigEditor({
     <AIConfigEditorThemeProvider mode={mode} themeMode={themeMode}>
       <AIConfigContext.Provider value={contextValue}>
         <Notifications />
-        <div className="editorBackground">
+        <Container className="editorBackground" maw="80rem">
           {serverStatus !== "OK" && (
             <>
               {/* // Simple placeholder block div to make sure the banner does not overlap page contents until scrolling past its height */}
@@ -985,7 +985,7 @@ export default function AIConfigEditor({
               </Alert>
             </>
           )}
-          <Container maw="80rem">
+          <div>
             <Flex justify="flex-end" mt="md" mb="xs">
               {
                 <Group>
@@ -1035,7 +1035,7 @@ export default function AIConfigEditor({
               setDescription={onSetDescription}
               setName={onSetName}
             />
-          </Container>
+          </div>
           <GlobalParametersContainer
             initialValue={aiconfigState?.metadata?.parameters ?? {}}
             onUpdateParameters={onUpdateGlobalParameters}
@@ -1055,7 +1055,7 @@ export default function AIConfigEditor({
             prompts={aiconfigState.prompts}
             runningPromptId={runningPromptId}
           />
-        </div>
+        </Container>
       </AIConfigContext.Provider>
     </AIConfigEditorThemeProvider>
   );

--- a/python/src/aiconfig/editor/client/src/components/GlobalParametersContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/GlobalParametersContainer.tsx
@@ -1,4 +1,4 @@
-import { Container, Accordion, Text } from "@mantine/core";
+import { Accordion, Text } from "@mantine/core";
 import { JSONObject } from "aiconfig";
 import { memo, useState } from "react";
 import ParametersRenderer from "./ParametersRenderer";
@@ -15,7 +15,7 @@ export default memo(function GlobalParametersContainer({
   const [isParametersDrawerOpen, setIsParametersDrawerOpen] = useState(false);
 
   return (
-    <Container maw="80rem" className="parametersContainer">
+    <div className="parametersContainer">
       <Accordion
         styles={{
           item: { borderBottom: 0 },
@@ -42,6 +42,6 @@ export default memo(function GlobalParametersContainer({
           </Accordion.Panel>
         </Accordion.Item>
       </Accordion>
-    </Container>
+    </div>
   );
 });

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptsContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptsContainer.tsx
@@ -1,4 +1,4 @@
-import { Container, Flex, Stack, createStyles } from "@mantine/core";
+import { Flex, Stack, createStyles } from "@mantine/core";
 import { memo, useContext } from "react";
 import AIConfigContext from "../../contexts/AIConfigContext";
 import AddPromptButton from "./AddPromptButton";
@@ -46,7 +46,7 @@ export default memo(function PromptsContainer(props: Props) {
   const { readOnly } = useContext(AIConfigContext);
 
   return (
-    <Container maw="80rem" className={classes.promptsContainer}>
+    <div className={classes.promptsContainer}>
       {!readOnly && (
         <AddPromptButton
           getModels={props.getModels}
@@ -60,10 +60,12 @@ export default memo(function PromptsContainer(props: Props) {
         return (
           <Stack key={prompt._ui.id}>
             <Flex mt="md">
-              {!readOnly && <PromptMenuButton
-                promptId={prompt._ui.id}
-                onDeletePrompt={() => props.onDeletePrompt(prompt._ui.id)}
-              />}
+              {!readOnly && (
+                <PromptMenuButton
+                  promptId={prompt._ui.id}
+                  onDeletePrompt={() => props.onDeletePrompt(prompt._ui.id)}
+                />
+              )}
               <PromptContainer
                 prompt={prompt}
                 getModels={props.getModels}
@@ -92,6 +94,6 @@ export default memo(function PromptsContainer(props: Props) {
           </Stack>
         );
       })}
-    </Container>
+    </div>
   );
 });

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -130,7 +130,7 @@ export const GRADIO_THEME: MantineThemeOverride = {
     ".parametersContainer": {
       maxWidth: "1250px",
       maxHeight: "-webkit-fill-available",
-      margin: "16px auto",
+      margin: "16px auto 16px 36px",
       padding: "0",
       backgroundColor: theme.colorScheme === "light" ? "#F9FAFB" : "#1f2938",
       borderRadius: "8px",

--- a/python/src/aiconfig/editor/client/src/themes/LocalTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/LocalTheme.ts
@@ -111,7 +111,7 @@ export const LOCAL_THEME: MantineThemeOverride = {
     ".parametersContainer": {
       maxWidth: "1250px",
       maxHeight: "-webkit-fill-available",
-      margin: "16px auto",
+      margin: "16px auto 16px 36px",
       padding: "0",
       backgroundColor: "rgba(226,232,255,.1)",
       borderRadius: "4px",


### PR DESCRIPTION
[editor] Fix Padding on Parameters Bar

# [editor] Fix Padding on Parameters Bar

We were wrapping some components in a Container (which adds padding on the sides), but not the global parameters bar. This resulted in weird padding differences between the parameters and cells:

<img width="1065" alt="Screenshot 2024-01-30 at 1 45 44 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/c599e211-04b8-418a-b451-69ceb4a15633">

To fix, just remove these inner containers and instead wrap the entire editor contents in a container, plus fix the left margin on parameters container:
<img width="1788" alt="Screenshot 2024-01-30 at 2 56 18 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/0f8f198f-e044-476a-9d73-de52b25c56af">
<img width="1346" alt="Screenshot 2024-01-30 at 2 57 28 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/887c2a89-9245-4a53-8d22-48c6e6222432">

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1077).
* #1081
* __->__ #1077