### PR TITLE
[gradio] Fix readonly RunPromptButton Margin

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/prompt/RunPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/RunPromptButton.tsx
@@ -33,7 +33,7 @@ export default memo(function RunPromptButton({
       disabled={disabledOrReadOnly}
       p="xs"
       size="xs"
-      className="runPromptButton"
+      className={`runPromptButton ${readOnly ? "runPromptButtonReadOnly" : ""}`}
     >
       {isRunning ? (
         <Flex align="center" justify="center">

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -236,6 +236,10 @@ export const GRADIO_THEME: MantineThemeOverride = {
           height: "auto",
         },
 
+        ".runPromptButton.runPromptButtonReadOnly": {
+          marginTop: "13px",
+        },
+
         ".actionTabsPanel": {
           width: "400px",
         },


### PR DESCRIPTION
[gradio] Fix readonly RunPromptButton Margin

# [gradio] Fix readonly RunPromptButton Margin

Pretty annoying, but we have custom margin for the runPromptButton in gradio to account for the Prompt label being shown (by our gradio styles). But in readOnly we don't show the label, but kept the same margin. This ends up looking like this:

![Screenshot 2024-02-02 at 3 03 45 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/c093468d-fe12-4de8-bdac-5e3f38a4c983)


To fix, add .runPromptButtonReadOnly class to the button in readOnly and use it to set the margin in the theme:

![Screenshot 2024-02-02 at 3 22 05 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/b1b61fc4-a091-4b67-a7cb-4ff9c6ecaf10)
![Screenshot 2024-02-02 at 3 23 58 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/232b8e55-23e5-4765-b265-7c56f922e9de)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1117).
* #1118
* __->__ #1117