### PR TITLE
Pin vscode extension to 1.1.22 for aiconfig library

### DIFF
--- a/vscode-extension/python/requirements.txt
+++ b/vscode-extension/python/requirements.txt
@@ -1,5 +1,5 @@
 # AIConfig
-python-aiconfig>=1.1.19
+python-aiconfig>=1.1.22
 
 #Other
 asyncio


### PR DESCRIPTION
Pin vscode extension to 1.1.22 for aiconfig library


This will fix the google Gemini issue since we pinned it in https://github.com/lastmile-ai/aiconfig/pull/1172
