### PR TITLE
[editor] Update HF conversational prompt schema with parameters

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/conversational.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/conversational.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 # HuggingFace API imports
 from huggingface_hub import InferenceClient
+from huggingface_hub.inference._types import (
+    ConversationalOutput,
+)
 
 from aiconfig import CallbackEvent
 from aiconfig.default_parsers.parameterized_model_parser import (
@@ -33,9 +36,7 @@ def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
     Doc Ref: https://huggingface.co/docs/huggingface_hub/package_reference/inference_client#huggingface_hub.InferenceClient.conversational
     """
 
-    supported_keys = {
-        "model",
-    }
+    supported_keys = {"model", "parameters"}
 
     completion_data: dict[str, Any] = {}
 
@@ -52,9 +53,25 @@ def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
     else:
         # manually set default model because, otherwise this will fail. see comment above.
         # see this thread for more info: https://github.com/huggingface/huggingface_hub/issues/2023
-        completion_data["model"] = "https://api-inference.huggingface.co/models/facebook/blenderbot-400M-distill"
+        completion_data["model"] = (
+            "https://api-inference.huggingface.co/pipeline/conversational/facebook/blenderbot-400M-distill"
+        )
 
     return completion_data
+
+
+def construct_output(response: ConversationalOutput) -> Output:
+    metadata: dict[str, str] = {"raw_response": response}
+    output = ExecuteResult(
+        **{
+            "output_type": "execute_result",
+            "data": response.get("generated_text"),
+            "execution_count": 0,
+            "metadata": metadata,
+        }
+    )
+    return output
+
 
 class HuggingFaceConversationalRemoteInference(ParameterizedModelParser):
     """

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceConversationalRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceConversationalRemoteInferencePromptSchema.ts
@@ -18,6 +18,46 @@ export const HuggingFaceConversationalRemoteInferencePromptSchema: PromptSchema 
         to a deployed Inference Endpoint`,
         default: "facebook/blenderbot-400M-distill",
       },
+      parameters: {
+        type: "object",
+        description: "Additional parameters for the conversational task.",
+        properties: {
+          min_length: {
+            type: "integer",
+            description: "Integer to define the minimum length in tokens of the output summary..",
+          },
+          max_length: {
+            type: "integer",
+            description: "Integer to define the maximum length in tokens of the output summary."
+          },
+          top_k: {
+            type: "integer",
+            description: "Integer to define the top tokens considered within the sample operation to create new text."
+          },
+          top_p: {
+            type: "number",
+            description: "Float to define the tokens that are within the sample operation of text generation. Add tokens in the sample for more probable to least probable until the sum of the probabilities is greater than top_p."
+          },
+          temperature: {
+            type: "number",
+            description: "The temperature of the sampling operation. 1 means regular sampling, 0 means always take the highest score, 100.0 is getting closer to uniform probability.",
+            minimum: 0,
+            maximum: 100,
+          },
+          repetition_penalty: {
+            type: "number",
+            description: "The more a token is used within generation the more it is penalized to not be picked in successive generation passes.",
+            minimum: 0,
+            maximum: 100
+          },
+          max_time: {
+            type: "number",
+            description: "The amount of time in seconds that the query should take maximum. Network can cause some overhead so it will be a soft limit.",
+            minimum: 0,
+            maximum: 120,
+          }
+        }
+      }
     },
   },
 };


### PR DESCRIPTION
[editor] Update HF conversationalprompt schema with parameters

Taken from https://huggingface.co/docs/api-inference/detailed_parameters#conversational-task


Skipped the options dictionary for now, they are not relevant to inference.

## testplan

https://github.com/huggingface/huggingface_hub/assets/141073967/59039705-64cd-453f-a09c-090c7beef597

## Dependencies:

continued from: https://github.com/lastmile-ai/aiconfig/pull/1230

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1235).
* __->__ #1235
* #1233