### PR TITLE
[rfc] Prevent 'Error starting aiconfig server' notification when closing w/ unsaved changes

### DIFF
--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -6,7 +6,7 @@ import {
   getCurrentWorkingDirectory,
   getDocumentFromServer,
   getPythonPath,
-  initializeServerState,
+  updateServerState,
   updateWebviewEditorThemeMode,
   waitUntilServerReady,
 } from "./util";
@@ -144,23 +144,59 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
             return;
           }
 
+          // TODO: Should we skip events with no content changes?
+          // if (e.contentChanges.length === 0) {
+          //   console.log(
+          //     `changeDocumentSubscription ${e.document.uri} - skipping event because there are no content changes`
+          //   );
+          //   return;
+          // }
+
           // TODO: saqadri - instead of sending the entire document to the webview,
           // can ask it to reload the document from the server
 
           // Update webview immediately, and server state should be updated in the background.
+          console.log(
+            `changeDocumentSubscription ${e.document.uri} -- updating webview`
+          );
           updateWebview();
 
           // Notify server of updated document
           if (editorServer) {
-            console.log("changeDocumentSubscription -- updating server");
-
             // TODO: saqadri - decide if we want to await here or just fire and forget
-            await initializeServerState(editorServer.url, e.document);
-          }
+            try {
+              console.log("changeDocumentSubscription -- updating server");
+              await updateServerState(editorServer.url, e.document);
+            } catch (e) {
+              if (isWebviewDisposed) {
+                // Ignore errors caused by closing the webview while the server update
+                // request is in flight (e.g. closing config w/ unsaved changes will
+                // emit onDidChangeTextDocument with reverted unsaved changes)
+                // See #1201 for full details.
+                console.info(
+                  "Ignoring server update error due to webview disposal"
+                );
+                return;
+              }
 
-          console.log(
-            `changeDocumentSubscription ${e.document.uri} -- updating webview`
-          );
+              vscode.window
+                .showErrorMessage(
+                  "Failed to update aiconfig server. You can view the aiconfig but cannot modify it.",
+                  ...["Details", "Retry"]
+                )
+                .then((selection) => {
+                  if (selection === "Details") {
+                    this.extensionOutputChannel.error(
+                      e?.message ?? JSON.stringify(e)
+                    );
+                    this.extensionOutputChannel.show(/*preserveFocus*/ true);
+                  }
+                  if (selection === "Retry") {
+                    updateServerState(editorServer.url, e.document);
+                  }
+                });
+            }
+          }
         }
       }
     );
@@ -199,17 +235,17 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
 
     // Make sure we get rid of the listener when our editor is closed.
     webviewPanel.onDidDispose(() => {
+      isWebviewDisposed = true;
       console.log(`${document.fileName}: Webview disposed`);
+
       changeDocumentSubscription.dispose();
       willSaveDocumentSubscription.dispose();
 
-      // TODO: saqadri -- terminate the editor server process.
       if (editorServer) {
         console.log("Killing editor server process");
         editorServer.proc.kill();
+        editorServer = null;
       }
-
-      isWebviewDisposed = true;
     });
 
     // Receive message from the webview.
@@ -338,7 +374,24 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
     await waitUntilServerReady(editorServer.url);
 
     // Now set up the server with the latest document content
-    await initializeServerState(editorServer.url, document);
+    try {
+      await updateServerState(editorServer.url, document);
+    } catch (e) {
+      vscode.window
+        .showErrorMessage(
+          "Failed to start aiconfig server. You can view the aiconfig but cannot modify it.",
+          ...["Details", "Retry"]
+        )
+        .then((selection) => {
+          if (selection === "Details") {
+            this.extensionOutputChannel.error(e?.message ?? JSON.stringify(e));
+            this.extensionOutputChannel.show(/*preserveFocus*/ true);
+          }
+          if (selection === "Retry") {
+            updateServerState(editorServer.url, document);
+          }
+        });
+    }
 
     // Inform the webview of the server URL
     if (!isWebviewDisposed) {
@@ -375,7 +428,14 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
     // `aiconfig` command not useable here because it relies on python. Instead invoke the module directly.
     let startServer = spawn(
       pythonPath,
-      ["-m", "aiconfig.scripts.aiconfig_cli", "start", "--server-port", openPort.toString(), ...modelRegistryPathArgs],
+      [
+        "-m",
+        "aiconfig.scripts.aiconfig_cli",
+        "start",
+        "--server-port",
+        openPort.toString(),
+        ...modelRegistryPathArgs,
+      ],
       {
         cwd: getCurrentWorkingDirectory(document),
       }

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -84,33 +84,14 @@ export function updateWebviewEditorThemeMode(webview: vscode.Webview) {
   });
 }
 
-export async function initializeServerState(
+export async function updateServerState(
   serverUrl: string,
   document: vscode.TextDocument
 ) {
-  try {
-    return await ufetch.post(
-      EDITOR_SERVER_ROUTE_TABLE.LOAD_CONTENT(serverUrl),
-      {
-        content: document.getText(),
-        mode: getModeFromDocument(document),
-      }
-    );
-  } catch (e) {
-    // Code that should run in response to the hello message command
-    vscode.window
-      .showErrorMessage(
-        "Failed to start aiconfig server. You can view the aiconfig but cannot modify it.",
-        ...["Retry"]
-      )
-      .then((selection) => {
-        if (selection === "Retry") {
-          initializeServerState(serverUrl, document);
-        }
-      });
-
-    return;
-  }
+  return await ufetch.post(EDITOR_SERVER_ROUTE_TABLE.LOAD_CONTENT(serverUrl), {
+    content: document.getText(),
+    mode: getModeFromDocument(document),
+  });
 }
 
 // Figure out what kind of AIConfig this is that we are loading
@@ -304,9 +285,8 @@ export function urlJoin(...args) {
 }
 //#endregion
 
-
 /**
- * AIConfig Vscode extension has a dependency on the Python extension. 
+ * AIConfig Vscode extension has a dependency on the Python extension.
  * This function retrieves and returns the path to the current python interpreter.
  * @returns the path to the current python interpreter
  */
@@ -315,7 +295,8 @@ export async function getPythonPath(): Promise<string> {
   if (!pythonExtension.isActive) {
     await pythonExtension.activate();
   }
-  
-  const pythonPath = pythonExtension.exports.settings.getExecutionDetails().execCommand[0];
+
+  const pythonPath =
+    pythonExtension.exports.settings.getExecutionDetails().execCommand[0];
   return pythonPath;
 }


### PR DESCRIPTION
[rfc] Prevent 'Error starting aiconfig server' notification when closing w/ unsaved changes

# [rfc] Prevent 'Error starting aiconfig server' notification when closing w/ unsaved changes

Currently, whenever an aiconfig editor webview is closed with unsaved changes, a notifcation shows at the bottom right:
![Screenshot 2024-02-08 at 6 29 06 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/9e45fced-a60e-42e9-8a2f-e8f65cfcd27f)

This is caused by the following sequence of events:
1. changeDocumentSubscription happens with the "unsaved" changes being undone; this results in updating webview & server
2. server /load request is sent as a result
3. Another changeDocumentSubscription happens with no changed content (can probably just skip -- in all cases?)
4. Webview disposed, kills editor process
5. /load Request (STILL IN FLIGHT) fails, causing the notification

I spent some time but wasn't able to figure out why changeDocumentSubscription was happening (note -- NOT happening from the notifying dirty). Seems like this could potentially be a KP - https://github.com/microsoft/vscode/issues/81902 but not concrete.

For now, RFC on this, we could just handle the server request error specially in this case when the webview is already disposed (and ignore it).


https://github.com/lastmile-ai/aiconfig/assets/5060851/4e986654-31d9-4192-bba7-d07fe0756448

Make sure the error still shows for legit cases (e.g. opening config without correct parsers installed):

https://github.com/lastmile-ai/aiconfig/assets/5060851/912b8123-137f-4e8e-ab64-b05438adb44f
