### PR TITLE
[gradio] Add Log Events for Download & Share Button Clicks

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -182,6 +182,7 @@ function AIConfigEditorBase({
     }
     try {
       await downloadCallback();
+      logEventHandler?.("DOWNLOAD_BUTTON_CLICKED");
     } catch (err: unknown) {
       const message = (err as RequestCallbackError).message ?? null;
       showNotification({
@@ -190,7 +191,7 @@ function AIConfigEditorBase({
         type: "error",
       });
     }
-  }, [downloadCallback, showNotification]);
+  }, [downloadCallback, logEventHandler, showNotification]);
 
   const shareCallback = callbacks?.share;
   const onShare = useCallback(async () => {
@@ -199,6 +200,7 @@ function AIConfigEditorBase({
     }
     try {
       const { share_url: shareUrl } = await shareCallback();
+      logEventHandler?.("SHARE_BUTTON_CLICKED");
       return shareUrl;
     } catch (err: unknown) {
       const message = (err as RequestCallbackError).message ?? null;
@@ -208,7 +210,7 @@ function AIConfigEditorBase({
         type: "error",
       });
     }
-  }, [shareCallback, showNotification]);
+  }, [logEventHandler, shareCallback, showNotification]);
 
   const saveCallback = callbacks?.save;
   const onSave = useCallback(async () => {

--- a/python/src/aiconfig/editor/client/src/shared/types.ts
+++ b/python/src/aiconfig/editor/client/src/shared/types.ts
@@ -65,11 +65,13 @@ export function aiConfigToClientConfig(aiconfig: AIConfig): ClientAIConfig {
 
 export type LogEvent =
   | "ADD_PROMPT"
-  | "SAVE_BUTTON_CLICKED"
-  | "RUN_PROMPT_START"
+  | "DOWNLOAD_BUTTON_CLICKED"
   | "RUN_PROMPT_CANCELED"
   | "RUN_PROMPT_ERROR"
-  | "RUN_PROMPT_SUCCESS";
+  | "RUN_PROMPT_START"
+  | "RUN_PROMPT_SUCCESS"
+  | "SAVE_BUTTON_CLICKED"
+  | "SHARE_BUTTON_CLICKED";
 
 // TODO: schematize this
 export type LogEventData = JSONObject;


### PR DESCRIPTION
# [gradio] Add Log Events for Download & Share Button Clicks

Adding `DOWNLOAD_BUTTON_CLICKED` and `SHARE_BUTTON_CLICKED` events to track usage, per gradio GTM doc. The event name follows pattern used by 'SAVE_BUTTON_CLICKED' already.

## Testing:
- In `LocalEditor`, pass through callbacks for share and download and update logging check to allow logging in dev
- Click the buttons and ensure they show up in datadog:
<img width="758" alt="Screenshot 2024-02-12 at 11 34 16 AM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/6f08f596-05fd-4fe6-81b5-b73d945b12c3">

