### PR TITLE
[editor] Support Explicit themeOverride for AIConfigEditor Component

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -7,6 +7,7 @@ import {
   Alert,
   Group,
   ActionIcon,
+  MantineThemeOverride,
 } from "@mantine/core";
 import {
   AIConfig,
@@ -77,6 +78,11 @@ type Props = {
    * overriding that behavior.
    */
   themeMode?: ThemeMode;
+  /**
+   * Theme override for the editor. If provided, this will override the theme associated
+   * with the provided AIConfigEditorMode.
+   */
+  themeOverride?: MantineThemeOverride;
 };
 
 export type RunPromptStreamEvent =
@@ -1080,7 +1086,11 @@ function AIConfigEditorBase({
 // the theme provider to ensure all components have the proper theme
 export default function AIConfigEditor(props: Props) {
   return (
-    <AIConfigEditorThemeProvider mode={props.mode} themeMode={props.themeMode}>
+    <AIConfigEditorThemeProvider
+      mode={props.mode}
+      themeMode={props.themeMode}
+      themeOverride={props.themeOverride}
+    >
       <NotificationProvider
         showNotification={props.callbacks?.showNotification}
       >

--- a/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
+++ b/python/src/aiconfig/editor/client/src/themes/AIConfigEditorThemeProvider.tsx
@@ -1,4 +1,4 @@
-import { MantineProvider } from "@mantine/core";
+import { MantineProvider, MantineThemeOverride } from "@mantine/core";
 import { AIConfigEditorMode, ThemeMode } from "../shared/types";
 import { LOCAL_THEME } from "./LocalTheme";
 import { GRADIO_THEME } from "./GradioTheme";
@@ -11,6 +11,7 @@ type Props = {
   children: React.ReactNode;
   mode?: AIConfigEditorMode;
   themeMode?: ThemeMode;
+  themeOverride?: MantineThemeOverride;
 };
 
 const THEMES = {
@@ -23,6 +24,7 @@ export default function AIConfigEditorThemeProvider({
   children,
   mode,
   themeMode,
+  themeOverride,
 }: Props) {
   // Use system color scheme by default (don't conditionally call hooks!)
   let preferredColorScheme = useColorScheme();
@@ -34,16 +36,14 @@ export default function AIConfigEditorThemeProvider({
   const theme = useMemo(
     () => ({
       colorScheme: preferredColorScheme,
-      ...THEMES[
-        mode!
-      ] /* mode must be nonnull per conditional wrapper condition */,
+      ...(themeOverride ?? (mode ? THEMES[mode] : {})),
     }),
-    [mode, preferredColorScheme]
+    [mode, preferredColorScheme, themeOverride]
   );
 
   return (
     <ConditionalWrapper
-      condition={mode != null}
+      condition={mode != null || themeMode != null || themeOverride != null}
       wrapper={(children) => (
         <MantineProvider withGlobalStyles withNormalizeCSS theme={theme}>
           {children}


### PR DESCRIPTION
[editor] Support Explicit themeOverride for AIConfigEditor Component

# [editor] Support Explicit themeOverride for AIConfigEditor Component

From discussion earlier, the packaging devX for cleaning up the vscode theme for the vs code extension is still not in a good enough shape for easy iteration. To unblock Zak on theme work, we can support a themeOverride prop for the AIConfigEditor component and use it for overriding the theme instead of just using the static vs code theme defined. We can propagate the desired theme changes back to the static vs code theme afterwards.

Long-term this may be a nice prop to support anyway for external implementations to easily set the theme without requiring a bunch of css overrides to do so.

## Testing:
- Tested all permutations of existing mode, themeMode and system theme to ensure they all work correctly
- Explicitly set themeOverride value to gradio theme override object in LocalEditor and ensure it has proper theme. Also ensured the colorScheme in themeOverride takes precedence (if specified), otherwise default of system theme light/dark mode is used as expected
