### PR TITLE
[ez] Export missing default model parsers

### DIFF
--- a/python/src/aiconfig/Config.py
+++ b/python/src/aiconfig/Config.py
@@ -1,28 +1,27 @@
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
 import json
 import os
-from typing import Any, Dict, List, Literal, Optional, Tuple
-from aiconfig.default_parsers.claude import ClaudeBedrockModelParser
-
 import requests
 import yaml
-from aiconfig.callback import CallbackEvent, CallbackManager
-from aiconfig.default_parsers.anyscale_endpoint import (
+
+from .callback import CallbackEvent, CallbackManager
+from .default_parsers.anyscale_endpoint import (
     DefaultAnyscaleEndpointParser,
 )
-from aiconfig.default_parsers.openai import DefaultOpenAIParser
-from aiconfig.default_parsers.gemini import GeminiModelParser
-from aiconfig.default_parsers.palm import PaLMChatParser, PaLMTextParser
-from aiconfig.model_parser import InferenceOptions, ModelParser
-
-from aiconfig.schema import JSONObject
-
+from .default_parsers.claude import ClaudeBedrockModelParser
 from .default_parsers.dalle import DalleImageGenerationParser
+from .default_parsers.openai import DefaultOpenAIParser
+from .default_parsers.gemini import GeminiModelParser
 from .default_parsers.hf import HuggingFaceTextGenerationParser
+from .default_parsers.palm import PaLMChatParser, PaLMTextParser
+from .model_parser import InferenceOptions, ModelParser
+
 from .registry import (
     ModelParserRegistry,
     update_model_parser_registry_with_config_runtime,
 )
-from .schema import AIConfig, Prompt
+from .schema import AIConfig, JSONObject, Prompt
 from .util.config_utils import is_yaml_ext
 
 gpt_models_main = [
@@ -53,13 +52,13 @@ for model in dalle_image_generation_models:
 ModelParserRegistry.register_model_parser(
     DefaultAnyscaleEndpointParser("AnyscaleEndpoint")
 )
+ModelParserRegistry.register_model_parser(ClaudeBedrockModelParser())
+for model in gpt_models_extra:
+    ModelParserRegistry.register_model_parser(DefaultOpenAIParser(model))
 ModelParserRegistry.register_model_parser(
     GeminiModelParser("gemini-pro"), ["gemini-pro"]
 )
-ModelParserRegistry.register_model_parser(ClaudeBedrockModelParser())
 ModelParserRegistry.register_model_parser(HuggingFaceTextGenerationParser())
-for model in gpt_models_extra:
-    ModelParserRegistry.register_model_parser(DefaultOpenAIParser(model))
 ModelParserRegistry.register_model_parser(PaLMChatParser())
 ModelParserRegistry.register_model_parser(PaLMTextParser())
 

--- a/python/src/aiconfig/__init__.py
+++ b/python/src/aiconfig/__init__.py
@@ -9,10 +9,15 @@ from .callback import (
 
 # The AIConfigRuntime class. This is the main class that you will use to run your AIConfig.
 from .Config import AIConfigRuntime
-from .default_parsers.openai import DefaultOpenAIParser, OpenAIInference
-from .default_parsers.azure import AzureOpenAIParser
+
 
 # Model Parsers
+from .default_parsers.anyscale_endpoint import DefaultAnyscaleEndpointParser
+from .default_parsers.azure import AzureOpenAIParser
+from .default_parsers.claude import ClaudeBedrockModelParser
+from .default_parsers.dalle import DalleImageGenerationParser
+from .default_parsers.gemini import  GeminiModelParser
+from .default_parsers.openai import DefaultOpenAIParser, OpenAIInference
 from .default_parsers.palm import PaLMChatParser, PaLMTextParser
 from .default_parsers.parameterized_model_parser import (
     ParameterizedModelParser,


### PR DESCRIPTION
[ez] Export missing default model parsers

Now we can do `from aiconfig import ClaudeBedrockModelParser` for example. I also deleted the `hf.py` file since we now have `aiconfig_extension_hugging_face` for this

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1112).
* #1114
* __->__ #1112