### PR TITLE
[gradio] Fix Spinner Colors

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/global/DownloadButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/global/DownloadButton.tsx
@@ -39,6 +39,7 @@ export default memo(function DownloadButton({
       <Button
         loaderPosition="center"
         loading={isDownloading}
+        loaderProps={{ size: "sm" }}
         onClick={onClick}
         size="xs"
         variant="filled"

--- a/python/src/aiconfig/editor/client/src/components/global/ShareButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/global/ShareButton.tsx
@@ -67,6 +67,7 @@ export default memo(function ShareButton({
       <Button
         loaderPosition="center"
         loading={isLoading}
+        loaderProps={{ size: "sm" }}
         onClick={onClick}
         size="xs"
         variant="filled"

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -97,6 +97,24 @@ export const GRADIO_THEME: MantineThemeOverride = {
             color: "#374151",
           },
 
+        /*
+         * Fix loading spinner color for buttons and loaders rendered in buttons
+         */
+        "button.mantine-Button-root > div.mantine-Button-inner > span.mantine-Button-label > div > svg":
+          {
+            stroke: "#E85921",
+          },
+
+        "button.mantine-Button-root > div.mantine-Button-inner": {
+          "span.mantine-Button-centerLoader > svg": {
+            stroke: "#E85921",
+          },
+        },
+
+        "button.mantine-Button-root[data-loading]::before": {
+          backgroundColor: "rgba(26, 27, 30, 0.2)",
+        },
+
         ".mantine-Checkbox-root": {
           ".mantine-Checkbox-input": {
             borderColor: inputBorderColor,
@@ -274,6 +292,11 @@ export const GRADIO_THEME: MantineThemeOverride = {
           margin: "33px 4px 4px 4px",
           padding: "0.625rem !important",
           height: "auto",
+
+          // Make the icon filled when running spinner is shown
+          "div.mantine-Button-inner > span.mantine-Button-label > div > svg": {
+            fill: "#E85921",
+          },
         },
 
         ".runPromptButton.runPromptButtonReadOnly": {


### PR DESCRIPTION
[gradio] Fix Spinner Colors

# [gradio] Fix Spinner Colors

The loading spinner on the run button, download and share buttons is not clearly visible in gradio right now, especially in light mode:

https://github.com/lastmile-ai/aiconfig/assets/5060851/a7204248-1a8a-4f3a-8d12-e553dd66c03d


To fix, we need to override the stroke for the svg that's used. Also, for running prompt button, updated to make the square in the runPromptButton fill with the gradio color instead of white.

Test in light & dark themeMode:

https://github.com/lastmile-ai/aiconfig/assets/5060851/489745c0-f5bb-4f17-8cfd-d817adc78c9b


https://github.com/lastmile-ai/aiconfig/assets/5060851/e37e543c-c43d-43f6-bf22-4bce4ea08644

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1250).
* #1251
* __->__ #1250