### PR TITLE
[vscode][ez] Fix Propt Input Focus Outline Colour

### DIFF
--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -72,7 +72,8 @@ export const VSCODE_THEME: MantineThemeOverride = {
         boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
         backgroundColor: "var(--vscode-input-background)",
         ":focus": {
-          outline: "solid 1px #ff1cf7 !important",
+          outline:
+            "solid 1px var(--vscode-inputOption-activeBorder) !important",
           outlineOffset: "-1px",
         },
       },


### PR DESCRIPTION
[vscode][ez] Fix Propt Input Focus Outline Colour

# [vscode][ez] Fix Propt Input Focus Outline Colour

Looks like this colour was missed when translating to vscode variables, so just use the same outline as other places.

## Before
![Screenshot 2024-02-07 at 5 54 54 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/93160d6e-c7a6-47e6-9246-14cc1168c2f2)

## After
![Screenshot 2024-02-07 at 5 55 42 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/af3e1c87-1e1b-4841-8088-cea0191ac6dc)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1165).
* #1168
* #1166
* __->__ #1165