### PR TITLE
[vscode] Use VS Code Notifications for showNotification

### DIFF
--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -7,7 +7,7 @@ import {
   LogEvent,
   LogEventData,
 } from "@lastmileai/aiconfig-editor";
-import { Flex, Loader, Image, createStyles } from "@mantine/core";
+import { Flex, Loader, createStyles } from "@mantine/core";
 import {
   AIConfig,
   InferenceSettings,
@@ -28,6 +28,8 @@ import {
   updateWebviewState,
 } from "./utils/vscodeUtils";
 import { VSCODE_THEME } from "./VSCodeTheme";
+// TODO: Update package to export AIConfigEditorNotification type
+import { AIConfigEditorNotification } from "@lastmileai/aiconfig-editor/dist/components/notifications/NotificationProvider";
 
 const useStyles = createStyles(() => ({
   editorBackground: {
@@ -281,7 +283,7 @@ export default function VSCodeEditor() {
   const cancel = useCallback(
     async (cancellationToken: string) => {
       // TODO: saqadri - check the status of the response (can be 400 or 422 if cancellation fails)
-      const res = await ufetch.post(ROUTE_TABLE.CANCEL(aiConfigServerUrl), {
+      await ufetch.post(ROUTE_TABLE.CANCEL(aiConfigServerUrl), {
         cancellation_token_id: cancellationToken,
       });
 
@@ -402,6 +404,12 @@ export default function VSCodeEditor() {
     []
   );
 
+  const showNotification = useCallback(
+    (notification: AIConfigEditorNotification) =>
+      vscode?.postMessage({ type: "show_notification", notification }),
+    [vscode]
+  );
+
   const callbacks: AIConfigCallbacks = useMemo(
     () => ({
       addPrompt,
@@ -415,6 +423,7 @@ export default function VSCodeEditor() {
       setConfigDescription,
       setConfigName,
       setParameters,
+      showNotification,
       updateModel,
       updatePrompt,
       // explicitly omitted
@@ -432,6 +441,7 @@ export default function VSCodeEditor() {
       setConfigDescription,
       setConfigName,
       setParameters,
+      showNotification,
       updateModel,
       updatePrompt,
     ]


### PR DESCRIPTION
# [vscode] Use VS Code Notifications for showNotification

Just familiarizing myself a bit with the vscode extension dev so picked up this quick task. We support custom notifications via `showNotification` callback in the `AIConfigEditor`. For VS Code, we can leverage this callback to use the vs code `showXMessage` api, for X in 'information', 'warning', 'error'.

A caveat with vscode notifications is that they are intended to be very succinct -- they only allow a message string (and they strip newlines). They allow showing additional 'details' string but ONLY for modal UX, which is a bad UX to use compared to the toasts. As a workaround, this PR adds a 'Details' button to the notification toast so that the user can click it and see the full details message in the output log.


https://github.com/lastmile-ai/aiconfig/assets/5060851/1b0536b4-536b-4c44-a40c-faab80182677


