### PR TITLE
Support Prompt Schemas for Local Models with Task Names

### DIFF
--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -82,7 +82,7 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   "dall-e-2": DalleImageGenerationParserPromptSchema,
   "dall-e-3": DalleImageGenerationParserPromptSchema,
 
-  "ClaudeBedrockModelParser": ClaudeBedrockPromptSchema,
+  ClaudeBedrockModelParser: ClaudeBedrockPromptSchema,
 
   HuggingFaceImage2TextRemoteInference:
     HuggingFaceImage2TextRemoteInferencePromptSchema,
@@ -149,6 +149,15 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   "Text Generation": HuggingFaceTextGenerationRemoteInferencePromptSchema,
   Summarization: HuggingFaceTextSummarizationRemoteInferencePromptSchema,
   Translation: HuggingFaceTextTranslationRemoteInferencePromptSchema,
+
+  "Automatic Speech Recognition (Local)":
+    HuggingFaceAutomaticSpeechRecognitionPromptSchema,
+  "Image-to-Text (Local)": HuggingFaceImage2TextTransformerPromptSchema,
+  "Text-to-Image (Local)": HuggingFaceText2ImageDiffusorPromptSchema,
+  "Text-to-Speech (Local)": HuggingFaceText2SpeechTransformerPromptSchema,
+  "Text Generation (Local)": HuggingFaceTextGenerationTransformerPromptSchema,
+  "Summarization (Local)": HuggingFaceTextSummarizationTransformerPromptSchema,
+  "Translation (Local)": HuggingFaceTextGenerationTransformerPromptSchema,
 };
 
 export type PromptInputSchema =


### PR DESCRIPTION
# Support Prompt Schemas for Local Models with Task Names

In gradio, we'll surface a way for users to use the local model parsers we've created. When they do that, we want the names to be closer to the task name instead of the parser class name. We need to update the promptUtils so that the PromptSchemas are correct for those names.

## Testing:
- Updated hf parser registry to
```
    automatic_speech_recognition = (
        HuggingFaceAutomaticSpeechRecognitionTransformer()
    )
    AIConfigRuntime.register_model_parser(
        automatic_speech_recognition, "Automatic Speech Recognition (Local)"
    )
    image_to_text = HuggingFaceImage2TextTransformer()
    AIConfigRuntime.register_model_parser(
        image_to_text, "Image-to-Text (Local)"
    )
    text_to_image = HuggingFaceText2ImageDiffusor()
    AIConfigRuntime.register_model_parser(
        text_to_image, "Text-to-Image (Local)"
    )
    text_to_speech = HuggingFaceText2SpeechTransformer()
    AIConfigRuntime.register_model_parser(
        text_to_speech, "Text-to-Speech (Local)"
    )
    text_generation = HuggingFaceTextGenerationTransformer()
    AIConfigRuntime.register_model_parser(
        text_generation, "Text Generation (Local)"
    )
    text_summarization = HuggingFaceTextSummarizationTransformer()
    AIConfigRuntime.register_model_parser(
        text_summarization, "Summarization (Local)"
    )
    text_translation = HuggingFaceTextTranslationTransformer()
    AIConfigRuntime.register_model_parser(
        text_translation, "Translation (Local)"
    )
```
Then point to that parser file for the editor. Then, ensured each parser shows up with (Local) name and the prompt schemas are correct
