### PR TITLE
Add hoverContainer class to ConfigNameDescription

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
@@ -128,7 +128,9 @@ export default memo(function ConfigNameDescription({
           <Title
             ref={nameDisplayRef}
             onClick={onClickEdit}
-            className={!readOnly ? classes.hoverContainer : undefined}
+            className={
+              !readOnly ? `${classes.hoverContainer} hoverContainer` : undefined
+            }
           >
             {name}
           </Title>
@@ -136,7 +138,11 @@ export default memo(function ConfigNameDescription({
             <div
               ref={descriptionDisplayRef}
               onClick={onClickEdit}
-              className={!readOnly ? classes.hoverContainer : undefined}
+              className={
+                !readOnly
+                  ? `${classes.hoverContainer} hoverContainer`
+                  : undefined
+              }
             >
               <TextRenderer content={description} />
             </div>


### PR DESCRIPTION
Add hoverContainer class to ConfigNameDescription

# Add hoverContainer class to ConfigNameDescription

In https://github.com/lastmile-ai/aiconfig/pull/1121/files, the local hoverContainer class is modified to have vs code-specific styles. Instead, we can add the literal `hoverContainer` class to the elements so that our vscode theme can override the styles with greater specificity

## Testing:
- Make sure existing styles still work
- See class added:
![Screenshot 2024-02-05 at 11 25 09 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/7c8c2285-5650-4641-ae62-764ed48abb76)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1131).
* #1134
* #1133
* #1132
* __->__ #1131