### PR TITLE
[extension] fixes for conversational model parser

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/conversational.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/conversational.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 # HuggingFace API imports
 from huggingface_hub import InferenceClient
+from huggingface_hub.inference._types import (
+    ConversationalOutput,
+)
 
 from aiconfig import CallbackEvent
 from aiconfig.default_parsers.parameterized_model_parser import (
@@ -24,6 +27,9 @@ from aiconfig.util.params import resolve_prompt
 if TYPE_CHECKING:
     from aiconfig.Config import AIConfigRuntime
 
+# TODO: add conversation history support
+# TODO: update this in future to Serverless Endpoint once OpenAI format becomes their standard. See https://github.com/lastmile-ai/aiconfig/issues/1232
+
 
 # Step 1: define Helpers
 def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
@@ -33,9 +39,7 @@ def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
     Doc Ref: https://huggingface.co/docs/huggingface_hub/package_reference/inference_client#huggingface_hub.InferenceClient.conversational
     """
 
-    supported_keys = {
-        "model",
-    }
+    supported_keys = {"model", "parameters"}
 
     completion_data: dict[str, Any] = {}
 
@@ -52,9 +56,25 @@ def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
     else:
         # manually set default model because, otherwise this will fail. see comment above.
         # see this thread for more info: https://github.com/huggingface/huggingface_hub/issues/2023
-        completion_data["model"] = "https://api-inference.huggingface.co/models/facebook/blenderbot-400M-distill"
+        completion_data["model"] = (
+            "https://api-inference.huggingface.co/pipeline/conversational/facebook/blenderbot-400M-distill"
+        )
 
     return completion_data
+
+
+def construct_output(response: ConversationalOutput) -> Output:
+    metadata: dict[str, str] = {"raw_response": response}
+    output = ExecuteResult(
+        **{
+            "output_type": "execute_result",
+            "data": response.get("generated_text"),
+            "execution_count": 0,
+            "metadata": metadata,
+        }
+    )
+    return output
+
 
 class HuggingFaceConversationalRemoteInference(ParameterizedModelParser):
     """


### PR DESCRIPTION
[extension] fixes for conversational model parser

- set the right url for the default conversational model
- define method for construct output
- add "parameters" to chat completion params filter

## Testplan
Default model
<img width="1346" alt="Screenshot 2024-02-13 at 5 53 47 PM" src="https://github.com/huggingface/huggingface_hub/assets/141073967/34e02bc5-e034-42f8-8eb5-8851da725b11">

Test with flan x5
<img width="1398" alt="Screenshot 2024-02-13 at 5 55 30 PM" src="https://github.com/huggingface/huggingface_hub/assets/141073967/397973a8-b60f-410b-999d-bf665c34e90b">
