### PR TITLE
[editor] Clearer Input Type Error Messaging

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/prompt/RunPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/RunPromptButton.tsx
@@ -33,7 +33,7 @@ export default memo(function RunPromptButton({
       disabled={disabledOrReadOnly}
       p="xs"
       size="xs"
-      className="runPromptButton"
+      className={`runPromptButton ${readOnly ? "runPromptButtonReadOnly" : ""}`}
     >
       {isRunning ? (
         <Flex align="center" justify="center">

--- a/python/src/aiconfig/editor/client/src/components/prompt/model_settings/ModelSettingsRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/model_settings/ModelSettingsRenderer.tsx
@@ -43,7 +43,8 @@ function SettingsErrorFallback({
             }}
           />
         </Flex>
-        Invalid settings format for model. Toggle JSON editor to update
+        Invalid settings format for model. Toggle JSON editor to update. Set to
+        {" {}"} in JSON editor and toggle back to reset.
       </Text>
       <JSONRenderer content={settings} />
     </Flex>

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/PromptInputRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/PromptInputRenderer.tsx
@@ -47,7 +47,8 @@ function InputErrorFallback({
     <>
       <Flex direction="column">
         <Text color="red" size="sm">
-          Invalid input format for model. Toggle JSON editor to update
+          Invalid input format for model. Toggle JSON editor to update. Set to
+          {" {}"} in JSON editor and toggle back to reset.
         </Text>
         <Flex>
           <div className={classes.promptInputRendererWrapper}>

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
@@ -64,18 +64,21 @@ function SchemaRenderer({ input, schema, onChangeInput }: SchemaRendererProps) {
 }
 
 export default memo(function PromptInputSchemaRenderer(props: Props) {
-  const {readOnly} = useContext(AIConfigContext);
+  const { readOnly } = useContext(AIConfigContext);
 
   if (props.schema.type === "string") {
     if (props.input && typeof props.input !== "string") {
       return (
         <>
-          <Text color="red">Expected input type string</Text>
+          <Text color="red">
+            Expected input type string. Toggle JSON editor to update. Set to
+            {' ""'} in JSON editor and toggle back to reset.
+          </Text>
           <JSONRenderer content={props.input} />
         </>
       );
     }
-    return  readOnly ? (
+    return readOnly ? (
       <div style={{ padding: "0.5em" }}>
         <Spoiler
           maxHeight={200}
@@ -84,10 +87,10 @@ export default memo(function PromptInputSchemaRenderer(props: Props) {
           initialState={false}
           transitionDuration={300}
         >
-          <TextRenderer content={(props.input as string)} />
+          <TextRenderer content={props.input as string} />
         </Spoiler>
-      </div> 
-      ): (
+      </div>
+    ) : (
       <Textarea
         value={props.input}
         label="Prompt"

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -236,6 +236,10 @@ export const GRADIO_THEME: MantineThemeOverride = {
           height: "auto",
         },
 
+        ".runPromptButton.runPromptButtonReadOnly": {
+          marginTop: "13px",
+        },
+
         ".actionTabsPanel": {
           width: "400px",
         },


### PR DESCRIPTION
# [editor] Clearer Input Type Error Messaging

When viewing the JSONRenderer for an input and swapping to a model with different input type (based on prompt schema), the error at the top is currently ambiguous: "Invalid input format for model. Toggle JSON editor to update."

This updates to explain how to reset the input / rendering:

https://github.com/lastmile-ai/aiconfig/assets/5060851/02fc09dd-0a3d-4f11-b636-0e8fd213fcf5

https://github.com/lastmile-ai/aiconfig/assets/5060851/4cd82c59-1728-46f7-a484-d40ff0a8a8bd



---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1118).
* __->__ #1118
* #1117