### PR TITLE
[vscode] Update aiconfig-editor Package to 0.1.21 & Override Theme

### DIFF
--- a/vscode-extension/editor/package.json
+++ b/vscode-extension/editor/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^5.7.0",
     "@emotion/react": "^11.11.1",
-    "@lastmileai/aiconfig-editor": "^0.1.15",
+    "@lastmileai/aiconfig-editor": "^0.1.21",
     "@mantine/carousel": "^6.0.7",
     "@mantine/core": "^6.0.7",
     "@mantine/dates": "^6.0.16",

--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -27,6 +27,7 @@ import {
   notifyDocumentDirty,
   updateWebviewState,
 } from "./utils/vscodeUtils";
+import { VSCODE_THEME } from "./VSCodeTheme";
 
 const useStyles = createStyles(() => ({
   editorBackground: {
@@ -425,6 +426,7 @@ export default function VSCodeEditor() {
       clearOutputs,
       deletePrompt,
       getModels,
+      getServerStatus,
       logEventHandler,
       runPrompt,
       setConfigDescription,
@@ -442,7 +444,12 @@ export default function VSCodeEditor() {
           <Loader size="xl" />
         </Flex>
       ) : (
-        <AIConfigEditor aiconfig={aiconfig} callbacks={callbacks} mode={MODE} />
+        <AIConfigEditor
+          aiconfig={aiconfig}
+          callbacks={callbacks}
+          mode={MODE}
+          themeOverride={VSCODE_THEME}
+        />
       )}
     </div>
   );

--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -1,0 +1,218 @@
+import { MantineThemeOverride } from "@mantine/core";
+
+// For quicker theme devX, use this theme to pass through to the AIConfigEditor instead of
+// the static VSCodeTheme packaged with the editor. We will consolidate later.
+export const VSCODE_THEME: MantineThemeOverride = {
+  defaultGradient: {
+    from: "#ff1cf7",
+    to: "#ff1cf7",
+    deg: 45,
+  },
+
+  globalStyles: () => ({
+    body: {
+      padding: "0 !important",
+      color: "var(--vscode-editor-foreground)",
+    },
+    ".addPromptRow": {
+      borderRadius: "0px",
+    },
+    ".editorBackground": {
+      background: "var(--vscode-editor-background)",
+      margin: "0",
+      maxWidth: "100%",
+      minHeight: "100vh",
+    },
+    ".monoFont": {
+      fontFamily:
+        "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+    },
+    ".ghost": {
+      border: "none",
+      borderRadius: "4px",
+      padding: "4px",
+      margin: "0px",
+
+      color: "var(--vscode-editor-foreground)",
+      backgroundColor: "var(--vscode-input-background)",
+
+      ":hover": {
+        backgroundColor: "rgba(226,232,255,.1)",
+      },
+      input: {
+        maxHeight: "16px",
+        fontFamily:
+          "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+        border: "none",
+        borderRadius: "4px",
+        padding: "4px",
+        margin: "0px",
+        backgroundColor: "var(--vscode-input-background)",
+        color: "var(--vscode-editor-foreground)",
+      },
+    },
+    ".cellStyle": {
+      border: "1px solid",
+      borderColor: "var(--vscode-notebook-cellBorderColor) !important",
+      backgroundColor: "var(--vscode-editorWidget-background)",
+      flex: 1,
+      color: "var(--vscode-editor-foreground)",
+      borderTopRightRadius: "0px",
+      borderBottomRightRadius: "0px",
+      borderTopLeftRadius: "0px",
+      borderBottomLeftRadius: "0px",
+      ":hover": {
+        background: "rgba(249, 250, 251, 0.01) !important",
+      },
+      textarea: {
+        border: "1px solid !important",
+        borderColor: "var(--vscode-notebook-cellBorderColor) !important",
+        color: "var(--vscode-editor-foreground)",
+        borderRadius: "0px",
+        margin: "0px 0px 0px 0px",
+        boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
+        backgroundColor: "var(--vscode-input-background)",
+        ":focus": {
+          outline: "solid 1px #ff1cf7 !important",
+          outlineOffset: "-1px",
+        },
+      },
+      ".mantine-InputWrapper-label": {
+        display: "none",
+      },
+    },
+    ".sidePanel": {
+      border: "1px solid",
+      borderColor: "var(--vscode-notebook-cellBorderColor)",
+      borderLeft: "none",
+      color: "var(--vscode-editor-foreground)",
+      borderTopRightRadius: "0px",
+      borderBottomRightRadius: "0px",
+      background: "var(--vscode-sideBar-background)",
+      minWidth: "32px",
+      input: {
+        borderRadius: "0px",
+        border: "1px solid",
+        borderColor: "var(--vscode-notebook-cellBorderColor)",
+        color: "var(--vscode-editor-foreground)",
+        backgroundColor: "var(--vscode-input-background)",
+        ":focus": {
+          outline:
+            "solid 1px var(--vscode-inputOption-activeBorder) !important",
+          outlineOffset: "-1px",
+        },
+      },
+      textarea: {
+        borderRadius: "0px",
+        border: "1px solid",
+        borderColor: "var(--vscode-notebook-cellBorderColor)",
+        color: "var(--vscode-editor-foreground)",
+        backgroundColor: "var(--vscode-input-background)",
+        ":focus": {
+          outline:
+            "solid 1px var(--vscode-inputOption-activeBorder) !important",
+          outlineOffset: "-1px",
+        },
+      },
+      label: {
+        color: "var(--vscode-editor-foreground) !important",
+      },
+      button: {
+        color: "var(--vscode-editor-foreground) !important",
+        borderColor: "ff1cf7 !important",
+      },
+    },
+    ".runPromptButton": {
+      background: "var(--vscode-button-background)",
+      color: "white",
+      borderRadius: "0",
+      height: "auto",
+      "&:hover": {
+        background: "var(--vscode-button-hoverBackground)",
+      },
+    },
+    ".primaryButton": {
+      background: "var(--vscode-button-background)",
+      color: "white",
+      "&:hover": {
+        background: "var(--vscode-button-hoverBackground)",
+      },
+    },
+    ".secondaryButton": {
+      background: "var(--vscode-button-secondaryBackground)",
+      color: "white",
+      "&:hover": {
+        background: "var(--vscode-button-secondaryHoverBackground)",
+      },
+    },
+    ".divider": {
+      borderTopWidth: "1px",
+      borderTopColor: "var(--vscode-notebook-cellBorderColor)",
+      marginBottom: "0.5em",
+    },
+
+    ".parametersContainer": {
+      maxHeight: "-webkit-fill-available",
+      margin: "16px auto 16px 36px",
+      padding: "0",
+      background: "var(--vscode-sideBar-background)",
+      color: "var(--vscode-editor-foreground) !important",
+      borderRadius: "0px",
+      border: "1px solid",
+      borderColor: "var(--vscode-notebook-cellBorderColor)",
+      textAlign: "left",
+      button: {
+        ":hover": {
+          backgroundColor: "var(--vscode-toolbar-hoverBackground)",
+        },
+      },
+      input: {
+        border: "1px solid",
+        borderColor: "var(--vscode-notebook-cellBorderColor)",
+        borderRadius: "0px",
+        color: "var(--vscode-editor-foreground)",
+        backgroundColor: "var(--vscode-input-background) !important",
+        ":focus": {
+          outline:
+            "solid 1px var(--vscode-inputOption-activeBorder) !important",
+          outlineOffset: "-1px",
+        },
+      },
+      textarea: {
+        border: "1px solid",
+        borderColor: "var(--vscode-notebook-cellBorderColor)",
+        borderRadius: "0px",
+        color: "var(--vscode-editor-foreground)",
+        backgroundColor: "var(--vscode-input-background) !important",
+        ":focus": {
+          outline:
+            "solid 1px var(--vscode-inputOption-activeBorder) !important",
+          outlineOffset: "-1px",
+        },
+      },
+
+      ".addParameterButton": {
+        position: "sticky",
+        left: "0",
+        bottom: "0",
+        margin: "16px 0 0 0",
+        borderRadius: "0px",
+        background: "var(--vscode-button-background)",
+        ":hover": {
+          backgroundColor: "var(--vscode-button-hoverBackground)",
+        },
+        path: {
+          color: "#fff",
+        },
+      },
+      ".promptMenuButton": {
+        marginLeft: -8,
+        background: "var(--vscode-button-secondaryBackground)",
+        color: "white",
+        ":hover": {
+          backgroundColor: "var(--vscode-button-hoverBackground)",
+        },
+      },
+    },
+  }),
+};

--- a/vscode-extension/editor/yarn.lock
+++ b/vscode-extension/editor/yarn.lock
@@ -1780,10 +1780,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lastmileai/aiconfig-editor@^0.1.15":
-  version "0.1.15"
-  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.1.15.tgz#b763525286191d95fb18fa199a8b9559a5e50c7e"
-  integrity sha512-/o7pTRyGvz3yhtFjmHfZQ2irtUaEjsGHYpdaKSeGiWqTioim4IfOQpVtW0Erw2hZSnnal0KhmU1sl29YrpXMcg==
+"@lastmileai/aiconfig-editor@^0.1.21":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.1.21.tgz#1110f36a7a43270f7315833643034bcdcbd998a5"
+  integrity sha512-SaY/nwnSYV/AzBvFeERBIMeuptlh28+koXiiaY8ssvK1XTeNNTmUS3sjlQaGeAJtfGpompXyDxAUMcIkv5I41A==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@mantine/carousel" "^6.0.7"


### PR DESCRIPTION
# [vscode] Update aiconfig-editor Package to 0.1.21 & Override Theme

Bump the aiconfig-editor package to the most recent, which includes a bunch of UI fixes and functionality (open in text editor button, showNotification overrides). Crucially, this also includes the ability to explicitly override the theme with `themeOverride` prop. This will allow us to quickly iterate on the theme in this package without needing to worry about re-packaging the editor or figuring out the package linking stuff (for now). We can propagate the theme back to the static theme value once it's finalized.

For the themeOverride, I just copy/pasted the existing VSCodeTheme and made two minor modifications to editorBackground and global parametersContainer styles to work with the updated styles from the package itself.

![Screenshot 2024-02-06 at 4 42 07 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/bc1321ae-e1c3-4d87-a3f7-61cf4f3fb898)
