### PR TITLE
[python]  serialize first assistant message as prompt

### DIFF
--- a/python/src/aiconfig/default_parsers/openai.py
+++ b/python/src/aiconfig/default_parsers/openai.py
@@ -74,7 +74,7 @@ class OpenAIInference(ParameterizedModelParser):
             },
         )
         await ai_config.callback_manager.run_callbacks(event)
-        prompts = []
+        prompts: list[Prompt] = []
 
         # Combine conversation data with any extra keyword args
         conversation_data = {**data}
@@ -154,6 +154,29 @@ class OpenAIInference(ParameterizedModelParser):
                         }
                     ),
                     outputs=assistant_output,
+                )
+                prompts.append(prompt)
+            elif i == 0 and role == "assistant":
+                # If the first message is an assistant message,
+                # build a prompt with an empty input, 
+                # and the assistant response as the output
+
+                # Pull assistant response
+                assistant_output = build_output_data(conversation_data["messages"][i])
+                prompt = Prompt(
+                    name= f"{prompt_name}_{len(prompts) + 1}",
+                    input="",
+                    metadata=PromptMetadata(
+                        model= copy.deepcopy(model_metadata),
+                        parameters= parameters,
+                        remember_chat_context = True
+                    ),
+                    outputs=[                        ExecuteResult(
+                            output_type="execute_result",
+                            execution_count=None,
+                            data=assistant_output,
+                            metadata={},
+                        )],
                 )
                 prompts.append(prompt)
             i += 1


### PR DESCRIPTION
[python]  serialize first assistant message as prompt


A user was building with AIConfig and was attempting to serialize a set of prompts with OpenAI.

Their messages array looked like this
```
{ "role": "assistant", "content": "Welcome, ask me anything." },
{ "role": "user", "content": "Say this is a test" },
...
```

Notice how the first message was an assistant message! Previously serializing this with config.serialize() was not supported.

This diff adds minimal support by allowing serialization of the first assistant message, and creates a prompt with an empty input, and the assistant message as the output.

## testplan
Execute the user's test code. Also tested deserialize() and run() and they work as expected. No functional changes on that side

| <img width="546" alt="Screenshot 2024-02-07 at 11 42 31 AM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/06299485-a5ae-4a9c-adf6-e6f21293d8ed">|<img width="456" alt="Screenshot 2024-02-07 at 11 41 53 AM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/e60c1cc6-cf7a-4e6a-8e20-e6ad6db866bf">|
