### PR TITLE
[vscode][ez] Override Mantine Tab Hover Background Color

### DIFF
--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -59,6 +59,16 @@ export const VSCODE_THEME: MantineThemeOverride = {
       borderRadius: "0px",
       color: "var(--vscode-menu-foreground)",
     },
+    ".mantine-Slider-bar": {
+      backgroundColor: "var(--vscode-button-background)",
+    },
+    ".mantine-Slider-thumb": {
+      // Intentionally flip border/background to have color around the center
+      // Since border is null (i.e. will match sidePanel background). We need
+      // a background since high contrast dark buttons have null color
+      backgroundColor: "var(--vscode-notebook-cellBorderColor)",
+      border: "0.25rem solid var(--vscode-button-background)",
+    },
     ".monoFont": {
       fontFamily:
         "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",

--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -78,6 +78,11 @@ export const VSCODE_THEME: MantineThemeOverride = {
       backgroundColor: "var(--vscode-notebook-cellBorderColor)",
       border: "0.25rem solid var(--vscode-button-background)",
     },
+    ".mantine-Tabs-tab": {
+      "&:hover": {
+        backgroundColor: "var(--vscode-inputOption-hoverBackground)",
+      },
+    },
     ".mantine-Tabs-tab[data-active]": {
       borderBottom: "solid 1px var(--vscode-list-focusOutline)",
       ":hover": {

--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -37,6 +37,15 @@ export const VSCODE_THEME: MantineThemeOverride = {
         },
       },
     },
+    ".mantine-Checkbox-input": {
+      "&:checked": {
+        backgroundColor: "var(--vscode-button-background)",
+        borderColor: "var(--vscode-notebook-cellBorderColor)",
+      },
+      "&:hover": {
+        background: "var(--vscode-button-hoverBackground)",
+      },
+    },
     ".mantine-Input-input": {
       backgroundColor: "var(--vscode-input-background)",
       borderColor: "var(--vscode-notebook-cellBorderColor)",

--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -69,6 +69,12 @@ export const VSCODE_THEME: MantineThemeOverride = {
       backgroundColor: "var(--vscode-notebook-cellBorderColor)",
       border: "0.25rem solid var(--vscode-button-background)",
     },
+    ".mantine-Tabs-tab[data-active]": {
+      borderBottom: "solid 1px var(--vscode-list-focusOutline)",
+      ":hover": {
+        borderBottom: "solid 1px var(--vscode-list-focusOutline)",
+      },
+    },
     ".monoFont": {
       fontFamily:
         "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",


### PR DESCRIPTION
# [vscode][ez] Override Mantine Tab Hover Background Color

Default hover background for the tabs is just the same dark color on all themes:

![Screenshot 2024-02-08 at 11 26 45 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/754084d2-f8c3-4444-8a97-de0c8c7bf1df)

Fix to use vscode hover theme style:

https://github.com/lastmile-ai/aiconfig/assets/5060851/3ba4ff99-ec39-476f-917f-84fd1c6dce45



---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1176).
* __->__ #1176
* #1175
* #1174
* #1173