### PR TITLE
[editor][vscode][ez] Fix Padding on .ghost Input

### DIFF
--- a/python/src/aiconfig/editor/client/src/themes/LocalTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/LocalTheme.ts
@@ -43,7 +43,6 @@ export const LOCAL_THEME: MantineThemeOverride = {
           "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
         border: "none",
         borderRadius: "4px",
-        padding: "4px",
         margin: "0px",
         backgroundColor: "transparent",
       },

--- a/python/src/aiconfig/editor/client/src/themes/VSCodeTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/VSCodeTheme.ts
@@ -42,7 +42,6 @@ export const VSCODE_THEME: MantineThemeOverride = {
           "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
         border: "none",
         borderRadius: "4px",
-        padding: "4px",
         margin: "0px",
         backgroundColor: "var(--vscode-input-background)",
         color: "var(--vscode-editor-foreground)",

--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -45,7 +45,6 @@ export const VSCODE_THEME: MantineThemeOverride = {
           "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
         border: "none",
         borderRadius: "4px",
-        padding: "4px",
         margin: "0px",
         backgroundColor: "var(--vscode-input-background)",
         color: "var(--vscode-editor-foreground)",


### PR DESCRIPTION
[editor][vscode][ez] Fix Padding on .ghost Input

# [editor][vscode][ez] Fix Padding on .ghost Input

The 4px padding makes long text overlapped by the 'x' button. Let's just use the default mantine padding (which already handles preventing overlap).

Next PR, will try to get the inputs set up nicely so that they fit longer text as well

## Before
![Screenshot 2024-02-07 at 1 59 31 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/bbb25d2c-e630-4436-be73-f3c270d815d9)

## After
VS Code
![Screenshot 2024-02-07 at 1 57 33 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/24a370cc-dbd4-4733-bddd-33105b63807d)

Local
![Screenshot 2024-02-07 at 1 58 26 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/e1636dd5-8db2-4016-9c30-1fa1b8b5d2f2)
