### PR TITLE
[vscode] Propagate themeMode for dark/light Theme Switching

### DIFF
--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -28,8 +28,9 @@ import {
   updateWebviewState,
 } from "./utils/vscodeUtils";
 import { VSCODE_THEME } from "./VSCodeTheme";
-// TODO: Update package to export AIConfigEditorNotification type
+// TODO: Update package to export AIConfigEditorNotification and ThemeMode types
 import { AIConfigEditorNotification } from "@lastmileai/aiconfig-editor/dist/components/notifications/NotificationProvider";
+import { ThemeMode } from "@lastmileai/aiconfig-editor/dist/shared/types";
 
 const useStyles = createStyles(() => ({
   editorBackground: {
@@ -50,6 +51,10 @@ export default function VSCodeEditor() {
   const [aiconfig, setAIConfig] = useState<AIConfig | undefined>();
   const [aiConfigServerUrl, setAIConfigServerUrl] = useState<string>(
     webviewState?.serverUrl ?? ""
+  );
+
+  const [themeMode, setThemeMode] = useState<ThemeMode | undefined>(
+    webviewState?.theme
   );
 
   const { classes } = useStyles();
@@ -99,6 +104,12 @@ export default function VSCodeEditor() {
 
         // TODO: saqadri - as soon as content is updated, we have to call
         // /get endpoint so we get the latest content from the server
+        return;
+      }
+      case "set_theme": {
+        const theme = message.theme;
+        setThemeMode(theme);
+        updateWebviewState(vscode, { theme });
         return;
       }
       default: {
@@ -459,6 +470,7 @@ export default function VSCodeEditor() {
           callbacks={callbacks}
           mode={MODE}
           themeOverride={VSCODE_THEME}
+          themeMode={themeMode}
         />
       )}
     </div>

--- a/vscode-extension/editor/src/utils/vscodeUtils.ts
+++ b/vscode-extension/editor/src/utils/vscodeUtils.ts
@@ -1,6 +1,6 @@
 import { WebviewApi } from "vscode-webview";
 import { ClientAIConfig } from "@lastmileai/aiconfig-editor/dist/shared/types";
-import { JSONObject, JSONValue } from "aiconfig";
+import { JSONValue } from "aiconfig";
 
 /**
  * State that gets serialized and restored when the webview is recreated.
@@ -12,6 +12,7 @@ import { JSONObject, JSONValue } from "aiconfig";
 export type WebviewState = {
   aiconfigState?: ClientAIConfig;
   serverUrl?: string;
+  theme?: "light" | "dark";
 };
 
 /**

--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -6,6 +6,7 @@ import {
   getCurrentWorkingDirectory,
   getDocumentFromServer,
   initializeServerState,
+  updateWebviewEditorThemeMode,
   waitUntilServerReady,
 } from "./util";
 import { getNonce } from "./utilities/getNonce";
@@ -312,6 +313,25 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
 
     // Update webview immediately so we unblock the render; server init should happen in the background.
     updateWebview();
+
+    // Set initial dark/light theme mode for the webview and on theme changes. Also, on tab activation.
+    if (!isWebviewDisposed) {
+      updateWebviewEditorThemeMode(webviewPanel.webview);
+
+      vscode.window.onDidChangeActiveColorTheme(() => {
+        if (!isWebviewDisposed) {
+          updateWebviewEditorThemeMode(webviewPanel.webview);
+        }
+      });
+
+      webviewPanel.onDidChangeViewState((e) => {
+        if (e.webviewPanel.active) {
+          if (!isWebviewDisposed) {
+            updateWebviewEditorThemeMode(webviewPanel.webview);
+          }
+        }
+      });
+    }
 
     // Wait for server ready
     await waitUntilServerReady(editorServer.url);

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -65,6 +65,17 @@ export async function waitUntilServerReady(serverUrl: string) {
   }
 }
 
+export function updateWebviewEditorThemeMode(webview: vscode.Webview) {
+  const isDarkMode =
+    vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark ||
+    vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.HighContrast;
+  // ColorThemeKind.Light or ColorThemeKind.HighContrastLight is light mode
+  webview.postMessage({
+    type: "set_theme",
+    theme: isDarkMode ? "dark" : "light",
+  });
+}
+
 export async function initializeServerState(
   serverUrl: string,
   document: vscode.TextDocument


### PR DESCRIPTION
[vscode] Propagate themeMode for dark/light Theme Switching

# [vscode] Propagate themeMode for dark/light Theme Switching

VS Code themes have a `ColorThemeKind` which is one of Light, Dark, HighContrast (dark) or HighConstrastLight. We can leverage this to explicitly set the `themeMode` for the `AIConfigEditor`, which will be used for a few things:
- default mantine highlight and text backgrounds
- JSON editor dark/light theme colors
- as needed, can use the theme 'dark' or 'light' in our custom VSCode theme styles to override defaults

## Testing:
Make sure the JSON editor background as well as hover and title text background are correct when changing between themes

https://github.com/lastmile-ai/aiconfig/assets/5060851/195e3d30-e3db-479c-80f5-c3aaddaa6a35
