### PR TITLE
[gradio] Use variable for input border color

### DIFF
--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -16,278 +16,281 @@ export const GRADIO_THEME: MantineThemeOverride = {
   },
 
   //gradio light theme
-  globalStyles: (theme) => ({
-    "div.editorBackground": {
-      background: theme.colorScheme === "light" ? "white" : "#0b0f19",
-      borderRadius: "8px",
-      // Gradio component is iframed so height should be in relation to
-      // the height of the containing iframe, not the viewport
-      height: "100%",
-      // Add some margin & padding to better visually separate from surrounding
-      // gradio card
-      margin: "14px auto 0 auto",
-      minHeight: "400px",
-      paddingTop: "2px",
-
-      // Apply nested styles on mantine elements for higher specificity
-      // than gradio element styles
-
-      /*
-       * For all buttons, excluding menu dropdown and .ghost class buttons, apply the gradio color
-       * styles
-       */
-      ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu'])":
-        {
-          background: "linear-gradient(to bottom right, #ffedd5, #fdba74 100%)",
-          border: "1px solid #fed7aa",
-          boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05)",
-          color: "#ea580c !important",
-          fontSize: "16px" /* var(--button-large-text-size) */,
-          fontWeight: 600 /* var(--button-large-text-weight) */,
-          padding: "0 1.25rem",
-        },
-
-      /*
-       * Same as above, only on hover
-       */
-      ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu']):hover":
-        {
-          background: "linear-gradient(to bottom right, #ffedd5, #fed7aa)",
-        },
-
-      /*
-       * Same as above, only on disabled. See gradio styles for these colors, specifically
-       * .secondary[disabled] since .primary doesn't make enough of a contrast
-       */
-      ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu']):disabled":
-        {
-          background:
-            "linear-gradient(to bottom right, #e5e7eb,  #e5e7eb)" /* var(--button-secondary-background-fill-hover) */,
-          borderColor:
-            "#e5e7eb" /* var(--button-secondary-border-color-hover) */,
-          color:
-            "#374151 !important" /* var(--button-secondary-text-color-hover) */,
-          cursor: "not-allowed",
-          pointerEvents:
-            "auto" /* mantine sets to disabled, we want the cursor to show per gradio styles */,
-        },
-
-      /*
-       * For all buttons, excluding menu dropdown, .ghost class buttons, and .runPromptButton, apply
-       * this dark text color (from gradio text) so the text can be seen over orange button background
-       * regardless of theme
-       */
-      ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu']):not(.runPromptButton)":
-        {
-          color: "#374151",
-        },
-
-      /*
-       * Specifically set the .runPromptButton to have the desired styles specified in our custom gradio theme
-       */
-      ".mantine-Button-root.mantine-UnstyledButton-root.runPromptButton": {
+  globalStyles: (theme) => {
+    return {
+      "div.editorBackground": {
+        background: theme.colorScheme === "light" ? "white" : "#0b0f19",
         borderRadius: "8px",
-        height: "auto",
-        margin: "4px",
-        marginTop: "30px",
-        padding: "0.625rem !important",
-      },
+        // Gradio component is iframed so height should be in relation to
+        // the height of the containing iframe, not the viewport
+        height: "100%",
+        // Add some margin & padding to better visually separate from surrounding
+        // gradio card
+        margin: "14px auto 0 auto",
+        minHeight: "400px",
+        paddingTop: "2px",
 
-      ".mantine-Input-input:focus": {
-        outline: "solid 1px #E85921 !important",
-        outlineOffset: "-1px",
-      },
+        // Apply nested styles on mantine elements for higher specificity
+        // than gradio element styles
 
-      ".mantine-Input-input":
-        theme.colorScheme === "dark"
-          ? {
-              color: "#C1C2C5",
-              backgroundColor: "#25262b",
-            }
-          : undefined, // light colorScheme is fine without overrides
+        /*
+         * For all buttons, excluding menu dropdown and .ghost class buttons, apply the gradio color
+         * styles
+         */
+        ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu'])":
+          {
+            background:
+              "linear-gradient(to bottom right, #ffedd5, #fdba74 100%)",
+            border: "1px solid #fed7aa",
+            boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05)",
+            color: "#ea580c !important",
+            fontSize: "16px" /* var(--button-large-text-size) */,
+            fontWeight: 600 /* var(--button-large-text-weight) */,
+            padding: "0 1.25rem",
+          },
 
-      ".mantine-Menu-dropdown": {
-        border: "0.0625rem solid #373A40",
-      },
+        /*
+         * Same as above, only on hover
+         */
+        ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu']):hover":
+          {
+            background: "linear-gradient(to bottom right, #ffedd5, #fed7aa)",
+          },
 
-      ".mantine-Slider-bar": {
-        backgroundColor: "#E85921",
-      },
+        /*
+         * Same as above, only on disabled. See gradio styles for these colors, specifically
+         * .secondary[disabled] since .primary doesn't make enough of a contrast
+         */
+        ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu']):disabled":
+          {
+            background:
+              "linear-gradient(to bottom right, #e5e7eb,  #e5e7eb)" /* var(--button-secondary-background-fill-hover) */,
+            borderColor:
+              "#e5e7eb" /* var(--button-secondary-border-color-hover) */,
+            color:
+              "#374151 !important" /* var(--button-secondary-text-color-hover) */,
+            cursor: "not-allowed",
+            pointerEvents:
+              "auto" /* mantine sets to disabled, we want the cursor to show per gradio styles */,
+          },
 
-      ".mantine-Slider-thumb": {
-        border: "0.25rem solid #E85921",
-      },
+        /*
+         * For all buttons, excluding menu dropdown, .ghost class buttons, and .runPromptButton, apply
+         * this dark text color (from gradio text) so the text can be seen over orange button background
+         * regardless of theme
+         */
+        ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu']):not(.runPromptButton)":
+          {
+            color: "#374151",
+          },
 
-      ".mantine-Tabs-tab[data-active]": {
-        borderBottom: "solid 1px #E85921",
-        ":hover": {
+        /*
+         * Specifically set the .runPromptButton to have the desired styles specified in our custom gradio theme
+         */
+        ".mantine-Button-root.mantine-UnstyledButton-root.runPromptButton": {
+          borderRadius: "8px",
+          height: "auto",
+          margin: "4px",
+          marginTop: "30px",
+          padding: "0.625rem !important",
+        },
+
+        ".mantine-Input-input:focus": {
+          outline: "solid 1px #E85921 !important",
+          outlineOffset: "-1px",
+        },
+
+        ".mantine-Input-input":
+          theme.colorScheme === "dark"
+            ? {
+                color: "#C1C2C5",
+                backgroundColor: "#25262b",
+              }
+            : undefined, // light colorScheme is fine without overrides
+
+        ".mantine-Menu-dropdown": {
+          border: "0.0625rem solid #373A40",
+        },
+
+        ".mantine-Slider-bar": {
+          backgroundColor: "#E85921",
+        },
+
+        ".mantine-Slider-thumb": {
+          border: "0.25rem solid #E85921",
+        },
+
+        ".mantine-Tabs-tab[data-active]": {
           borderBottom: "solid 1px #E85921",
+          ":hover": {
+            borderBottom: "solid 1px #E85921",
+          },
+        },
+
+        ".mantine-Tabs-tabsList": {
+          gap: "12px",
+        },
+
+        ".mantine-Text-root":
+          theme.colorScheme === "dark"
+            ? {
+                color: "#C1C2C5",
+                // default inherited backgroundColor is correct
+              }
+            : undefined, // light colorScheme is fine without overrides
+
+        ".mantine-TextInput-input[data-with-icon]": {
+          paddingLeft: "2.25rem",
+        },
+
+        ".mantine-Title-root.mantine-Text-root": {
+          fontSize: "2rem",
         },
       },
-
-      ".mantine-Tabs-tabsList": {
-        gap: "12px",
-      },
-
-      ".mantine-Text-root":
-        theme.colorScheme === "dark"
-          ? {
-              color: "#C1C2C5",
-              // default inherited backgroundColor is correct
-            }
-          : undefined, // light colorScheme is fine without overrides
-
-      ".mantine-TextInput-input[data-with-icon]": {
-        paddingLeft: "2.25rem",
-      },
-
-      ".mantine-Title-root.mantine-Text-root": {
-        fontSize: "2rem",
-      },
-    },
-    ".monoFont": {
-      fontFamily:
-        "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
-    },
-    ".ghost": {
-      input: {
-        maxHeight: "16px",
+      ".monoFont": {
         fontFamily:
           "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
-        borderRadius: "8px",
-        margin: "8px 0px 0px 0px",
-        backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
-        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
       },
-    },
-    ".cellStyle": {
-      border: "1px solid",
-      borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
-      background: theme.colorScheme === "light" ? "white" : "#1f2938",
-      flex: 1,
-      borderTopRightRadius: "0px",
-      borderBottomRightRadius: "0px",
-      borderTopLeftRadius: "8px",
-      borderBottomLeftRadius: "8px",
-      ":hover": {
+      ".ghost": {
+        input: {
+          maxHeight: "16px",
+          fontFamily:
+            "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+          borderRadius: "8px",
+          margin: "8px 0px 0px 0px",
+          backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
+          boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+        },
+      },
+      ".cellStyle": {
+        border: "1px solid",
+        borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
+        background: theme.colorScheme === "light" ? "white" : "#1f2938",
+        flex: 1,
+        borderTopRightRadius: "0px",
+        borderBottomRightRadius: "0px",
+        borderTopLeftRadius: "8px",
+        borderBottomLeftRadius: "8px",
+        ":hover": {
+          background:
+            theme.colorScheme === "light"
+              ? "rgba(249, 250, 251, 0.5) !important"
+              : "#1f2938",
+        },
+        textarea: {
+          border: "1px solid !important",
+          borderColor:
+            theme.colorScheme === "light"
+              ? "#E5E7EB !important"
+              : "#384152 !important",
+          borderRadius: "8px",
+          margin: "8px 0px 0px 0px",
+          boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+          backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
+        },
+      },
+      ".sidePanel": {
+        border: "1px solid",
+        borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
+        borderLeft: "none",
+        borderTopRightRadius: "8px",
+        borderBottomRightRadius: "8px",
         background:
           theme.colorScheme === "light"
-            ? "rgba(249, 250, 251, 0.5) !important"
-            : "#1f2938",
-      },
-      textarea: {
-        border: "1px solid !important",
-        borderColor:
-          theme.colorScheme === "light"
-            ? "#E5E7EB !important"
-            : "#384152 !important",
-        borderRadius: "8px",
-        margin: "8px 0px 0px 0px",
-        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
-        backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
-      },
-    },
-    ".sidePanel": {
-      border: "1px solid",
-      borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
-      borderLeft: "none",
-      borderTopRightRadius: "8px",
-      borderBottomRightRadius: "8px",
-      background:
-        theme.colorScheme === "light"
-          ? "linear-gradient(90deg, #F6F6F6, #FFFFFF)"
-          : "transparent",
-      input: {
-        border: "1px solid #E5E7EB !important",
-        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
-        backgroundColor: "#ffffff",
-        ":focus": {
-          outline: "solid 1px #E85921 !important",
-          outlineOffset: "-1px",
+            ? "linear-gradient(90deg, #F6F6F6, #FFFFFF)"
+            : "transparent",
+        input: {
+          border: "1px solid #E5E7EB !important",
+          boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+          backgroundColor: "#ffffff",
+          ":focus": {
+            outline: "solid 1px #E85921 !important",
+            outlineOffset: "-1px",
+          },
         },
       },
-    },
-    ".divider": {
-      borderTopWidth: "1px",
-      borderTopColor: "rgba(226,232,255,.1)",
-      marginBottom: "0.5em",
-    },
-    ".runPromptButton": {
-      borderRadius: "8px",
-      border: "1px solid #FDD7AD",
-      background: "linear-gradient(180deg, #FEE1C0 0%, #FCC792 100%)",
-      boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05)",
-      margin: "4px",
-      height: "auto",
-      color: "#E85921",
-      path: {
-        color: "#E85921",
+      ".divider": {
+        borderTopWidth: "1px",
+        borderTopColor: "rgba(226,232,255,.1)",
+        marginBottom: "0.5em",
       },
-      ":hover": {
-        background: "linear-gradient(180deg, #FEE1C0 0%, #FF9E3D 100%)",
-      },
-    },
-    ".actionTabsPanel": {
-      width: "400px",
-    },
-    ".logo": {
-      maxWidth: "80rem",
-      margin: "0 auto",
-      padding: "32px 0 0 32px",
-      display: "flex",
-      justifyContent: "space-between",
-      alignItems: "center",
-    },
-
-    ".parametersContainer": {
-      maxWidth: "1250px",
-      maxHeight: "-webkit-fill-available",
-      margin: "16px auto 16px 36px",
-      padding: "0",
-      backgroundColor: theme.colorScheme === "light" ? "#F9FAFB" : "#1f2938",
-      borderRadius: "8px",
-      border: "1px solid",
-      borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
-      button: {
-        ":hover": {
-          backgroundColor:
-            theme.colorScheme === "light" ? "#F0F1F1" : "transparent",
-        },
-      },
-      input: {
-        border: "1px solid !important",
-        borderColor:
-          theme.colorScheme === "light"
-            ? "#E5E7EB !important"
-            : "#384152 !important",
-        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+      ".runPromptButton": {
         borderRadius: "8px",
-        backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
-      },
-      textarea: {
-        border: "1px solid !important",
-        borderColor:
-          theme.colorScheme === "light"
-            ? "#E5E7EB !important"
-            : "#384152 !important",
-        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
-        borderRadius: "8px",
-        backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
-        ":focus": {
-          outline: "solid 1px #E85921 !important",
-          outlineOffset: "-1px",
-        },
-      },
-      ".addParameterButton": {
-        position: "sticky",
-        left: "0",
-        bottom: "0",
-        margin: "16px 0 0 0",
+        border: "1px solid #FDD7AD",
         background: "linear-gradient(180deg, #FEE1C0 0%, #FCC792 100%)",
+        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05)",
+        margin: "4px",
+        height: "auto",
+        color: "#E85921",
         path: {
           color: "#E85921",
         },
+        ":hover": {
+          background: "linear-gradient(180deg, #FEE1C0 0%, #FF9E3D 100%)",
+        },
       },
-    },
-  }),
+      ".actionTabsPanel": {
+        width: "400px",
+      },
+      ".logo": {
+        maxWidth: "80rem",
+        margin: "0 auto",
+        padding: "32px 0 0 32px",
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+      },
+
+      ".parametersContainer": {
+        maxWidth: "1250px",
+        maxHeight: "-webkit-fill-available",
+        margin: "16px auto 16px 36px",
+        padding: "0",
+        backgroundColor: theme.colorScheme === "light" ? "#F9FAFB" : "#1f2938",
+        borderRadius: "8px",
+        border: "1px solid",
+        borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
+        button: {
+          ":hover": {
+            backgroundColor:
+              theme.colorScheme === "light" ? "#F0F1F1" : "transparent",
+          },
+        },
+        input: {
+          border: "1px solid !important",
+          borderColor:
+            theme.colorScheme === "light"
+              ? "#E5E7EB !important"
+              : "#384152 !important",
+          boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+          borderRadius: "8px",
+          backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
+        },
+        textarea: {
+          border: "1px solid !important",
+          borderColor:
+            theme.colorScheme === "light"
+              ? "#E5E7EB !important"
+              : "#384152 !important",
+          boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+          borderRadius: "8px",
+          backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
+          ":focus": {
+            outline: "solid 1px #E85921 !important",
+            outlineOffset: "-1px",
+          },
+        },
+        ".addParameterButton": {
+          position: "sticky",
+          left: "0",
+          bottom: "0",
+          margin: "16px 0 0 0",
+          background: "linear-gradient(180deg, #FEE1C0 0%, #FCC792 100%)",
+          path: {
+            color: "#E85921",
+          },
+        },
+      },
+    };
+  },
 };

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -29,8 +29,70 @@ export const GRADIO_THEME: MantineThemeOverride = {
       minHeight: "400px",
       paddingTop: "2px",
 
-      // Apply nested styles on mantine text components for higher specificity
-      // than gradio text styles
+      // Apply nested styles on mantine elements for higher specificity
+      // than gradio element styles
+
+      /*
+       * For all buttons, excluding menu dropdown and .ghost class buttons, apply the gradio color
+       * styles
+       */
+      ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu'])":
+        {
+          background: "linear-gradient(to bottom right, #ffedd5, #fdba74 100%)",
+          border: "1px solid #fed7aa",
+          boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05)",
+          color: "#ea580c !important",
+          fontSize: "16px" /* var(--button-large-text-size) */,
+          fontWeight: 600 /* var(--button-large-text-weight) */,
+          padding: "0 1.25rem",
+        },
+
+      /*
+       * Same as above, only on hover
+       */
+      ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu']):hover":
+        {
+          background: "linear-gradient(to bottom right, #ffedd5, #fed7aa)",
+        },
+
+      /*
+       * Same as above, only on disabled. See gradio styles for these colors, specifically
+       * .secondary[disabled] since .primary doesn't make enough of a contrast
+       */
+      ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu']):disabled":
+        {
+          background:
+            "linear-gradient(to bottom right, #e5e7eb,  #e5e7eb)" /* var(--button-secondary-background-fill-hover) */,
+          borderColor:
+            "#e5e7eb" /* var(--button-secondary-border-color-hover) */,
+          color:
+            "#374151 !important" /* var(--button-secondary-text-color-hover) */,
+          cursor: "not-allowed",
+          pointerEvents:
+            "auto" /* mantine sets to disabled, we want the cursor to show per gradio styles */,
+        },
+
+      /*
+       * For all buttons, excluding menu dropdown, .ghost class buttons, and .runPromptButton, apply
+       * this dark text color (from gradio text) so the text can be seen over orange button background
+       * regardless of theme
+       */
+      ".mantine-Button-root.mantine-UnstyledButton-root:not(.ghost):not([aria-haspopup='menu']):not(.runPromptButton)":
+        {
+          color: "#374151",
+        },
+
+      /*
+       * Specifically set the .runPromptButton to have the desired styles specified in our custom gradio theme
+       */
+      ".mantine-Button-root.mantine-UnstyledButton-root.runPromptButton": {
+        borderRadius: "8px",
+        height: "auto",
+        margin: "4px",
+        marginTop: "30px",
+        padding: "0.625rem !important",
+      },
+
       ".mantine-Input-input:focus": {
         outline: "solid 1px #E85921 !important",
         outlineOffset: "-1px",
@@ -44,6 +106,29 @@ export const GRADIO_THEME: MantineThemeOverride = {
             }
           : undefined, // light colorScheme is fine without overrides
 
+      ".mantine-Menu-dropdown": {
+        border: "0.0625rem solid #373A40",
+      },
+
+      ".mantine-Slider-bar": {
+        backgroundColor: "#E85921",
+      },
+
+      ".mantine-Slider-thumb": {
+        border: "0.25rem solid #E85921",
+      },
+
+      ".mantine-Tabs-tab[data-active]": {
+        borderBottom: "solid 1px #E85921",
+        ":hover": {
+          borderBottom: "solid 1px #E85921",
+        },
+      },
+
+      ".mantine-Tabs-tabsList": {
+        gap: "12px",
+      },
+
       ".mantine-Text-root":
         theme.colorScheme === "dark"
           ? {
@@ -51,6 +136,14 @@ export const GRADIO_THEME: MantineThemeOverride = {
               // default inherited backgroundColor is correct
             }
           : undefined, // light colorScheme is fine without overrides
+
+      ".mantine-TextInput-input[data-with-icon]": {
+        paddingLeft: "2.25rem",
+      },
+
+      ".mantine-Title-root.mantine-Text-root": {
+        fontSize: "2rem",
+      },
     },
     ".monoFont": {
       fontFamily:
@@ -194,19 +287,6 @@ export const GRADIO_THEME: MantineThemeOverride = {
         path: {
           color: "#E85921",
         },
-      },
-    },
-
-    ".mantine-Slider-thumb": {
-      border: "0.25rem solid #E85921",
-    },
-    ".mantine-Slider-bar": {
-      backgroundColor: "#E85921",
-    },
-    ".mantine-Tabs-tab[data-active]": {
-      borderBottom: "solid 1px #E85921",
-      ":hover": {
-        borderBottom: "solid 1px #E85921",
       },
     },
   }),

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -17,6 +17,9 @@ export const GRADIO_THEME: MantineThemeOverride = {
 
   //gradio light theme
   globalStyles: (theme) => {
+    const inputBorderColor =
+      theme.colorScheme === "light" ? "#E5E7EB" : "#384152";
+
     return {
       "div.editorBackground": {
         background: theme.colorScheme === "light" ? "white" : "#0b0f19",
@@ -163,8 +166,7 @@ export const GRADIO_THEME: MantineThemeOverride = {
         },
       },
       ".cellStyle": {
-        border: "1px solid",
-        borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
+        border: `1px solid ${inputBorderColor}`,
         background: theme.colorScheme === "light" ? "white" : "#1f2938",
         flex: 1,
         borderTopRightRadius: "0px",
@@ -178,11 +180,7 @@ export const GRADIO_THEME: MantineThemeOverride = {
               : "#1f2938",
         },
         textarea: {
-          border: "1px solid !important",
-          borderColor:
-            theme.colorScheme === "light"
-              ? "#E5E7EB !important"
-              : "#384152 !important",
+          border: `1px solid ${inputBorderColor} !important`,
           borderRadius: "8px",
           margin: "8px 0px 0px 0px",
           boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
@@ -190,8 +188,7 @@ export const GRADIO_THEME: MantineThemeOverride = {
         },
       },
       ".sidePanel": {
-        border: "1px solid",
-        borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
+        border: `1px solid ${inputBorderColor}`,
         borderLeft: "none",
         borderTopRightRadius: "8px",
         borderBottomRightRadius: "8px",
@@ -200,7 +197,7 @@ export const GRADIO_THEME: MantineThemeOverride = {
             ? "linear-gradient(90deg, #F6F6F6, #FFFFFF)"
             : "transparent",
         input: {
-          border: "1px solid #E5E7EB !important",
+          border: `1px solid ${inputBorderColor} !important`,
           boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
           backgroundColor: "#ffffff",
           ":focus": {
@@ -248,8 +245,7 @@ export const GRADIO_THEME: MantineThemeOverride = {
         padding: "0",
         backgroundColor: theme.colorScheme === "light" ? "#F9FAFB" : "#1f2938",
         borderRadius: "8px",
-        border: "1px solid",
-        borderColor: theme.colorScheme === "light" ? "#E5E7EB" : "#384152",
+        border: `1px solid ${inputBorderColor}`,
         button: {
           ":hover": {
             backgroundColor:
@@ -257,21 +253,13 @@ export const GRADIO_THEME: MantineThemeOverride = {
           },
         },
         input: {
-          border: "1px solid !important",
-          borderColor:
-            theme.colorScheme === "light"
-              ? "#E5E7EB !important"
-              : "#384152 !important",
+          border: `1px solid ${inputBorderColor} !important`,
           boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
           borderRadius: "8px",
           backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",
         },
         textarea: {
-          border: "1px solid !important",
-          borderColor:
-            theme.colorScheme === "light"
-              ? "#E5E7EB !important"
-              : "#384152 !important",
+          border: `1px solid ${inputBorderColor} !important`,
           boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
           borderRadius: "8px",
           backgroundColor: theme.colorScheme === "light" ? "white" : "#384152",


### PR DESCRIPTION
[gradio] Use variable for input border color

# [gradio] Use variable for input border color

Use a variable, `inputBorderColor` for referencing the border color for different inputs so that it can be used without manually repeating the colors based on theme everywhere we want to have the same border color

## Testing
- Make sure the border for all the inputs are correct (note title is focused so it's orange)
![Screenshot 2024-01-31 at 11 36 10 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/024d67b9-ef84-4f7f-81b1-76d2fad02560)
![Screenshot 2024-01-31 at 11 36 37 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/0f20f5a9-481a-4f07-8e28-8bf4aa15d95a)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1097).
* #1109
* #1105
* #1104
* #1103
* #1102
* #1101
* #1100
* #1099
* #1098
* __->__ #1097
* #1096
* #1095