### PR TITLE
Fix Dark Theme in Gradio

### DIFF
--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -17,13 +17,40 @@ export const GRADIO_THEME: MantineThemeOverride = {
 
   //gradio light theme
   globalStyles: (theme) => ({
-    ".editorBackground": {
+    "div.editorBackground": {
       background: theme.colorScheme === "light" ? "white" : "#0b0f19",
-      margin: "0 auto",
-      minHeight: "400px",
+      borderRadius: "8px",
       // Gradio component is iframed so height should be in relation to
       // the height of the containing iframe, not the viewport
       height: "100%",
+      // Add some margin & padding to better visually separate from surrounding
+      // gradio card
+      margin: "14px auto 0 auto",
+      minHeight: "400px",
+      paddingTop: "2px",
+
+      // Apply nested styles on mantine text components for higher specificity
+      // than gradio text styles
+      ".mantine-Input-input:focus": {
+        outline: "solid 1px #E85921 !important",
+        outlineOffset: "-1px",
+      },
+
+      ".mantine-Input-input":
+        theme.colorScheme === "dark"
+          ? {
+              color: "#C1C2C5",
+              backgroundColor: "#25262b",
+            }
+          : undefined, // light colorScheme is fine without overrides
+
+      ".mantine-Text-root":
+        theme.colorScheme === "dark"
+          ? {
+              color: "C1C2C5",
+              // default inherited backgroundColor is correct
+            }
+          : undefined, // light colorScheme is fine without overrides
     },
     ".monoFont": {
       fontFamily:
@@ -38,10 +65,6 @@ export const GRADIO_THEME: MantineThemeOverride = {
         margin: "8px 0px 0px 0px",
         backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
         boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
-        ":focus": {
-          outline: "solid 1px #E85921 !important",
-          outlineOffset: "-1px",
-        },
       },
     },
     ".cellStyle": {
@@ -69,10 +92,6 @@ export const GRADIO_THEME: MantineThemeOverride = {
         margin: "8px 0px 0px 0px",
         boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
         backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
-        ":focus": {
-          outline: "solid 1px #E85921 !important",
-          outlineOffset: "-1px",
-        },
       },
     },
     ".sidePanel": {
@@ -151,10 +170,6 @@ export const GRADIO_THEME: MantineThemeOverride = {
         boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
         borderRadius: "8px",
         backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
-        ":focus": {
-          outline: "solid 1px #E85921 !important",
-          outlineOffset: "-1px",
-        },
       },
       textarea: {
         border: "1px solid !important",


### PR DESCRIPTION
Fix Dark Theme in Gradio

# Fix Dark Theme in Gradio

Updating the gradio theme here for 2 style updates:

1. (Most important) Currently, the gradio workbook respects the dark/light theme of the system and/or hugging face space in most places. The exception is text/input (see title input and settings input):
<img width="1489" alt="Screenshot 2024-01-30 at 5 25 45 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/e03080a7-ab3b-418d-80ac-b73b78aa7979">
The problem is that gradio itself has some "text" and "input" style selectors which use system theme instead of the hugging face themeMode. This is only a problem for "dark" theme, though.
To fix, we use more specific selectors which *do* take into account the themeMode here (made the changes in gradio-workbook styles.css and copied over here, checking they still work as intended):

https://github.com/lastmile-ai/aiconfig/assets/5060851/596bbd75-dc34-499f-9046-5edaac393d6e


https://github.com/lastmile-ai/aiconfig/assets/5060851/db2c07a7-fdd2-4961-a6a2-38d7db3db2ea

Also double-checked light mode is still correct.


2. HF / gradio renders components within a card. Our workbook's background is a slightly darker shade than the card (and we probably don't want it to match, since the cells themselves are the same as the surrounding background and cells should have different shade than our background). For now, just make the separation a bit clearer by adding some margin/padding and rounding the corners:

Before:
<img width="1324" alt="Screenshot 2024-01-30 at 4 40 12 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/204bbe6d-78b5-42ad-b288-334b4449c82a">

After:
<img width="1327" alt="Screenshot 2024-01-30 at 4 38 08 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/295fba63-db36-4648-b255-8117b040e9dd">

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1082).
* #1083
* __->__ #1082