### PR TITLE
remove hf extension from vscode dependencies

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -104,5 +104,8 @@
     "oboe": "^2.1.5",
     "portfinder": "^1.0.32",
     "ufetch": "^1.6.0"
-  }
+  },
+  "extensionDependencies": [
+    "ms-python.python"
+  ]
 }

--- a/vscode-extension/python/requirements.txt
+++ b/vscode-extension/python/requirements.txt
@@ -1,9 +1,6 @@
 # AIConfig
 python-aiconfig>=1.1.19
 
-# Hugging Face Extension for AIConfig
-aiconfig-extension-hugging-face >= 0.0.3
-
 #Other
 asyncio
 ruamel.yaml

--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -5,6 +5,7 @@ import {
   ServerInfo,
   getCurrentWorkingDirectory,
   getDocumentFromServer,
+  getPythonPath,
   initializeServerState,
   updateWebviewEditorThemeMode,
   waitUntilServerReady,
@@ -368,10 +369,13 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
 
     const openPort = await getPortPromise();
 
+    const pythonPath = await getPythonPath();
+
     // TODO: saqadri - specify parsers_module_path
+    // `aiconfig` command not useable here because it relies on python. Instead invoke the module directly.
     let startServer = spawn(
-      "aiconfig",
-      ["start", "--server-port", openPort.toString(), ...modelRegistryPathArgs],
+      pythonPath,
+      ["-m", "aiconfig.scripts.aiconfig_cli", "start", "--server-port", openPort.toString(), ...modelRegistryPathArgs],
       {
         cwd: getCurrentWorkingDirectory(document),
       }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -16,6 +16,7 @@ import {
   sanitizeFileName,
   getTodayDateString,
   LASTMILE_BASE_URI,
+  getPythonPath
 } from "./util";
 import { AIConfigEditorProvider } from "./aiConfigEditor";
 import { AIConfigEditorManager } from "./aiConfigEditorManager";
@@ -474,9 +475,13 @@ async function installRequirements(
     "python",
     "requirements.txt"
   );
+  const pythonPath = await getPythonPath();
 
   return new Promise((resolve, _reject) => {
-    const pipInstall = spawn("pip3", [
+
+    const pipInstall = spawn(pythonPath, [
+      "-m",
+      "pip",
       "install",
       "-r",
       requirementsPath,
@@ -543,8 +548,10 @@ async function checkRequirements(
     "requirements.txt"
   );
 
+  const pythonPath = await getPythonPath();
+
   return new Promise((resolve, reject) => {
-    let checkRequirements = spawn("python3", [
+    let checkRequirements = spawn(pythonPath, [
       checkRequirementsScriptPath,
       "--requirements_path",
       requirementsPath,
@@ -582,10 +589,13 @@ async function checkRequirements(
  * Checks if Python is installed on the system, and if not, prompts the user to install it.
  */
 async function checkPython() {
+  const pythonPath = await getPythonPath();
   return new Promise((resolve, _reject) => {
-    exec("python3 --version", (error, stdout, stderr) => {
+    
+    exec(pythonPath + " --version", (error, stdout, stderr) => {
       if (error) {
         console.error("Python was not found, can't install requirements");
+        console.error("retrieved python path: " + pythonPath);
 
         // Guide for installation
         vscode.window
@@ -615,8 +625,11 @@ async function checkPython() {
  * Checks if pip is installed on the system, and if not, prompts the user to install it.
  */
 async function checkPip() {
+  const pythonPath = await getPythonPath();
   return new Promise((resolve, _reject) => {
-    exec("pip3 --version", (error, stdout, stderr) => {
+    // when calling pip using `python -m`, no need to worry about pip vs pip3. 
+    // You're directly specifying which Python environment's pip to use.
+    exec(pythonPath + " -m pip --version", (error, stdout, stderr) => {
       if (error) {
         console.log("pip is not found");
         // Guide for installation

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -295,3 +295,19 @@ export function urlJoin(...args) {
   return normalize(parts);
 }
 //#endregion
+
+
+/**
+ * AIConfig Vscode extension has a dependency on the Python extension. 
+ * This function retrieves and returns the path to the current python interpreter.
+ * @returns the path to the current python interpreter
+ */
+export async function getPythonPath(): Promise<string> {
+  const pythonExtension = vscode.extensions.getExtension("ms-python.python");
+  if (!pythonExtension.isActive) {
+    await pythonExtension.activate();
+  }
+  
+  const pythonPath = pythonExtension.exports.settings.getExecutionDetails().execCommand[0];
+  return pythonPath;
+}


### PR DESCRIPTION
remove hf extension from vscode dependencies

default installation of python fails when building sentencepiece. Remove it for now

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1167).
* __->__ #1167
* #1151