### PR TITLE
[gradio][docs] Add Warning for using sdk_version 4.16.0

### DIFF
--- a/aiconfig-docs/docs/gradio-notebook.md
+++ b/aiconfig-docs/docs/gradio-notebook.md
@@ -32,6 +32,10 @@ You can:
   - [app.py](https://huggingface.co/spaces/lastmileai/gradio-notebook-template/blob/main/app.py)
   - [requirements.txt](https://huggingface.co/spaces/lastmileai/gradio-notebook-template/blob/main/requirements.txt)
 
+:::caution
+Please ensure the `sdk_version` in your Space's `README.md` is set to `sdk_version: 4.16.0` or lower due to compatibilty issues in higher `gradio` package versions
+:::
+
 ### 2. Design your Space
 
 Use the playground UI in your space to setup your models and prompts that you want on your space.
@@ -158,15 +162,15 @@ model_output = await config.run('prompt_1')
 Model parsers also exist for local models associated with most of the above tasks (via Hugging Face Transformers and Diffusers library). 
 
 :::danger
-Using local models will download the models to your space, using up space resources, even if the space user is not an owner of the space. Downloading the models will also require a significant wait when running a cell if they have not already been downloaded to your space. Please be aware of these considerations when using local models.
+Using local models will download the models to your Space, using up Space resources, even if the Space user is not an owner of the Space. Downloading the models will also require a significant wait when running a cell if they have not already been downloaded to your Space. Please be aware of these considerations when using local models.
 :::
 
-These local parsers can be used by adding them to the `ModelParserRegistry` for your space. To do so:
+These local parsers can be used by adding them to the `ModelParserRegistry` for your Space. To do so:
 - add a `model_parsers.py` file in your space repo
 - in the file, import the relevant model parser from `aiconfig_extension_hugging_face`
 - register the model parser in a `register_model_parsers` function
 
-See https://huggingface.co/spaces/lastmileai/gradio_notebook_local_model/blob/main/model_parsers.py for an example `model_parsers.py` file. You can copy this file to your own space and uncomment the desired local parsers.
+See https://huggingface.co/spaces/lastmileai/gradio_notebook_local_model/blob/main/model_parsers.py for an example `model_parsers.py` file. You can copy this file to your own Space and uncomment the desired local parsers.
 
 Once the `model_parsers.py` file is created, simply reference it in `app.py`:
 ```


### PR DESCRIPTION
# [gradio][docs] Add Warning for using sdk_version 4.16.0

Changes in version 4.17 and 4.18 break our component so warn users to use 4.16 or lower for now

![Screenshot 2024-02-13 at 11 39 25 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/5e9fac22-010f-4f78-ab62-f398b51ade01)

Also update 'space' to 'Space' in the local parsers section below

