### PR TITLE
[vscode] Connect openInTextEditor Callback

### DIFF
--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -415,6 +415,10 @@ export default function VSCodeEditor() {
     []
   );
 
+  const openInTextEditor = useCallback(async () => {
+    vscode?.postMessage({ type: "open_in_text_editor" });
+  }, [vscode]);
+
   const showNotification = useCallback(
     (notification: AIConfigEditorNotification) =>
       vscode?.postMessage({ type: "show_notification", notification }),
@@ -430,6 +434,7 @@ export default function VSCodeEditor() {
       getModels,
       getServerStatus,
       logEventHandler,
+      openInTextEditor,
       runPrompt,
       setConfigDescription,
       setConfigName,
@@ -448,6 +453,7 @@ export default function VSCodeEditor() {
       getModels,
       getServerStatus,
       logEventHandler,
+      openInTextEditor,
       runPrompt,
       setConfigDescription,
       setConfigName,


### PR DESCRIPTION
# [vscode] Connect openInTextEditor Callback

Connect the button & event added in https://github.com/lastmile-ai/aiconfig/pull/1142/files with the callback to reopen the aiconfig editor webview as a text editor to interact with the underlying file directly. 

https://github.com/lastmile-ai/aiconfig/assets/5060851/76a25aa7-566f-491d-9949-b0f2f9ec3b1a

Note, this requires closing and reopening the file in order to re-initialize the aiconfig editor webview for the file. We could potentially add another command to handle this scenario (something like, "AIConfig: Open in Editor" which defaults to current file but shows others in current directory?)


