### PR TITLE
[python] Pin Huggingface-hub dependency version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,7 @@ flask-cors
 flask[async]
 frozendict
 google-generativeai
-huggingface-hub
+huggingface-hub >= 0.20.3
 hypothesis==6.91.0
 lastmile-utils==0.0.21
 mock


### PR DESCRIPTION
[python] Pin Huggingface-hub dependency version

From #1156, not all versions of the python package huggingface-hub is compatible with the python sdk for AIConfig. We utilize the `InferenceClient` which was introduced sometime in 2023.

This diff pins it on > 0.20.3.

Current use of huggingface-hub is within the hugging face text generation model parser (core model parser).

## Testplan

I ran pip list on my computer to check which version I am developing with locally.
```
ankush@ap-mbp aiconfig % pip list | grep huggingface-hub
huggingface-hub                               0.20.3
```
