### PR TITLE
[vscode][ez] Override Mantine Checkbox Checked Background Color

### DIFF
--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -59,6 +59,16 @@ export const VSCODE_THEME: MantineThemeOverride = {
       borderRadius: "0px",
       color: "var(--vscode-menu-foreground)",
     },
+    ".mantine-Slider-bar": {
+      backgroundColor: "var(--vscode-button-background)",
+    },
+    ".mantine-Slider-thumb": {
+      // Intentionally flip border/background to have color around the center
+      // Since border is null (i.e. will match sidePanel background). We need
+      // a background since high contrast dark buttons have null color
+      backgroundColor: "var(--vscode-notebook-cellBorderColor)",
+      border: "0.25rem solid var(--vscode-button-background)",
+    },
     ".monoFont": {
       fontFamily:
         "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",

--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -37,6 +37,15 @@ export const VSCODE_THEME: MantineThemeOverride = {
         },
       },
     },
+    ".mantine-Checkbox-input": {
+      "&:checked": {
+        backgroundColor: "var(--vscode-button-background)",
+        borderColor: "var(--vscode-notebook-cellBorderColor)",
+      },
+      "&:hover": {
+        background: "var(--vscode-button-hoverBackground)",
+      },
+    },
     ".mantine-Input-input": {
       backgroundColor: "var(--vscode-input-background)",
       borderColor: "var(--vscode-notebook-cellBorderColor)",

--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -69,6 +69,12 @@ export const VSCODE_THEME: MantineThemeOverride = {
       backgroundColor: "var(--vscode-notebook-cellBorderColor)",
       border: "0.25rem solid var(--vscode-button-background)",
     },
+    ".mantine-Tabs-tab[data-active]": {
+      borderBottom: "solid 1px var(--vscode-list-focusOutline)",
+      ":hover": {
+        borderBottom: "solid 1px var(--vscode-list-focusOutline)",
+      },
+    },
     ".monoFont": {
       fontFamily:
         "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",


### PR DESCRIPTION
# [vscode][ez] Override Mantine Checkbox Checked Background Color

The checkbox background colour when checked is still mantine's default blue:
![Screenshot 2024-02-08 at 11 09 24 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/f3a7bba8-2100-43d2-b3e4-6c64158b06ac)

So fix with vscode variable:

https://github.com/lastmile-ai/aiconfig/assets/5060851/ea2030e7-5c2b-4907-ba22-531c373a02cd



---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1175).
* #1176
* __->__ #1175
* #1174
* #1173