### PR TITLE
[editor][4/4] Support showNotification Callback

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -60,7 +60,9 @@ import AIConfigEditorThemeProvider from "../themes/AIConfigEditorThemeProvider";
 import DownloadButton from "./global/DownloadButton";
 import ShareButton from "./global/ShareButton";
 import PromptsContainer from "./prompt/PromptsContainer";
-import NotificationProvider from "./notifications/NotificationProvider";
+import NotificationProvider, {
+  AIConfigEditorNotification,
+} from "./notifications/NotificationProvider";
 import NotificationContext from "./notifications/NotificationContext";
 
 type Props = {
@@ -111,6 +113,7 @@ export type AIConfigCallbacks = {
     prompt: Prompt,
     index: number
   ) => Promise<{ aiconfig: AIConfig }>;
+  cancel: (cancellationToken: string) => Promise<void>;
   clearOutputs: () => Promise<{ aiconfig: AIConfig }>;
   deletePrompt: (promptName: string) => Promise<void>;
   download?: () => Promise<void>;
@@ -124,12 +127,12 @@ export type AIConfigCallbacks = {
     enableStreaming?: boolean,
     cancellationToken?: string
   ) => Promise<{ aiconfig: AIConfig }>;
-  cancel: (cancellationToken: string) => Promise<void>;
   save?: (aiconfig: AIConfig) => Promise<void>;
-  share?: () => Promise<{ share_url: string }>;
   setConfigDescription: (description: string) => Promise<void>;
   setConfigName: (name: string) => Promise<void>;
   setParameters: (parameters: JSONObject, promptName?: string) => Promise<void>;
+  share?: () => Promise<{ share_url: string }>;
+  showNotification?: (notification: AIConfigEditorNotification) => void;
   updateModel: (value: {
     modelName?: string;
     settings?: InferenceSettings;
@@ -1065,7 +1068,9 @@ function AIConfigEditorBase({
 export default function AIConfigEditor(props: Props) {
   return (
     <AIConfigEditorThemeProvider mode={props.mode} themeMode={props.themeMode}>
-      <NotificationProvider>
+      <NotificationProvider
+        showNotification={props.callbacks?.showNotification}
+      >
         <AIConfigEditorBase {...props} />
       </NotificationProvider>
     </AIConfigEditorThemeProvider>

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -7,7 +7,6 @@ import {
   Alert,
   Group,
 } from "@mantine/core";
-import { showNotification } from "@mantine/notifications";
 import {
   AIConfig,
   InferenceSettings,
@@ -18,6 +17,7 @@ import {
 } from "aiconfig";
 import {
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useReducer,
@@ -61,6 +61,7 @@ import DownloadButton from "./global/DownloadButton";
 import ShareButton from "./global/ShareButton";
 import PromptsContainer from "./prompt/PromptsContainer";
 import NotificationProvider from "./notifications/NotificationProvider";
+import NotificationContext from "./notifications/NotificationContext";
 
 type Props = {
   aiconfig: AIConfig;
@@ -155,6 +156,8 @@ function AIConfigEditorBase({
     aiConfigToClientConfig(initialAIConfig)
   );
 
+  const { showNotification } = useContext(NotificationContext);
+
   const stateRef = useRef(aiconfigState);
   stateRef.current = aiconfigState;
 
@@ -172,10 +175,10 @@ function AIConfigEditorBase({
       showNotification({
         title: "Error downloading AIConfig",
         message,
-        color: "red",
+        type: "error",
       });
     }
-  }, [downloadCallback]);
+  }, [downloadCallback, showNotification]);
 
   const shareCallback = callbacks?.share;
   const onShare = useCallback(async () => {
@@ -190,10 +193,10 @@ function AIConfigEditorBase({
       showNotification({
         title: "Error sharing AIConfig",
         message,
-        color: "red",
+        type: "error",
       });
     }
-  }, [shareCallback]);
+  }, [shareCallback, showNotification]);
 
   const saveCallback = callbacks?.save;
   const onSave = useCallback(async () => {
@@ -211,12 +214,12 @@ function AIConfigEditorBase({
       showNotification({
         title: "Error saving",
         message,
-        color: "red",
+        type: "error",
       });
     } finally {
       setIsSaving(false);
     }
-  }, [saveCallback]);
+  }, [saveCallback, showNotification]);
 
   const updatePromptCallback = callbacks?.updatePrompt;
   const debouncedUpdatePrompt = useMemo(() => {
@@ -267,7 +270,7 @@ function AIConfigEditorBase({
         showNotification({
           title: "Error updating prompt input",
           message,
-          color: "red",
+          type: "error",
         });
       };
 
@@ -296,7 +299,7 @@ function AIConfigEditorBase({
         onError(err);
       }
     },
-    [debouncedUpdatePrompt, dispatch]
+    [debouncedUpdatePrompt, dispatch, showNotification]
   );
 
   const onChangePromptName = useCallback(
@@ -312,7 +315,7 @@ function AIConfigEditorBase({
         showNotification({
           title: "Error updating prompt name",
           message,
-          color: "red",
+          type: "error",
         });
       };
 
@@ -344,7 +347,7 @@ function AIConfigEditorBase({
         onError(err);
       }
     },
-    [debouncedUpdatePrompt]
+    [debouncedUpdatePrompt, showNotification]
   );
 
   const updateModelCallback = callbacks?.updateModel;
@@ -391,7 +394,7 @@ function AIConfigEditorBase({
         showNotification({
           title: "Error updating prompt model settings",
           message,
-          color: "red",
+          type: "error",
         });
       };
 
@@ -419,7 +422,7 @@ function AIConfigEditorBase({
         onError(err);
       }
     },
-    [debouncedUpdateModel, dispatch]
+    [debouncedUpdateModel, dispatch, showNotification]
   );
 
   const onUpdatePromptModel = useCallback(
@@ -441,7 +444,7 @@ function AIConfigEditorBase({
         showNotification({
           title: "Error updating model for prompt",
           message,
-          color: "red",
+          type: "error",
         });
       };
 
@@ -462,7 +465,7 @@ function AIConfigEditorBase({
         onError(err);
       }
     },
-    [dispatch, debouncedUpdateModel]
+    [dispatch, debouncedUpdateModel, showNotification]
   );
 
   const setParametersCallback = callbacks?.setParameters;
@@ -505,7 +508,7 @@ function AIConfigEditorBase({
         showNotification({
           title: "Error setting global parameters",
           message: message,
-          color: "red",
+          type: "error",
         });
       };
 
@@ -519,7 +522,7 @@ function AIConfigEditorBase({
         onError(err);
       }
     },
-    [debouncedSetParameters, dispatch]
+    [debouncedSetParameters, dispatch, showNotification]
   );
 
   const onUpdatePromptParameters = useCallback(
@@ -543,7 +546,7 @@ function AIConfigEditorBase({
         showNotification({
           title: `Error setting parameters for prompt ${promptIdentifier}`,
           message: message,
-          color: "red",
+          type: "error",
         });
       };
 
@@ -557,7 +560,7 @@ function AIConfigEditorBase({
         onError(err);
       }
     },
-    [debouncedSetParameters, dispatch]
+    [debouncedSetParameters, dispatch, showNotification]
   );
 
   const addPromptCallback = callbacks?.addPrompt;
@@ -611,11 +614,11 @@ function AIConfigEditorBase({
         showNotification({
           title: "Error adding prompt to config",
           message: message,
-          color: "red",
+          type: "error",
         });
       }
     },
-    [addPromptCallback, logEventHandler]
+    [addPromptCallback, logEventHandler, showNotification]
   );
 
   const deletePromptCallback = callbacks?.deletePrompt;
@@ -643,11 +646,11 @@ function AIConfigEditorBase({
         showNotification({
           title: "Error deleting prompt",
           message,
-          color: "red",
+          type: "error",
         });
       }
     },
-    [deletePromptCallback, dispatch]
+    [deletePromptCallback, dispatch, showNotification]
   );
 
   const clearOutputsCallback = callbacks?.clearOutputs;
@@ -668,10 +671,10 @@ function AIConfigEditorBase({
       showNotification({
         title: "Error clearing outputs",
         message,
-        color: "red",
+        type: "error",
       });
     }
-  }, [clearOutputsCallback, dispatch]);
+  }, [clearOutputsCallback, dispatch, showNotification]);
 
   const runPromptCallback = callbacks?.runPrompt;
 
@@ -706,7 +709,7 @@ function AIConfigEditorBase({
         showNotification({
           title: `Error running prompt${promptName ? ` ${promptName}` : ""}`,
           message,
-          color: "red",
+          type: "error",
         });
       };
 
@@ -770,7 +773,7 @@ function AIConfigEditorBase({
                     promptName ? ` '${promptName}'` : ""
                   }. Resetting output to previous state.`,
                   message: event.data.message,
-                  color: "yellow",
+                  type: "warning",
                 });
               } else {
                 onPromptError(event.data.message);
@@ -797,7 +800,7 @@ function AIConfigEditorBase({
         onPromptError(message);
       }
     },
-    [logEventHandler, runPromptCallback]
+    [logEventHandler, runPromptCallback, showNotification]
   );
 
   const setNameCallback = callbacks?.setConfigName;
@@ -833,11 +836,11 @@ function AIConfigEditorBase({
         showNotification({
           title: "Error setting config name",
           message,
-          color: "red",
+          type: "error",
         });
       });
     },
-    [debouncedSetName]
+    [debouncedSetName, showNotification]
   );
 
   const setDescriptionCallback = callbacks?.setConfigDescription;
@@ -876,11 +879,11 @@ function AIConfigEditorBase({
         showNotification({
           title: "Error setting config description",
           message,
-          color: "red",
+          type: "error",
         });
       });
     },
-    [debouncedSetDescription]
+    [debouncedSetDescription, showNotification]
   );
 
   const getState = useCallback(() => stateRef.current, []);

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -7,7 +7,7 @@ import {
   Alert,
   Group,
 } from "@mantine/core";
-import { Notifications, showNotification } from "@mantine/notifications";
+import { showNotification } from "@mantine/notifications";
 import {
   AIConfig,
   InferenceSettings,
@@ -60,6 +60,7 @@ import AIConfigEditorThemeProvider from "../themes/AIConfigEditorThemeProvider";
 import DownloadButton from "./global/DownloadButton";
 import ShareButton from "./global/ShareButton";
 import PromptsContainer from "./prompt/PromptsContainer";
+import NotificationProvider from "./notifications/NotificationProvider";
 
 type Props = {
   aiconfig: AIConfig;
@@ -141,12 +142,11 @@ export type AIConfigCallbacks = {
 
 type RequestCallbackError = { message?: string };
 
-export default function AIConfigEditor({
+function AIConfigEditorBase({
   aiconfig: initialAIConfig,
   callbacks,
   mode,
   readOnly = false,
-  themeMode,
 }: Props) {
   const [isSaving, setIsSaving] = useState(false);
   const [serverStatus, setServerStatus] = useState<"OK" | "ERROR">("OK");
@@ -954,113 +954,117 @@ export default function AIConfigEditor({
   const runningPromptId: string | undefined = aiconfigState._ui.runningPromptId;
 
   return (
-    <AIConfigEditorThemeProvider mode={mode} themeMode={themeMode}>
-      <AIConfigContext.Provider value={contextValue}>
-        <Notifications />
-        <Container className="editorBackground" maw="80rem">
-          {serverStatus !== "OK" && (
-            <>
-              {/* // Simple placeholder block div to make sure the banner does not overlap page contents until scrolling past its height */}
-              <div style={{ height: "100px" }} />
-              <Alert
-                color="red"
-                title="Server Connection Error"
-                w="100%"
-                style={{ position: "fixed", top: 0, zIndex: 999 }}
-              >
-                <Text>
-                  There is a problem with the editor server connection. Please
-                  copy important changes somewhere safe and then try reloading
-                  the page or restarting the editor.
-                </Text>
-                <Flex align="center">
-                  <CopyButton
-                    value={JSON.stringify(
-                      clientConfigToAIConfig(aiconfigState),
-                      null,
-                      2
-                    )}
-                    contentLabel="AIConfig JSON"
-                  />
-                  <Text color="dimmed">
-                    Click to copy current AIConfig JSON
-                  </Text>
-                </Flex>
-              </Alert>
-            </>
-          )}
-          <div>
-            <Flex justify="flex-end" mt="md" mb="xs">
-              {
-                <Group>
-                  {downloadCallback && (
-                    <DownloadButton onDownload={onDownload} />
+    <AIConfigContext.Provider value={contextValue}>
+      <Container className="editorBackground" maw="80rem">
+        {serverStatus !== "OK" && (
+          <>
+            {/* // Simple placeholder block div to make sure the banner does not overlap page contents until scrolling past its height */}
+            <div style={{ height: "100px" }} />
+            <Alert
+              color="red"
+              title="Server Connection Error"
+              w="100%"
+              style={{ position: "fixed", top: 0, zIndex: 999 }}
+            >
+              <Text>
+                There is a problem with the editor server connection. Please
+                copy important changes somewhere safe and then try reloading the
+                page or restarting the editor.
+              </Text>
+              <Flex align="center">
+                <CopyButton
+                  value={JSON.stringify(
+                    clientConfigToAIConfig(aiconfigState),
+                    null,
+                    2
                   )}
-                  {shareCallback && <ShareButton onShare={onShare} />}
-                  {!readOnly && onClearOutputs && (
+                  contentLabel="AIConfig JSON"
+                />
+                <Text color="dimmed">Click to copy current AIConfig JSON</Text>
+              </Flex>
+            </Alert>
+          </>
+        )}
+        <div>
+          <Flex justify="flex-end" mt="md" mb="xs">
+            {
+              <Group>
+                {downloadCallback && <DownloadButton onDownload={onDownload} />}
+                {shareCallback && <ShareButton onShare={onShare} />}
+                {!readOnly && onClearOutputs && (
+                  <Button
+                    loading={undefined}
+                    onClick={onClearOutputs}
+                    size="xs"
+                    variant="gradient"
+                  >
+                    Clear Outputs
+                  </Button>
+                )}
+                {!readOnly && saveCallback && (
+                  <Tooltip
+                    label={
+                      isDirty ? "Save changes to config" : "No unsaved changes"
+                    }
+                  >
                     <Button
-                      loading={undefined}
-                      onClick={onClearOutputs}
+                      leftIcon={<IconDeviceFloppy />}
+                      loading={isSaving}
+                      onClick={() => {
+                        onSave();
+                        logEventHandler?.("SAVE_BUTTON_CLICKED");
+                      }}
+                      disabled={!isDirty}
                       size="xs"
                       variant="gradient"
                     >
-                      Clear Outputs
+                      Save
                     </Button>
-                  )}
-                  {!readOnly && saveCallback && (
-                    <Tooltip
-                      label={
-                        isDirty
-                          ? "Save changes to config"
-                          : "No unsaved changes"
-                      }
-                    >
-                      <Button
-                        leftIcon={<IconDeviceFloppy />}
-                        loading={isSaving}
-                        onClick={() => {
-                          onSave();
-                          logEventHandler?.("SAVE_BUTTON_CLICKED");
-                        }}
-                        disabled={!isDirty}
-                        size="xs"
-                        variant="gradient"
-                      >
-                        Save
-                      </Button>
-                    </Tooltip>
-                  )}
-                </Group>
-              }
-            </Flex>
-            <ConfigNameDescription
-              name={aiconfigState.name}
-              description={aiconfigState.description}
-              setDescription={onSetDescription}
-              setName={onSetName}
-            />
-          </div>
-          <GlobalParametersContainer
-            initialValue={aiconfigState?.metadata?.parameters ?? {}}
-            onUpdateParameters={onUpdateGlobalParameters}
+                  </Tooltip>
+                )}
+              </Group>
+            }
+          </Flex>
+          <ConfigNameDescription
+            name={aiconfigState.name}
+            description={aiconfigState.description}
+            setDescription={onSetDescription}
+            setName={onSetName}
           />
-          <PromptsContainer
-            cancelRunPrompt={callbacks?.cancel}
-            defaultModel={aiconfigState.metadata.default_model}
-            getModels={callbacks?.getModels}
-            onAddPrompt={onAddPrompt}
-            onChangePromptInput={onChangePromptInput}
-            onChangePromptName={onChangePromptName}
-            onDeletePrompt={onDeletePrompt}
-            onRunPrompt={onRunPrompt}
-            onUpdatePromptModel={onUpdatePromptModel}
-            onUpdatePromptModelSettings={onUpdatePromptModelSettings}
-            onUpdatePromptParameters={onUpdatePromptParameters}
-            prompts={aiconfigState.prompts}
-            runningPromptId={runningPromptId}
-          />
-        </Container>
-      </AIConfigContext.Provider>
+        </div>
+        <GlobalParametersContainer
+          initialValue={aiconfigState?.metadata?.parameters ?? {}}
+          onUpdateParameters={onUpdateGlobalParameters}
+        />
+        <PromptsContainer
+          cancelRunPrompt={callbacks?.cancel}
+          defaultModel={aiconfigState.metadata.default_model}
+          getModels={callbacks?.getModels}
+          onAddPrompt={onAddPrompt}
+          onChangePromptInput={onChangePromptInput}
+          onChangePromptName={onChangePromptName}
+          onDeletePrompt={onDeletePrompt}
+          onRunPrompt={onRunPrompt}
+          onUpdatePromptModel={onUpdatePromptModel}
+          onUpdatePromptModelSettings={onUpdatePromptModelSettings}
+          onUpdatePromptParameters={onUpdatePromptParameters}
+          prompts={aiconfigState.prompts}
+          runningPromptId={runningPromptId}
+        />
+      </Container>
+    </AIConfigContext.Provider>
+  );
+}
+
+// Wrap the AIConfigEditorBase in the NotificationProvider to provide NotificationContext
+// to the AIConfigEditorBase. Wrap both NotificationProvider and AIConfigEditorBase with
+// the theme provider to ensure all components have the proper theme
+export default function AIConfigEditor(props: Props) {
+  return (
+    <AIConfigEditorThemeProvider mode={props.mode} themeMode={props.themeMode}>
+      <NotificationProvider>
+        <AIConfigEditorBase {...props} />
+      </NotificationProvider>
     </AIConfigEditorThemeProvider>
   );
 }

--- a/python/src/aiconfig/editor/client/src/components/notifications/NotificationContext.tsx
+++ b/python/src/aiconfig/editor/client/src/components/notifications/NotificationContext.tsx
@@ -1,0 +1,16 @@
+import { createContext } from "react";
+import { AIConfigEditorNotification } from "./NotificationProvider";
+
+/**
+ * Context for providing showNotification method throughout the editor. For example,
+ * for VS Code extension we want to re-use VS Code's notification framework instead of
+ * using the default (mantine) -- set in context with the `showNotification` callback
+ * provided to AIConfigEditor.
+ */
+const NotificationContext = createContext<{
+  showNotification: (notification: AIConfigEditorNotification) => void;
+}>({
+  showNotification: () => {},
+});
+
+export default NotificationContext;

--- a/python/src/aiconfig/editor/client/src/components/notifications/NotificationProvider.tsx
+++ b/python/src/aiconfig/editor/client/src/components/notifications/NotificationProvider.tsx
@@ -1,0 +1,61 @@
+import {
+  Notifications,
+  showNotification as mantineShowNotification,
+} from "@mantine/notifications";
+import { useCallback, useMemo } from "react";
+import NotificationContext from "./NotificationContext";
+
+export type AIConfigEditorNotificationType =
+  | "info"
+  | "success"
+  | "warning"
+  | "error";
+
+export type AIConfigEditorNotification = {
+  title: string;
+  message: string | null;
+  type?: AIConfigEditorNotificationType;
+  autoClose?: boolean | number;
+  onClose?: () => void;
+  onOpen?: () => void;
+};
+
+type Props = {
+  children: React.ReactNode;
+  showNotification?: (notification: AIConfigEditorNotification) => void;
+};
+
+const NOTIFICATION_TYPE_COLOR = {
+  info: "blue",
+  success: "green",
+  warning: "yellow",
+  error: "red",
+};
+
+export default function NotificationProvider({
+  children,
+  showNotification: overrideShowNotification,
+}: Props) {
+  const defaultShowNotification = useCallback(
+    (notification: AIConfigEditorNotification) =>
+      mantineShowNotification({
+        ...notification,
+        color: NOTIFICATION_TYPE_COLOR[notification.type ?? "info"],
+      }),
+    []
+  );
+
+  const notificationContext = useMemo(
+    () => ({
+      showNotification: overrideShowNotification ?? defaultShowNotification,
+    }),
+    [defaultShowNotification, overrideShowNotification]
+  );
+
+  return (
+    <NotificationContext.Provider value={notificationContext}>
+      {!overrideShowNotification && <Notifications />}
+      {children}
+    </NotificationContext.Provider>
+  );
+}

--- a/python/src/aiconfig/editor/client/src/hooks/useLoadModels.ts
+++ b/python/src/aiconfig/editor/client/src/hooks/useLoadModels.ts
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useState } from "react";
-import { showNotification } from "@mantine/notifications";
+import { useCallback, useContext, useEffect, useState } from "react";
+import NotificationContext from "../components/notifications/NotificationContext";
 
 export default function useLoadModels(
   modelSearch: string,
   getModels?: (search: string) => Promise<string[]>
 ) {
   const [models, setModels] = useState<string[]>([]);
+  const { showNotification } = useContext(NotificationContext);
 
   const loadModels = useCallback(
     async (modelSearch: string) => {
@@ -20,11 +21,11 @@ export default function useLoadModels(
         showNotification({
           title: "Error loading models",
           message,
-          color: "red",
+          type: "error",
         });
       }
     },
-    [getModels]
+    [getModels, showNotification]
   );
 
   useEffect(() => {


### PR DESCRIPTION
[editor][4/4] Support showNotification Callback

# [4/4] Support showNotification Callback

With the previous PRs in place, we can now support the `showNotification` callback to our AIConfigEditor, leveraging it in the context for all `showNotification` calls if provided.

## Testing:
- In LocalEditor, passed in the following:
```
      showNotification: (data) => {
        window.alert(`Notification: ${JSON.stringify(data)}`);
      },
```

Then ran and cancelled a prompt, ensuring the window alert is shown:
![Screenshot 2024-02-02 at 8 39 47 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/cb0b485c-3068-4c04-9fe1-acb70d3dd5f5)

- Without passing in the function, ensure notifications use mantine as normal

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1130).
* __->__ #1130
* #1129
* #1128
* #1127