### PR TITLE
[vscode] Use Python path for initialization

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -104,5 +104,8 @@
     "oboe": "^2.1.5",
     "portfinder": "^1.0.32",
     "ufetch": "^1.6.0"
-  }
+  },
+  "extensionDependencies": [
+    "ms-python.python"
+  ]
 }

--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -5,6 +5,7 @@ import {
   ServerInfo,
   getCurrentWorkingDirectory,
   getDocumentFromServer,
+  getPythonPath,
   initializeServerState,
   updateWebviewEditorThemeMode,
   waitUntilServerReady,
@@ -368,10 +369,13 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
 
     const openPort = await getPortPromise();
 
+    const pythonPath = await getPythonPath();
+
     // TODO: saqadri - specify parsers_module_path
+    // `aiconfig` command not useable here because it relies on python. Instead invoke the module directly.
     let startServer = spawn(
-      "aiconfig",
-      ["start", "--server-port", openPort.toString(), ...modelRegistryPathArgs],
+      pythonPath,
+      ["-m", "aiconfig.scripts.aiconfig_cli", "start", "--server-port", openPort.toString(), ...modelRegistryPathArgs],
       {
         cwd: getCurrentWorkingDirectory(document),
       }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -16,6 +16,7 @@ import {
   sanitizeFileName,
   getTodayDateString,
   LASTMILE_BASE_URI,
+  getPythonPath
 } from "./util";
 import { AIConfigEditorProvider } from "./aiConfigEditor";
 import { AIConfigEditorManager } from "./aiConfigEditorManager";
@@ -474,9 +475,13 @@ async function installRequirements(
     "python",
     "requirements.txt"
   );
+  const pythonPath = await getPythonPath();
 
   return new Promise((resolve, _reject) => {
-    const pipInstall = spawn("pip3", [
+
+    const pipInstall = spawn(pythonPath, [
+      "-m",
+      "pip",
       "install",
       "-r",
       requirementsPath,
@@ -543,8 +548,10 @@ async function checkRequirements(
     "requirements.txt"
   );
 
+  const pythonPath = await getPythonPath();
+
   return new Promise((resolve, reject) => {
-    let checkRequirements = spawn("python3", [
+    let checkRequirements = spawn(pythonPath, [
       checkRequirementsScriptPath,
       "--requirements_path",
       requirementsPath,
@@ -582,10 +589,13 @@ async function checkRequirements(
  * Checks if Python is installed on the system, and if not, prompts the user to install it.
  */
 async function checkPython() {
+  const pythonPath = await getPythonPath();
   return new Promise((resolve, _reject) => {
-    exec("python3 --version", (error, stdout, stderr) => {
+    
+    exec(pythonPath + " --version", (error, stdout, stderr) => {
       if (error) {
         console.error("Python was not found, can't install requirements");
+        console.error("retrieved python path: " + pythonPath);
 
         // Guide for installation
         vscode.window
@@ -615,8 +625,11 @@ async function checkPython() {
  * Checks if pip is installed on the system, and if not, prompts the user to install it.
  */
 async function checkPip() {
+  const pythonPath = await getPythonPath();
   return new Promise((resolve, _reject) => {
-    exec("pip3 --version", (error, stdout, stderr) => {
+    // when calling pip using `python -m`, no need to worry about pip vs pip3. 
+    // You're directly specifying which Python environment's pip to use.
+    exec(pythonPath + " -m pip --version", (error, stdout, stderr) => {
       if (error) {
         console.log("pip is not found");
         // Guide for installation

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -295,3 +295,19 @@ export function urlJoin(...args) {
   return normalize(parts);
 }
 //#endregion
+
+
+/**
+ * AIConfig Vscode extension has a dependency on the Python extension. 
+ * This function retrieves and returns the path to the current python interpreter.
+ * @returns the path to the current python interpreter
+ */
+export async function getPythonPath(): Promise<string> {
+  const pythonExtension = vscode.extensions.getExtension("ms-python.python");
+  if (!pythonExtension.isActive) {
+    await pythonExtension.activate();
+  }
+  
+  const pythonPath = pythonExtension.exports.settings.getExecutionDetails().execCommand[0];
+  return pythonPath;
+}


### PR DESCRIPTION
[vscode] Use Python path for initialization








Downloading, Installing, and setting up python is not standardardized across users, windows, and mac os. Common differences include:
- python installed as python vs python3
- pip installed as pip vs pip3


To mitigate this problem, retrieve the user's python environment path. This is pulled through the python vscode extension, which is also introduced as a dependency to the vscode extension.

Now we don't have to worry about issues like python vs python3, and the user can select the python environment their vscode uses and AIConfig VSCode editor will also use that.

Note: this diff simply updates the invokation of python to use the right interpreter. Any other changes will come on top.

## Testplan

<img width="1917" alt="Screenshot 2024-02-07 at 4 04 59 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/e7ea30c5-38c1-414a-815a-d3190e681ce6">

Notes while testing.

1. If the user installs python for the first time and doesn't select a python interpreter within vscode, vscode editor will default to a nonexistant python interpreter, not open, and fail. But so will the python extension.

2. initialization flow pip installs python-aiconfig requirements, currently vscode flow installs sentencepiece as a requirement of aiconfig-extension-hugging-face. This fails on the windows fresh install. But creating a new config or editing an existing one still works. But This still needs to be fixed


```[error] pip install:   error: subprocess-exited-with-error

  Getting requirements to build wheel did not run successfully.
  exit code: 1

  [31 lines of output]
  Traceback (most recent call last):
    File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.752.0_x64__qbz5n2kfra8p0\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 353, in <module>
      main()
    File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.752.0_x64__qbz5n2kfra8p0\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 335, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.752.0_x64__qbz5n2kfra8p0\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 118, in get_requires_for_build_wheel
      return hook(config_settings)
             ^^^^^^^^^^^^^^^^^^^^^
    File "C:\Users\ankush\AppData\Local\Temp\pip-build-env-ylhodmyw\overlay\Lib\site-packages\setuptools\build_meta.py", line 325, in get_requires_for_build_wheel
      return self._get_build_requires(config_settings, requirements=['wheel'])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Users\ankush\AppData\Local\Temp\pip-build-env-ylhodmyw\overlay\Lib\site-packages\setuptools\build_meta.py", line 295, in _get_build_requires
      self.run_setup()
    File "C:\Users\ankush\AppData\Local\Temp\pip-build-env-ylhodmyw\overlay\Lib\site-packages\setuptools\build_meta.py", line 480, in run_setup
      super(_BuildMetaLegacyBackend, self).run_setup(setup_script=setup_script)
    File "C:\Users\ankush\AppData\Local\Temp\pip-build-env-ylhodmyw\overlay\Lib\site-packages\setuptools\build_meta.py", line 311, in run_setup
      exec(code, locals())
    File "<string>", line 126, in <module>
    File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.752.0_x64__qbz5n2kfra8p0\Lib\subprocess.py", line 408, in check_call
      retcode = call(*popenargs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.752.0_x64__qbz5n2kfra8p0\Lib\subprocess.py", line 389, in call
      with Popen(*popenargs, **kwargs) as p:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.752.0_x64__qbz5n2kfra8p0\Lib\subprocess.py", line 1026, in __init__
      self._execute_child(args, executable, preexec_fn, close_fds,
    File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.752.0_x64__qbz5n2kfra8p0\Lib\subprocess.py", line 1538, in _execute_child
      hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  FileNotFoundError: [WinError 2] The system cannot find the file specified
  [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.

2024-02-07 16:11:20.167 [error] pip install: error: subprocess-exited-with-error


2024-02-07 16:11:20.167 [error] pip install: Getting requirements to build wheel did not run successfully.
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1151).
* #1167
* __->__ #1151