### PR TITLE
[vscode][ez] Fix Default Gradient Color (for Top Buttons)

### DIFF
--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -4,8 +4,8 @@ import { MantineThemeOverride } from "@mantine/core";
 // the static VSCodeTheme packaged with the editor. We will consolidate later.
 export const VSCODE_THEME: MantineThemeOverride = {
   defaultGradient: {
-    from: "#ff1cf7",
-    to: "#ff1cf7",
+    from: "var(--vscode-button-background)",
+    to: "var(--vscode-button-background)",
     deg: 45,
   },
 


### PR DESCRIPTION
# [vscode][ez] Fix Default Gradient Color (for Top Buttons)

Most of the top buttons in the editor are using 'gradient' as their variant. We have the defaultGradient set to pink in the theme so changing it to match what the vscode button color should be.

## Before:
![Screenshot 2024-02-07 at 4 39 38 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/70ef5444-1bfd-4db9-9b7d-1ed8f9ef5f1b)

## After:
![Screenshot 2024-02-07 at 4 34 55 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/0478616f-3420-40be-af94-8895727344f2)

