### PR TITLE
Set Working Default Models in HF Parsers

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/automatic_speech_recognition.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/automatic_speech_recognition.py
@@ -43,6 +43,13 @@ def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
         if key.lower() in supported_keys:
             completion_data[key.lower()] = model_settings[key]
 
+    # The default model is openai/whisper-large-v3, which does not work as of
+    # 02/13/2024. Instead, default to a free model (which supports remote
+    # inference) with the next most "likes" in HF
+    # https://huggingface.co/models?pipeline_tag=automatic-speech-recognition&sort=likes
+    if completion_data.get("model") is None:
+        completion_data["model"] = "openai/whisper-large-v2"
+
     return completion_data
 
 
@@ -299,7 +306,7 @@ class HuggingFaceAutomaticSpeechRecognitionRemoteInference(ModelParser):
             output_data = output.data
             if isinstance(output_data, str):
                 return output_data
-            
+
             else:
                 raise ValueError(
                     f"Invalid output data type {type(output_data)} for prompt '{prompt.name}'. Expected string."
@@ -347,7 +354,7 @@ def validate_and_retrieve_audio_from_attachments(prompt: Prompt) -> str:
         raise ValueError(
             "Multiple audio inputs are not supported for the HF Automatic Speech Recognition Inference api. Please specify a single audio input attachment for Prompt: {prompt.name}."
         )
-    
+
     attachment = prompt.input.attachments[0]
 
     validate_attachment_type_is_audio(attachment)

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_2_speech.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_2_speech.py
@@ -47,6 +47,13 @@ def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
         if key.lower() in supported_keys:
             completion_data[key.lower()] = model_settings[key]
 
+    # The default model is suno/bark, which requires HF Pro subscription
+    # Instead, default to a free model (which supports remote inference) with
+    # the next most "likes" in HF
+    # https://huggingface.co/models?pipeline_tag=text-to-speech&sort=likes
+    if completion_data.get("model") is None:
+        completion_data["model"] = "facebook/fastspeech2-en-ljspeech"
+
     return completion_data
 
 


### PR DESCRIPTION
# Set Working Default Models in HF Parsers

The default model parsers for AST and TTS don't work:
- For ASR, `openai/whisper-large-v3` just throws 500 errors (even on the model card in HF)
- For TTS, `suno/bark` requires a HF PRO subscription to run

For now, we can just default to the next-best models for those tasks (based on like count) which support remote inference

## Testing:
- Build the hf extension following its README
- Update aiconfig/cookbooks/Gradio/aiconfig_model_registry.py to have the tts and asr remote parsers added (should register all remote ones by default there?)
```
(aiconfig) ryanholinshead@Ryans-MBP aiconfig % parsers_path=/Users/ryanholinshead/Projects/aiconfig/cookbooks/Gradio/aiconfig_model_registry.py
(aiconfig) ryanholinshead@Ryans-MBP aiconfig % aiconfig edit --server-mode=debug_servers --parsers-module-path=$parsers_path
```

Ensure the model defaults work:
<img width="1479" alt="Screenshot 2024-02-13 at 11 25 38 AM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/4bc7c3a8-c251-47df-87c3-11e1077bb61e">
<img width="1465" alt="Screenshot 2024-02-13 at 11 26 42 AM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/98697b09-3cf6-4a83-83e2-b8930f4a97ef">


Note, was getting an error using the travel.aiconfig.json config
```
(aiconfig) ryanholinshead@Ryans-MBP aiconfig % aiconfig edit --aiconfig-path=$aiconfig_path --server-mode=debug_servers --parsers-module-path=$parsers_path

 File "/Users/ryanholinshead/Projects/aiconfig/python/src/aiconfig/Config.py", line 138, in load_json
    update_model_parser_registry_with_config_runtime(config_runtime)
  File "/Users/ryanholinshead/Projects/aiconfig/python/src/aiconfig/registry.py", line 134, in update_model_parser_registry_with_config_runtime
    retrieved_model_parser = ModelParserRegistry.get_model_parser(
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ryanholinshead/Projects/aiconfig/python/src/aiconfig/registry.py", line 64, in get_model_parser
    return ModelParserRegistry._parsers[model_id]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'HuggingFaceImage2TextTransformer'
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1221).
* #1222
* __->__ #1221