### PR TITLE
[gradio] Fix Output List Padding

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/global/DownloadButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/global/DownloadButton.tsx
@@ -39,6 +39,7 @@ export default memo(function DownloadButton({
       <Button
         loaderPosition="center"
         loading={isDownloading}
+        loaderProps={{ size: "sm" }}
         onClick={onClick}
         size="xs"
         variant="filled"

--- a/python/src/aiconfig/editor/client/src/components/global/ShareButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/global/ShareButton.tsx
@@ -67,6 +67,7 @@ export default memo(function ShareButton({
       <Button
         loaderPosition="center"
         loading={isLoading}
+        loaderProps={{ size: "sm" }}
         onClick={onClick}
         size="xs"
         variant="filled"

--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_outputs/PromptOutputsRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_outputs/PromptOutputsRenderer.tsx
@@ -103,5 +103,11 @@ const OutputRenderer = memo(function Output({ output }: { output: Output }) {
 });
 
 export default memo(function PromptOutputsRenderer({ outputs }: Props) {
-  return outputs.map((output, i) => <OutputRenderer key={i} output={output} />);
+  return (
+    <Flex direction="column" className="outputContainer">
+      {outputs.map((output, i) => (
+        <OutputRenderer key={i} output={output} />
+      ))}
+    </Flex>
+  );
 });

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -97,6 +97,24 @@ export const GRADIO_THEME: MantineThemeOverride = {
             color: "#374151",
           },
 
+        /*
+         * Fix loading spinner color for buttons and loaders rendered in buttons
+         */
+        "button.mantine-Button-root > div.mantine-Button-inner > span.mantine-Button-label > div > svg":
+          {
+            stroke: "#E85921",
+          },
+
+        "button.mantine-Button-root > div.mantine-Button-inner": {
+          "span.mantine-Button-centerLoader > svg": {
+            stroke: "#E85921",
+          },
+        },
+
+        "button.mantine-Button-root[data-loading]::before": {
+          backgroundColor: "rgba(26, 27, 30, 0.2)",
+        },
+
         ".mantine-Checkbox-root": {
           ".mantine-Checkbox-input": {
             borderColor: inputBorderColor,
@@ -274,6 +292,11 @@ export const GRADIO_THEME: MantineThemeOverride = {
           margin: "33px 4px 4px 4px",
           padding: "0.625rem !important",
           height: "auto",
+
+          // Make the icon filled when running spinner is shown
+          "div.mantine-Button-inner > span.mantine-Button-label > div > svg": {
+            fill: "#E85921",
+          },
         },
 
         ".runPromptButton.runPromptButtonReadOnly": {

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -241,6 +241,15 @@ export const GRADIO_THEME: MantineThemeOverride = {
             boxShadow: "0px 1px 4px 0px rgba(0, 0, 0, 0.05) inset",
             backgroundColor: inputBackgroundColor,
           },
+
+          // Override gradio-container ol styles with mantine's
+          ".outputsContainer > ol": {
+            marginBlockStart: "1em",
+            marginBlockEnd: "1em",
+            marginInlineStart: "0px",
+            marginInlineEnd: "0px",
+            paddingInlineStart: "40px",
+          },
         },
 
         ".sidePanel": {


### PR DESCRIPTION
[gradio] Fix Output List Padding

# [gradio] Fix Output List Padding

Gradio has specific output list padding and margin styles which override mantine's:
![Screenshot 2024-02-14 at 3 29 31 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/3cd570de-fea0-49de-b2a5-9ad7309296dc)

This causes ordered lists in outputs to extend outside the cell card padding:
![Screenshot 2024-02-14 at 3 28 32 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/23da8498-8a0c-4373-ad25-5ae99ea06fbc)

We can fix by overriding with mantine's styles at higher specificity:
![Screenshot 2024-02-14 at 3 29 58 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/44d7d7e0-953a-45de-986b-5ff5ccd616fb)


## Testing:
- Locally, editor output list looks the same on main and in this PR for local and gradio modes:
![Screenshot 2024-02-14 at 3 26 34 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/9375c89e-1600-4cb6-a458-4a5af5c09f15)
![Screenshot 2024-02-14 at 3 26 48 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/1fb89d72-7d77-494e-944b-cf4d846d3d8f)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1251).
* __->__ #1251
* #1250