### PR TITLE
Make google-generativeai extension >=0.3.1

### DIFF
--- a/extensions/Gemini/python/requirements.txt
+++ b/extensions/Gemini/python/requirements.txt
@@ -1,5 +1,5 @@
 #Google
-google-generativeai==0.3.1
+google-generativeai>=0.3.1
 
 #Other
 asyncio

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,7 @@ flake8
 flask-cors
 flask[async]
 frozendict
-google-generativeai
+google-generativeai>=0.3.1
 huggingface-hub >= 0.20.3
 hypothesis==6.91.0
 lastmile-utils==0.0.21


### PR DESCRIPTION
Make google-generativeai extension >=0.3.1

Getting issues with this error:

```
AttributeError: module 'google.generativeai' has no attribute 'GenerativeModel'
```

This is similar to https://github.com/langchain-ai/langchain/issues/14724
