### PR TITLE
[python] temporary Fix Gemini Event loop

### DIFF
--- a/python/src/aiconfig/default_parsers/gemini.py
+++ b/python/src/aiconfig/default_parsers/gemini.py
@@ -104,6 +104,7 @@ class GeminiModelParser(ParameterizedModelParser):
         super().__init__()
         # TODO(?): @Ankush-lastmile Figure out how to make this model parser impl and init not depend on the model
         self.model = genai.GenerativeModel(id)
+        self.model_id = id
 
         # Note: we don't need to explicitly set the key as long as this is set
         # as an env var genai.configure() will pick up the env var
@@ -329,6 +330,10 @@ class GeminiModelParser(ParameterizedModelParser):
 
         if not self.api_key:
             self.api_key = get_api_key_from_environment("GOOGLE_API_KEY", required=True).unwrap()
+
+        # Gemini api stores a reference to the currently executing async event loop.
+        # Reinitialize the "client" to avoid issues with the event loop.
+        self.model = genai.GenerativeModel(self.model_id)
         genai.configure(api_key=self.api_key)
 
         # TODO: check and handle api key here


### PR DESCRIPTION
[python] temporary Fix Gemini Event loop




Gemini api under the hood saves a reference to the async event loop. This messes with the local editor because we create a new event loop on api/run.

This diff reinitializes the "client" at the run step for the Gemini model parser. I put client in quotes because its not called a client but its analogous to the openai client abstraction.

## Testplan

Run a gemini prompt twice inside local editor.
Before:
<img width="1598" alt="Screenshot 2024-02-05 at 5 36 26 PM" src="https://github.com/lastmile-ai/gradio-workbook/assets/141073967/5ed779f4-61b2-4595-a34c-11992a2c055c">

After:
run twice, no event loop error
https://github.com/lastmile-ai/gradio-workbook/assets/141073967/39d1d4b2-90c5-4ee1-b1a4-bc35d8528d60

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1137).
* #1139
* __->__ #1137