### PR TITLE
Add addPromptRow class to AddPromptButton div

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ConfigNameDescription.tsx
@@ -128,7 +128,9 @@ export default memo(function ConfigNameDescription({
           <Title
             ref={nameDisplayRef}
             onClick={onClickEdit}
-            className={!readOnly ? classes.hoverContainer : undefined}
+            className={
+              !readOnly ? `${classes.hoverContainer} hoverContainer` : undefined
+            }
           >
             {name}
           </Title>
@@ -136,7 +138,11 @@ export default memo(function ConfigNameDescription({
             <div
               ref={descriptionDisplayRef}
               onClick={onClickEdit}
-              className={!readOnly ? classes.hoverContainer : undefined}
+              className={
+                !readOnly
+                  ? `${classes.hoverContainer} hoverContainer`
+                  : undefined
+              }
             >
               <TextRenderer content={description} />
             </div>

--- a/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/ParametersRenderer.tsx
@@ -209,7 +209,7 @@ export default memo(function ParametersRenderer(props: {
             color="dimmed"
             size="sm"
             p="xs"
-            style={{ display: "block", margin: "0 auto", textAlign: "right" }}
+            style={{ display: "block", margin: "0 auto" }}
           >
             Use parameters in your prompt or system prompt with{" "}
             {"{{parameter}}"}

--- a/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
@@ -89,7 +89,7 @@ export default memo(function AddPromptButton({ addPrompt, getModels }: Props) {
   const { classes } = useStyles();
 
   return (
-    <div className={classes.addPromptRow}>
+    <div className={`${classes.addPromptRow} addPromptRow`}>
       <Menu
         position="bottom"
         // Manually maintain open state to support ... expand button


### PR DESCRIPTION
Add addPromptRow class to AddPromptButton div

# Add addPromptRow class to AddPromptButton div

From https://github.com/lastmile-ai/aiconfig/pull/1121/files, the div had hard-coded styles to work in vs code. We can instead apply this `addPromptRow` class to support overriding in vs code theme.

## Testing:
- Make sure current styles still work
![Screenshot 2024-02-05 at 11 50 04 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/cbff09ce-2e07-4c66-9faf-5453e7a33d61)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1133).
* #1134
* __->__ #1133
* #1132
* #1131