### PR TITLE
[vscode][ez] Override Mantine Default Input Colors with VSCode Theme

### DIFF
--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -72,7 +72,8 @@ export const VSCODE_THEME: MantineThemeOverride = {
         boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
         backgroundColor: "var(--vscode-input-background)",
         ":focus": {
-          outline: "solid 1px #ff1cf7 !important",
+          outline:
+            "solid 1px var(--vscode-inputOption-activeBorder) !important",
           outlineOffset: "-1px",
         },
       },

--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -23,6 +23,21 @@ export const VSCODE_THEME: MantineThemeOverride = {
       maxWidth: "100%",
       minHeight: "100vh",
     },
+    ".mantine-Input-input": {
+      backgroundColor: "var(--vscode-input-background)",
+      borderColor: "var(--vscode-notebook-cellBorderColor)",
+      borderRadius: "0px",
+      color: "var(--vscode-editor-foreground)",
+
+      ":focus": {
+        outline: "solid 1px var(--vscode-inputOption-activeBorder) !important",
+        outlineOffset: "-1px",
+      },
+
+      "::placeholder": {
+        color: "var(--vscode-input-placeholderForeground)",
+      },
+    },
     ".monoFont": {
       fontFamily:
         "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",


### PR DESCRIPTION
[vscode][ez] Override Mantine Default Input Colors with VSCode Theme

# [vscode][ez] Override Mantine Default Input Colors with VSCode Theme

The default mantine input styles (background, color, focus outline, placeholder color) are ok in some cases but can be improved for all themes by using the appropriate theme variables.

## Before:
https://github.com/lastmile-ai/aiconfig/assets/5060851/0efd596d-759e-4be6-b99c-01a1583d0ae0



## After:
https://github.com/lastmile-ai/aiconfig/assets/5060851/6baefd19-a3cf-491c-a2d4-12eae426087f

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1166).
* #1168
* __->__ #1166
* #1165