### PR TITLE
[vscode] Fix white bar at top of config

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -992,7 +992,7 @@ function AIConfigEditorBase({
           </>
         )}
         <div>
-          <Flex justify="flex-end" mt="md" mb="xs">
+          <Flex justify="flex-end" pt="md" mb="xs">
             {
               <Group>
                 {downloadCallback && <DownloadButton onDownload={onDownload} />}


### PR DESCRIPTION
# [vscode] Fix white bar at top of config

In vscode there's a white bar at the top of the config in some themes. The cause is a margin-top set on one of the Flex containers. 
![Screenshot 2024-02-06 at 12 51 41 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/80ead590-0bb2-4e28-83a8-f0d6c006798a)


We can achieve the same effect using padding-top instead, but will result in the background colour being correct since there's no empty space between the elements now.

Just make sure local editor UI looks the same with margin-top changed to padding-top:
<img width="1433" alt="Screenshot 2024-02-06 at 2 15 07 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/63e843ff-14cc-4ad1-ae68-046ac6380f35">

