### PR TITLE
[editor][ez] Fix AddPromptButton Width

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
@@ -3,6 +3,7 @@ import { useClickOutside } from "@mantine/hooks";
 import { memo, useCallback, useContext, useRef, useState } from "react";
 import AIConfigContext from "../contexts/AIConfigContext";
 import { TextRenderer } from "./prompt/TextRenderer";
+import { PROMPT_CELL_LEFT_MARGIN_PX } from "../utils/constants";
 
 type Props = {
   name?: string;
@@ -99,7 +100,7 @@ export default memo(function ConfigNameDescription({
     <Stack
       ref={isEditing ? inputSectionRef : undefined}
       spacing="xs"
-      ml={readOnly ? "auto" : "36px"}
+      ml={readOnly ? "auto" : PROMPT_CELL_LEFT_MARGIN_PX}
       mr="0.5em"
     >
       {isEditing ? (

--- a/python/src/aiconfig/editor/client/src/components/GlobalParametersContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/GlobalParametersContainer.tsx
@@ -3,6 +3,7 @@ import { JSONObject } from "aiconfig";
 import { memo, useContext, useState } from "react";
 import ParametersRenderer from "./ParametersRenderer";
 import AIConfigContext from "../contexts/AIConfigContext";
+import { PROMPT_CELL_LEFT_MARGIN_PX } from "../utils/constants";
 
 type Props = {
   initialValue: JSONObject;
@@ -11,7 +12,7 @@ type Props = {
 
 const useStyles = createStyles(() => ({
   parametersContainer: {
-    margin: "16px auto 16px 36px",
+    margin: `16px auto 16px ${PROMPT_CELL_LEFT_MARGIN_PX}px`,
   },
   parametersContainerReadonly: {
     margin: "16px auto",

--- a/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
@@ -10,6 +10,7 @@ import {
 import { IconPlus, IconSearch, IconTextCaption } from "@tabler/icons-react";
 import { memo, useCallback, useState } from "react";
 import useLoadModels from "../../hooks/useLoadModels";
+import { PROMPT_CELL_LEFT_MARGIN_PX } from "../../utils/constants";
 
 type Props = {
   addPrompt: (prompt: string) => void;
@@ -21,8 +22,8 @@ const useStyles = createStyles((theme) => ({
     borderRadius: rem(4),
     display: "flex",
     justifyContent: "center",
+    marginLeft: PROMPT_CELL_LEFT_MARGIN_PX,
     align: "center",
-    width: "100%",
     "&:hover": {
       backgroundColor:
         theme.colorScheme === "light"

--- a/python/src/aiconfig/editor/client/src/utils/constants.ts
+++ b/python/src/aiconfig/editor/client/src/utils/constants.ts
@@ -1,3 +1,6 @@
-export const DEBOUNCE_MS = 300;
 export const AUTOSAVE_INTERVAL_MS = 15 * 1000; // 15 seconds
+export const DEBOUNCE_MS = 300;
+// PromptMenuButton pushed prompt cells to the right, requiring other elements
+// to require this left margin to align with the prompt cells
+export const PROMPT_CELL_LEFT_MARGIN_PX = 36;
 export const SERVER_HEARTBEAT_INTERVAL_MS = 5 * 1000; // 5 seconds


### PR DESCRIPTION
[editor][ez] Fix AddPromptButton Width


# [editor][ez] Fix AddPromptButton Width

Fix the AddPromptButton so that it no longer extends beyond the left of the prompts. Requires both adding left margin (to offset its left side to match start of the prompt cells) and removing the 100% width (to prevent the right side from extending outside of the container right padding). The width is still the full width of the prompts without explicitly setting width

## Before
![Screenshot 2024-02-02 at 5 59 23 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/1112b68c-f779-417c-93c5-0b391dcef306)

## After
![Screenshot 2024-02-02 at 5 57 53 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/07879a14-fecd-4f10-82dd-655876f0b904)
