### PR TITLE
[fix] Update model parsers to config runtime on AIConfigRuntime.create() call

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -90,7 +90,7 @@ class AIConfigRuntime(AIConfig):
 
         This method creates a new AI configuration with the provided parameters and sets it as the current AI configuration.
         """
-        return cls(
+        config: "AIConfigRuntime" = cls(
             **{
                 "name": name,
                 "description": description,
@@ -99,6 +99,8 @@ class AIConfigRuntime(AIConfig):
                 "prompts": prompts,
             }
         )
+        update_model_parser_registry_with_config_runtime(config)
+        return config
 
     @classmethod
     def load(cls, config_filepath: str) -> "AIConfigRuntime":

--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -367,6 +367,7 @@ class OpenAIInference(ParameterizedModelParser):
                     output = ExecuteResult(
                         **{
                             "output_type": "execute_result",
+                            # TODO (rossdan): accumulated_message_for_choice.get("content")
                             "data": accumulated_message_for_choice,
                             "execution_count": index,
                             "metadata": chunk_without_choices,


### PR DESCRIPTION
[fix] Update model parsers to config runtime on AIConfigRuntime.create() call

Pretty good bug fix. If we define a model + model parser in a config and create it using `create()` instead of `load()` then this fails

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1078).
* __->__ #1078
* #1071