### PR TITLE
[vscode][ez] Override Mantine Tab Border Bottom Color

### DIFF
--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -59,6 +59,16 @@ export const VSCODE_THEME: MantineThemeOverride = {
       borderRadius: "0px",
       color: "var(--vscode-menu-foreground)",
     },
+    ".mantine-Slider-bar": {
+      backgroundColor: "var(--vscode-button-background)",
+    },
+    ".mantine-Slider-thumb": {
+      // Intentionally flip border/background to have color around the center
+      // Since border is null (i.e. will match sidePanel background). We need
+      // a background since high contrast dark buttons have null color
+      backgroundColor: "var(--vscode-notebook-cellBorderColor)",
+      border: "0.25rem solid var(--vscode-button-background)",
+    },
     ".monoFont": {
       fontFamily:
         "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",

--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -69,6 +69,12 @@ export const VSCODE_THEME: MantineThemeOverride = {
       backgroundColor: "var(--vscode-notebook-cellBorderColor)",
       border: "0.25rem solid var(--vscode-button-background)",
     },
+    ".mantine-Tabs-tab[data-active]": {
+      borderBottom: "solid 1px var(--vscode-list-focusOutline)",
+      ":hover": {
+        borderBottom: "solid 1px var(--vscode-list-focusOutline)",
+      },
+    },
     ".monoFont": {
       fontFamily:
         "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",


### PR DESCRIPTION
# [vscode][ez] Override Mantine Tab Border Bottom Color

Tab bottom border in the side panel is still mantine's default blue so fix with vs code variable:

https://github.com/lastmile-ai/aiconfig/assets/5060851/fbaa469c-e373-45ea-a9aa-41e4744ac59c




---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1174).
* #1176
* #1175
* __->__ #1174
* #1173