### PR TITLE
[editor][gradio] Fix Markdown Links Target & Color

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/prompt/TextRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/TextRenderer.tsx
@@ -1,4 +1,4 @@
-import { Text, Title, TitleOrder } from "@mantine/core";
+import { Anchor, Text, Title, TitleOrder } from "@mantine/core";
 import { Prism } from "@mantine/prism";
 import ReactMarkdown from "react-markdown";
 import { HeadingProps } from "react-markdown/lib/ast-to-react";
@@ -16,6 +16,20 @@ function CustomHeading({ level, children, ...props }: HeadingProps) {
   );
 }
 
+function LinkRenderer({
+  href,
+  children,
+}: {
+  href?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Anchor href={href} target="_blank">
+      {children}
+    </Anchor>
+  );
+}
+
 export function TextRenderer({ content }: TextRendererProps) {
   // Renders markdown & also syntax highlights code for code snippets from ChatGPT / GPT-3
   // Note that this may cause errors for some other responses / non-code things from other models potentially
@@ -24,6 +38,7 @@ export function TextRenderer({ content }: TextRendererProps) {
     <ReactMarkdown
       remarkPlugins={[[remarkGfm, { singleTilde: false }]]}
       components={{
+        a: LinkRenderer,
         code({ inline, className, children, ...props }) {
           const match = /language-(\w+)/.exec(className || "");
           return !inline ? (

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -24,6 +24,13 @@ export const GRADIO_THEME: MantineThemeOverride = {
 
     return {
       "div.editorBackground": {
+        a: {
+          // Change links back to mantine color instead of gradio override
+          color: `${
+            theme.colorScheme === "light" ? "#1c7ed6" : "#4dabf7"
+          } !important`,
+        },
+
         background: theme.colorScheme === "light" ? "white" : "#0b0f19",
         borderRadius: "8px",
         // Gradio component is iframed so height should be in relation to


### PR DESCRIPTION
# [editor][gradio] Fix Markdown Links Target & Color

In gradio, the links in the description markdown have a couple issues:
- Color is overridden by gradio text color
- Clicking opens the link in the current iframe embed

To fix:
- override link / anchor color in gradio theme to set back to mantine's link colors
- update ReactMarkdown to open links in a new tab by default (applies to editor core as well)

![Screenshot 2024-02-14 at 12 23 00 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/873bc181-7019-41bc-953d-ea0f837826ef)
![Screenshot 2024-02-14 at 12 24 17 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/d73dcc20-247d-47cf-b2c8-d2850f3082eb)

## Testing:
- Make sure clicking opens in new tab and keeps current tab open to the left of the new tab

