### PR TITLE
[gradio] Actually Fix ol Padding & Margin

### DIFF
--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -243,12 +243,9 @@ export const GRADIO_THEME: MantineThemeOverride = {
           },
 
           // Override gradio-container ol styles with mantine's
-          ".outputsContainer > ol": {
-            marginBlockStart: "1em",
-            marginBlockEnd: "1em",
-            marginInlineStart: "0px",
-            marginInlineEnd: "0px",
-            paddingInlineStart: "40px",
+          ".outputContainer > ol": {
+            margin: "1em 0",
+            paddingLeft: "40px",
           },
         },
 


### PR DESCRIPTION
# [gradio] Actually Fix ol Padding & Margin

Turns out we need to explicitly override padding and margin and not the block/inline start and end:

https://github.com/lastmile-ai/aiconfig/assets/5060851/3a20c384-7fab-494d-b9ee-a9173ad5ca28

![Screenshot 2024-02-14 at 4 16 20 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/72b31f67-7cce-44c4-940c-04db91b34f5d)

