### PR TITLE
[gradio] Add missing # for color

### DIFF
--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -47,7 +47,7 @@ export const GRADIO_THEME: MantineThemeOverride = {
       ".mantine-Text-root":
         theme.colorScheme === "dark"
           ? {
-              color: "C1C2C5",
+              color: "#C1C2C5",
               // default inherited backgroundColor is correct
             }
           : undefined, // light colorScheme is fine without overrides


### PR DESCRIPTION
# [gradio] Add missing # for color

The # for the hex color was somehow left off

<img width="1292" alt="Screenshot 2024-01-30 at 7 44 42 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/d168021f-f89a-44b4-afee-b70a0af4ccfa">

