### PR TITLE
[gradio] Update Share Copy to 'Notebook'

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/global/ShareButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/global/ShareButton.tsx
@@ -1,13 +1,15 @@
 import { Button, Container, Flex, Modal, Text, Tooltip } from "@mantine/core";
-import { memo, useState } from "react";
+import { memo, useContext, useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import CopyButton from "../CopyButton";
+import AIConfigContext from "../../contexts/AIConfigContext";
 
 type Props = {
   onShare: () => Promise<string | void>;
 };
 
 export default memo(function ShareButton({ onShare }: Props) {
+  const { mode } = useContext(AIConfigContext);
   const [isModalOpened, { open: openModal, close: closeModal }] =
     useDisclosure(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -29,9 +31,12 @@ export default memo(function ShareButton({ onShare }: Props) {
     openModal();
   };
 
+  // We use 'Notebook' in Gradio for GradioNotebook packaging
+  const artifactName = mode === "gradio" ? "Notebook" : "Workbook";
+
   const tooltipMessage: string = isLoading
     ? "Generating share link..."
-    : "Create a link to share your Workbook!";
+    : `Create a link to share your ${artifactName}!`;
   const button = (
     <Tooltip label={tooltipMessage} withArrow>
       <Button
@@ -41,18 +46,22 @@ export default memo(function ShareButton({ onShare }: Props) {
         size="xs"
         variant="filled"
       >
-        Share Workbook
+        Share {artifactName}
       </Button>
     </Tooltip>
   );
 
   return (
     <>
-      <Modal opened={isModalOpened} onClose={closeModal} title="Workbook URL">
+      <Modal
+        opened={isModalOpened}
+        onClose={closeModal}
+        title={`${artifactName} URL`}
+      >
         <Container p={0} mr={-8}>
           <Flex direction="row">
             <Text truncate>{shareUrl}</Text>
-            <CopyButton value={shareUrl} contentLabel="Workbook URL" />
+            <CopyButton value={shareUrl} contentLabel={`${artifactName} URL`} />
           </Flex>
         </Container>
       </Modal>


### PR DESCRIPTION
# [gradio] Update Share Copy to 'Notebook'

For rebranding gradio workbook to notebook, make sure the share button has correct copy


https://github.com/lastmile-ai/aiconfig/assets/5060851/338309b4-d33b-4230-a083-40b83d3fd36a


https://github.com/lastmile-ai/aiconfig/assets/5060851/ef919681-7f3e-4dc9-b5b2-844df98b6f6f


