### PR TITLE
[ez] Fix dall-e-2 and dall-e-3 Prompt Schemas

### DIFF
--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/DalleImageGenerationParserPromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/DalleImageGenerationParserPromptSchema.ts
@@ -1,13 +1,31 @@
 import { PromptSchema } from "../../utils/promptUtils";
 
-export const DalleImageGenerationParserPromptSchema: PromptSchema = {
+const DalleCommonPromptSchema: PromptSchema = {
   // See /opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/openai/resources/images.py
-  // for supported settings
-  // https://platform.openai.com/docs/api-reference/images/create for descriptions
-
   input: {
     type: "string",
   },
+  model_settings: {
+    type: "object",
+    properties: {
+      // Exclude model since it should be the first property for any schema, regardless of spread order
+      response_format: {
+        type: "string",
+        enum: ["url", "b64_json"],
+        description: "The format in which the generated images are returned.",
+      },
+      user: {
+        type: "string",
+        description: `A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.`,
+      },
+    },
+  },
+};
+
+export const Dalle2ImageGenerationParserPromptSchema: PromptSchema = {
+  // Extend DalleCommonPromptSchema with properties specific to Dalle2
+  // See https://platform.openai.com/docs/api-reference/images/create
+  ...DalleCommonPromptSchema,
   model_settings: {
     type: "object",
     properties: {
@@ -20,20 +38,36 @@ export const DalleImageGenerationParserPromptSchema: PromptSchema = {
         maximum: 10,
         description: "Number of images to generate",
       },
+      size: {
+        type: "string",
+        enum: ["256x256", "512x512", "1024x1024"],
+        description: "The size of the generated images.",
+      },
+      // Intentionally spread last to be ordered last
+      ...DalleCommonPromptSchema.model_settings!.properties,
+    },
+  },
+};
+
+export const Dalle3ImageGenerationParserPromptSchema: PromptSchema = {
+  // Extend DalleCommonPromptSchema with properties specific to Dalle3
+  // See https://platform.openai.com/docs/api-reference/images/create
+  ...DalleCommonPromptSchema,
+  model_settings: {
+    type: "object",
+    properties: {
+      model: {
+        type: "string",
+      },
       quality: {
         type: "string",
         enum: ["standard", "hd"],
         description: `The quality of the image that will be generated. 
         'hd' creates images with finer details and greater consistency across the image`,
       },
-      response_format: {
-        type: "string",
-        enum: ["url", "b64_json"],
-        description: "The format in which the generated images are returned.",
-      },
       size: {
         type: "string",
-        enum: ["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"],
+        enum: ["1024x1024", "1792x1024", "1024x1792"],
         description: "The size of the generated images.",
       },
       style: {
@@ -43,6 +77,8 @@ export const DalleImageGenerationParserPromptSchema: PromptSchema = {
         Vivid causes the model to lean towards generating hyper-real and dramatic images. 
         Natural causes the model to produce more natural, less hyper-real looking images.`,
       },
+      // Intentionally spread last to be ordered last
+      ...DalleCommonPromptSchema.model_settings!.properties,
     },
   },
 };

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -1,7 +1,10 @@
 import { JSONObject, JSONValue, Prompt } from "aiconfig";
 import { OpenAIChatModelParserPromptSchema } from "../shared/prompt_schemas/OpenAIChatModelParserPromptSchema";
 import { OpenAIChatVisionModelParserPromptSchema } from "../shared/prompt_schemas/OpenAIChatVisionModelParserPromptSchema";
-import { DalleImageGenerationParserPromptSchema } from "../shared/prompt_schemas/DalleImageGenerationParserPromptSchema";
+import {
+  Dalle2ImageGenerationParserPromptSchema,
+  Dalle3ImageGenerationParserPromptSchema,
+} from "../shared/prompt_schemas/DalleImageGenerationParserPromptSchema";
 import { PaLMTextParserPromptSchema } from "../shared/prompt_schemas/PaLMTextParserPromptSchema";
 import { PaLMChatParserPromptSchema } from "../shared/prompt_schemas/PaLMChatParserPromptSchema";
 import { AnyscaleEndpointPromptSchema } from "../shared/prompt_schemas/AnyscaleEndpointPromptSchema";
@@ -79,8 +82,8 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   "gpt-4-vision-preview": OpenAIChatVisionModelParserPromptSchema,
 
   // DalleImageGenerationParser
-  "dall-e-2": DalleImageGenerationParserPromptSchema,
-  "dall-e-3": DalleImageGenerationParserPromptSchema,
+  "dall-e-2": Dalle2ImageGenerationParserPromptSchema,
+  "dall-e-3": Dalle3ImageGenerationParserPromptSchema,
 
   ClaudeBedrockModelParser: ClaudeBedrockPromptSchema,
 


### PR DESCRIPTION
# [ez] Fix dall-e-2 and dall-e-3 Prompt Schemas

Update the prompt schemas to reflect the differing options between dall-e-2 and dall-e-3, per https://platform.openai.com/docs/api-reference/images/create

![Screenshot 2024-02-06 at 10 23 43 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/ced73780-f808-4cf2-97e4-0d6d744b0c26)
![Screenshot 2024-02-06 at 10 28 47 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/e7caa01f-e446-4485-8a25-8b9e5a2c43ce)


Made sure both models work with each option set to different values and with no settings specified