### PR TITLE
[vscode][ez] Override Mantine thumb/slider Colors

### DIFF
--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -59,6 +59,16 @@ export const VSCODE_THEME: MantineThemeOverride = {
       borderRadius: "0px",
       color: "var(--vscode-menu-foreground)",
     },
+    ".mantine-Slider-bar": {
+      backgroundColor: "var(--vscode-button-background)",
+    },
+    ".mantine-Slider-thumb": {
+      // Intentionally flip border/background to have color around the center
+      // Since border is null (i.e. will match sidePanel background). We need
+      // a background since high contrast dark buttons have null color
+      backgroundColor: "var(--vscode-notebook-cellBorderColor)",
+      border: "0.25rem solid var(--vscode-button-background)",
+    },
     ".monoFont": {
       fontFamily:
         "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",


### PR DESCRIPTION
# [vscode][ez] Override Mantine thumb/slider Colors

The thumb/slider for number settings is still using mantine's default blue:
![Screenshot 2024-02-08 at 10 28 57 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/1ac34731-7e93-45a8-822b-08f3bd6bb525)

Fix with vscode variables:

https://github.com/lastmile-ai/aiconfig/assets/5060851/de893ff7-4413-4da4-806a-0418daeb072c



---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1173).
* #1176
* #1175
* #1174
* __->__ #1173