### PR TITLE
Changing all pyproject `requires-python` to 3.10

### DIFF
--- a/extensions/HuggingFace/python/pyproject.toml
+++ b/extensions/HuggingFace/python/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "An extension for using Hugging Face tasks to parse models for AIConfig."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/extensions/llama/python/pyproject.toml
+++ b/extensions/llama/python/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Model Parser extension for Llama"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Python library for LastMile AI API"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
Changing all pyproject `requires-python` to 3.10

We have some libraries like `TypeAlias` that require Python 3.10, as flagged by https://github.com/lastmile-ai/aiconfig/issues/1143

We're just going to be consistent for all extensions (even the ones that don't use the 3.10 libraries).

I'm also going to re-publish and build the libraries (and includes this in the release notes!)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1152).
* #1153
* __->__ #1152