### PR TITLE
bump lm utils to 0.23 for relaxed pydantic version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "python-aiconfig"
-version = "1.1.22"
+version = "1.1.23"
 authors = [
   { name="Sarmad Qadri", email="sarmad@lastmileai.dev" },
 ]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ frozendict
 google-generativeai>=0.3.1
 huggingface-hub >= 0.20.3
 hypothesis==6.91.0
-lastmile-utils==0.0.21
+lastmile-utils==0.0.23
 mock
 nest_asyncio
 nltk


### PR DESCRIPTION
bump lm utils to 0.23 for relaxed pydantic version

Issue: https://github.com/lastmile-ai/lastmile-utils/issues/32

LM utils PR: https://github.com/lastmile-ai/lastmile-utils/pull/33

LM utils 0.21 -> 0.22 is safe. It simply adds one utility function.
0.22 -> 0.23 relaxes the pydantic constraint, which should be safe but we should sanity check.
