### PR TITLE
[editor] Don't Try to Save if No Save Callback

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -896,7 +896,7 @@ export default function AIConfigEditor({
 
   const isDirty = aiconfigState._ui.isDirty !== false;
   useEffect(() => {
-    if (!isDirty) {
+    if (!isDirty || !saveCallback) {
       return;
     }
 
@@ -904,10 +904,14 @@ export default function AIConfigEditor({
     const saveInterval = setInterval(onSave, AUTOSAVE_INTERVAL_MS);
 
     return () => clearInterval(saveInterval);
-  }, [isDirty, onSave]);
+  }, [isDirty, onSave, saveCallback]);
 
   // Override CMD+s and CTRL+s to save
   useEffect(() => {
+    if (!saveCallback) {
+      return;
+    }
+
     const saveHandler = (e: KeyboardEvent) => {
       // Note platform property to distinguish between CMD and CTRL for
       // Mac/Windows/Linux is deprecated.
@@ -925,7 +929,7 @@ export default function AIConfigEditor({
     window.addEventListener("keydown", saveHandler, false);
 
     return () => window.removeEventListener("keydown", saveHandler);
-  }, [onSave]);
+  }, [onSave, saveCallback]);
 
   // Server heartbeat, check every 3s to show error if server is down
   // Don't poll if server status is in an error state since it won't automatically recover


### PR DESCRIPTION
# [editor] Don't Try to Save if No Save Callback

If no `save` callback is provided to the editor we shouldn't have the interval set up to autosave, and should not override the default CMD+S listener.

## Testing:
- Ensure CMD + S and autosave still work correctly
- Remove `save` from the callbacks passed to the editor and ensure CMD+S opens the default browser save again:
![Screenshot 2024-02-02 at 5 42 33 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/ea2b1d69-0046-49e4-a4d6-39ab0860e8dc)
- Add console log in the effect to ensure no autosave is attempted

