### PR TITLE
[gradio] Set Default Models for Summarization and Translation

### DIFF
--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_summarization.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_summarization.py
@@ -57,6 +57,14 @@ def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
             parameters[key.lower()] = model_settings[key]
             completion_data["parameters"] = parameters
 
+    # The default model in HF is sshleifer/distilbart-cnn-12-6, which raises a
+    # KeyError, "summary_text", when calling the inference client.
+    # Instead, default to the model (which supports remote inference) with the
+    # most "likes" in HF
+    # https://huggingface.co/models?pipeline_tag=summarization&sort=likes
+    if completion_data.get("model") is None:
+        completion_data["model"] = "facebook/bart-large-cnn"
+
     return completion_data
 
 

--- a/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_translation.py
+++ b/extensions/HuggingFace/python/src/aiconfig_extension_hugging_face/remote_inference_client/text_translation.py
@@ -45,6 +45,14 @@ def refine_completion_params(model_settings: dict[Any, Any]) -> dict[str, Any]:
         if key.lower() in supported_keys:
             completion_data[key.lower()] = model_settings[key]
 
+    # The default model in HF is t5-small, which raises a KeyError,
+    # "translation_text", when calling the inference client.
+    # Instead, default to the model (which supports remote inference) with the
+    # most "likes" in HF
+    # https://huggingface.co/models?pipeline_tag=translation&sort=likes
+    if completion_data.get("model") is None:
+        completion_data["model"] = "facebook/mbart-large-50-many-to-many-mmt"
+
     return completion_data
 
 

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextSummarizationRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextSummarizationRemoteInferencePromptSchema.ts
@@ -15,7 +15,7 @@ export const HuggingFaceTextSummarizationRemoteInferencePromptSchema: PromptSche
           type: "string",
           description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL 
         to a deployed Inference Endpoint`,
-          default: "sshleifer/distilbart-cnn-12-6",
+          default: "facebook/bart-large-cnn",
         },
         min_length: {
           type: "integer",

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextTranslationRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceTextTranslationRemoteInferencePromptSchema.ts
@@ -16,7 +16,7 @@ export const HuggingFaceTextTranslationRemoteInferencePromptSchema: PromptSchema
           type: "string",
           description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL 
         to a deployed Inference Endpoint`,
-        default: "t5-small",
+          default: "facebook/mbart-large-50-many-to-many-mmt",
         },
         src_lang: {
           type: "string",


### PR DESCRIPTION
# [gradio] Set Default Models for Summarization and Translation

The default translation and summarization models are broken for the remote inference client, raising a `KeyError` for `summary_text` and `translation_text`, respectively.

We can hardcode working defaults for these parsers for now, based on the top most "liked" models for the relevant tasks:

![Screenshot 2024-02-14 at 10 54 24 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/b288e557-0ae9-4882-a192-aab491766e85)
![Screenshot 2024-02-14 at 10 55 32 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/6d8a617b-255f-4c9b-b798-371c97fdc3b6)

NOTE: This translation model requires specifying the target and source lang, otherwise it errors about them missing. I think this is fine for now, for a few reasons:
- it's better than current default of failing without clear error message and with no way to resolve (now, just add tgt and src lang)
- there are very few good translation models in the hub that actually work with inference API and those that do either require the src and tgt lang or are a poor UX/quality:
![Screenshot 2024-02-14 at 10 59 12 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/2e8d5e12-475b-470a-a24c-148496e371da)
- if we use this translation model with correct settings in our quickstart example, most people will probably clone and have the settings already or can at least use our quickstart as a reference

