### PR TITLE
[gradio] Minor UI Tweaks for Clean Up

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -1017,19 +1017,7 @@ function AIConfigEditorBase({
         <div>
           <Flex justify="flex-end" pt="md" mb="xs">
             {
-              <Group>
-                {downloadCallback && <DownloadButton onDownload={onDownload} />}
-                {shareCallback && <ShareButton onShare={onShare} />}
-                {openInTextEditorCallback && (
-                  <Tooltip label="Open in Text Editor" withArrow>
-                    <ActionIcon
-                      onClick={openInTextEditorCallback}
-                      className="secondaryButton"
-                    >
-                      <IconBraces size="1rem" />
-                    </ActionIcon>
-                  </Tooltip>
-                )}
+              <Group spacing="xs">
                 {!readOnly && onClearOutputs && (
                   <Button
                     loading={undefined}
@@ -1039,6 +1027,32 @@ function AIConfigEditorBase({
                   >
                     Clear Outputs
                   </Button>
+                )}
+                {(downloadCallback || shareCallback) && (
+                  <div>
+                    {downloadCallback && (
+                      <DownloadButton
+                        onDownload={onDownload}
+                        isGrouped={shareCallback != null}
+                      />
+                    )}
+                    {shareCallback && (
+                      <ShareButton
+                        onShare={onShare}
+                        isGrouped={downloadCallback != null}
+                      />
+                    )}
+                  </div>
+                )}
+                {openInTextEditorCallback && (
+                  <Tooltip label="Open in Text Editor" withArrow>
+                    <ActionIcon
+                      onClick={openInTextEditorCallback}
+                      className="secondaryButton"
+                    >
+                      <IconBraces size="1rem" />
+                    </ActionIcon>
+                  </Tooltip>
                 )}
                 {!readOnly && saveCallback && (
                   <Tooltip

--- a/python/src/aiconfig/editor/client/src/components/global/DownloadButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/global/DownloadButton.tsx
@@ -1,12 +1,29 @@
-import { Button } from "@mantine/core";
+import { Button, Tooltip, createStyles } from "@mantine/core";
+import { IconDownload } from "@tabler/icons-react";
 import { memo, useState } from "react";
 
 type Props = {
   onDownload: () => Promise<void>;
+  /**
+   * If grouped, apply styles to the button with assumption that
+   * the button is the leftmost in the group
+   */
+  isGrouped?: boolean;
 };
 
-export default memo(function DownloadButton({ onDownload }: Props) {
+const useStyles = createStyles(() => ({
+  buttonGroupLeft: {
+    borderBottomRightRadius: 0,
+    borderTopRightRadius: 0,
+  },
+}));
+
+export default memo(function DownloadButton({
+  onDownload,
+  isGrouped = false,
+}: Props) {
   const [isDownloading, setIsDownloading] = useState<boolean>(false);
+  const { classes } = useStyles();
 
   const onClick = async () => {
     if (isDownloading) {
@@ -18,14 +35,19 @@ export default memo(function DownloadButton({ onDownload }: Props) {
   };
 
   return (
-    <Button
-      loaderPosition="center"
-      loading={isDownloading}
-      onClick={onClick}
-      size="xs"
-      variant="filled"
-    >
-      Download
-    </Button>
+    <Tooltip label="Download config file">
+      <Button
+        loaderPosition="center"
+        loading={isDownloading}
+        onClick={onClick}
+        size="xs"
+        variant="filled"
+        className={
+          isGrouped ? `${classes.buttonGroupLeft} buttonGroupLeft` : undefined
+        }
+      >
+        <IconDownload size="20px" />
+      </Button>
+    </Tooltip>
   );
 });

--- a/python/src/aiconfig/editor/client/src/components/global/ShareButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/global/ShareButton.tsx
@@ -1,19 +1,44 @@
-import { Button, Container, Flex, Modal, Text, Tooltip } from "@mantine/core";
+import {
+  Button,
+  Container,
+  Flex,
+  Modal,
+  Text,
+  Tooltip,
+  createStyles,
+} from "@mantine/core";
 import { memo, useContext, useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import CopyButton from "../CopyButton";
 import AIConfigContext from "../../contexts/AIConfigContext";
+import { IconShare } from "@tabler/icons-react";
 
 type Props = {
   onShare: () => Promise<string | void>;
+  /**
+   * If grouped, apply styles to the button with assumption that
+   * the button is the rightmost in the group
+   */
+  isGrouped?: boolean;
 };
 
-export default memo(function ShareButton({ onShare }: Props) {
+const useStyles = createStyles(() => ({
+  buttonGroupRight: {
+    borderBottomLeftRadius: 0,
+    borderTopLeftRadius: 0,
+  },
+}));
+
+export default memo(function ShareButton({
+  onShare,
+  isGrouped = false,
+}: Props) {
   const { mode } = useContext(AIConfigContext);
   const [isModalOpened, { open: openModal, close: closeModal }] =
     useDisclosure(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [shareUrl, setShareUrl] = useState<string>("");
+  const { classes } = useStyles();
 
   const onClick = async () => {
     if (isLoading) {
@@ -45,8 +70,11 @@ export default memo(function ShareButton({ onShare }: Props) {
         onClick={onClick}
         size="xs"
         variant="filled"
+        className={
+          isGrouped ? `${classes.buttonGroupRight} buttonGroupRight` : undefined
+        }
       >
-        Share {artifactName}
+        <IconShare size="20px" />
       </Button>
     </Tooltip>
   );

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
@@ -109,7 +109,12 @@ export default memo(function PromptActionBar({
           </Tabs>
         </Container>
       ) : (
-        <Flex direction="column" justify="space-between" h="100%">
+        <Flex
+          className="promptActionBarClosed"
+          direction="column"
+          justify="space-between"
+          h="100%"
+        >
           <Flex direction="row" justify="center" mt="0.5em">
             <ActionIcon size="sm" onClick={() => setIsExpanded(true)}>
               <IconClearAll />

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -51,6 +51,7 @@ export const GRADIO_THEME: MantineThemeOverride = {
             color: "#ea580c !important",
             fontSize: "16px" /* var(--button-large-text-size) */,
             fontWeight: 600 /* var(--button-large-text-weight) */,
+            minHeight: "36px",
             padding: "0 1.25rem",
           },
 
@@ -150,7 +151,7 @@ export const GRADIO_THEME: MantineThemeOverride = {
         ".ghost": {
           input: {
             border: `1px solid ${inputBorderColor}`,
-            maxHeight: "16px",
+            minHeight: "36px",
             fontFamily:
               "sf mono, ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
             borderRadius: "8px",
@@ -164,6 +165,16 @@ export const GRADIO_THEME: MantineThemeOverride = {
               backgroundColor: "transparent",
             },
           },
+        },
+
+        ".buttonGroupLeft": {
+          borderBottomRightRadius: 0,
+          borderTopRightRadius: 0,
+        },
+
+        ".buttonGroupRight": {
+          borderBottomLeftRadius: 0,
+          borderTopLeftRadius: 0,
         },
 
         ".cellStyle": {
@@ -216,6 +227,10 @@ export const GRADIO_THEME: MantineThemeOverride = {
               outline: "solid 1px #E85921 !important",
               outlineOffset: "-1px",
             },
+          },
+
+          ".promptActionBarClosed": {
+            minWidth: "32px",
           },
         },
 


### PR DESCRIPTION
# [gradio] Minor UI Tweaks for Clean Up

Applying the minor UI tweaks proposed by Zak:
![gradioNotebook](https://github.com/lastmile-ai/aiconfig/assets/5060851/d49fd9e2-ccbf-4126-9e4c-d404c27f9227)


Mainly:
- Group share/download and use icons w/ tooltips (note, applying grouping style only when both are shown)
- Set min-height on top buttons and prompt name/model inputs to 36px
- Set min width of action bar to 32px when closed

## Before:
<img width="1279" alt="Screenshot 2024-02-13 at 3 14 24 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/048f673a-b3da-4ef1-8e9a-08c837742685">

## After:
<img width="1279" alt="Screenshot 2024-02-13 at 3 18 41 PM" src="https://github.com/lastmile-ai/aiconfig/assets/5060851/83bdfc5f-4337-4190-a9c1-80b75e3047ca">

