### PR TITLE
[gradio] Fix Checkbox Style

### DIFF
--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -90,6 +90,24 @@ export const GRADIO_THEME: MantineThemeOverride = {
             color: "#374151",
           },
 
+        ".mantine-Checkbox-root": {
+          ".mantine-Checkbox-input": {
+            borderColor: inputBorderColor,
+
+            "&:checked": {
+              background:
+                "linear-gradient(to bottom right, #ffedd5, #fdba74 100%)",
+            },
+            "&:hover": {
+              background: "linear-gradient(to bottom right, #ffedd5, #fed7aa)",
+            },
+          },
+
+          ".mantine-Checkbox-icon": {
+            color: "#E85921",
+          },
+        },
+
         ".mantine-Input-input:focus": {
           outline: "solid 1px #E85921 !important",
           outlineOffset: "-1px",


### PR DESCRIPTION
# [gradio] Fix Checkbox Style

Apply style overrides for the checkbox background color to match the other buttons:

![Screenshot 2024-02-14 at 11 53 11 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/575d3a43-724d-4159-87e8-e323162dc836)
![Screenshot 2024-02-14 at 11 53 34 AM](https://github.com/lastmile-ai/aiconfig/assets/5060851/6622c617-ca9f-4b54-9a1a-037101d6afaa)

