### PR TITLE
[editor][1/4] Set Up Notification Provider/Context

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/notifications/NotificationContext.tsx
+++ b/python/src/aiconfig/editor/client/src/components/notifications/NotificationContext.tsx
@@ -1,0 +1,16 @@
+import { createContext } from "react";
+import { AIConfigEditorNotification } from "./NotificationProvider";
+
+/**
+ * Context for providing showNotification method throughout the editor. For example,
+ * for VS Code extension we want to re-use VS Code's notification framework instead of
+ * using the default (mantine) -- set in context with the `showNotification` callback
+ * provided to AIConfigEditor.
+ */
+const NotificationContext = createContext<{
+  showNotification: (notification: AIConfigEditorNotification) => void;
+}>({
+  showNotification: () => {},
+});
+
+export default NotificationContext;

--- a/python/src/aiconfig/editor/client/src/components/notifications/NotificationProvider.tsx
+++ b/python/src/aiconfig/editor/client/src/components/notifications/NotificationProvider.tsx
@@ -1,0 +1,61 @@
+import {
+  Notifications,
+  showNotification as mantineShowNotification,
+} from "@mantine/notifications";
+import { useCallback, useMemo } from "react";
+import NotificationContext from "./NotificationContext";
+
+export type AIConfigEditorNotificationType =
+  | "info"
+  | "success"
+  | "warning"
+  | "error";
+
+export type AIConfigEditorNotification = {
+  title: string;
+  message: string | null;
+  type?: AIConfigEditorNotificationType;
+  autoClose?: boolean | number;
+  onClose?: () => void;
+  onOpen?: () => void;
+};
+
+type Props = {
+  children: React.ReactNode;
+  showNotification?: (notification: AIConfigEditorNotification) => void;
+};
+
+const NOTIFICATION_TYPE_COLOR = {
+  info: "blue",
+  success: "green",
+  warning: "yellow",
+  error: "red",
+};
+
+export default function NotificationProvider({
+  children,
+  showNotification: overrideShowNotification,
+}: Props) {
+  const defaultShowNotification = useCallback(
+    (notification: AIConfigEditorNotification) =>
+      mantineShowNotification({
+        ...notification,
+        color: NOTIFICATION_TYPE_COLOR[notification.type ?? "info"],
+      }),
+    []
+  );
+
+  const notificationContext = useMemo(
+    () => ({
+      showNotification: overrideShowNotification ?? defaultShowNotification,
+    }),
+    [defaultShowNotification, overrideShowNotification]
+  );
+
+  return (
+    <NotificationContext.Provider value={notificationContext}>
+      {!overrideShowNotification && <Notifications />}
+      {children}
+    </NotificationContext.Provider>
+  );
+}


### PR DESCRIPTION
[editor][1/4] Set Up Notification Provider/Context

[editor][1/4] Set Up Notification Provider/Context

# [editor][notifications][1/4] Set Up Notification Provider/Context

For the vs code extension, we want to leverage the vs code notification UX instead of mantine for showing notifications. To support that in a usable way, this PR stack sets up a Notification context which will propagate provided `showNotification` function to any components that request it from context. If there is no `showNotification` provided to the `AIConfigEditor` component we will default to the mantine `showNotification` function as usual.

This PR sets up the context, managing which `showNotification` function to call, and providing it through the context provider. The function takes in an `AIConfigEditorNotification` object, which includes the properties of mantine's `NotificationProps` type that we are currently using and which may be desired to use in the future (e.g. autoClose, onOpen, onClose). The remaining props are pretty UI-focused (e.g. color, radius, icon, etc.) and not really useful for external contexts.

## Testing:
- No-op here. Make sure notifications still work as usual

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1127).
* #1130
* #1129
* #1128
* __->__ #1127