### PR TITLE
[editor] Fix Model Setting Default Values

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/SettingsPropertyRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/SettingsPropertyRenderer.tsx
@@ -68,6 +68,18 @@ export default function SettingsPropertyRenderer({
     initialValue ?? defaultValue
   );
 
+  // If the default value (i.e. default from schema) changes, update the property value if
+  // the config value is not set. This will handle cases such as changing the prompt model
+  // selector when the model settings tab is open
+  // NOTE: We can't do the same for initialValue vs prevInitialValue because initialValue
+  // (config value) is updated on debounced propertyValue changes and that would cause issues
+  // with overwriting user changes with config value as they type
+  const [prevDefaultValue, setPrevDefaultValue] = useState(defaultValue);
+  if (prevDefaultValue !== defaultValue && initialValue == null) {
+    setPrevDefaultValue(defaultValue);
+    setPropertyValue(defaultValue);
+  }
+
   let propertyControl;
 
   const setAndPropagateValue = useCallback(


### PR DESCRIPTION
[editor] Fix Model Setting Default Values

# [editor] Fix Model Setting Default Values

Currently, the model settings state is retained when changing models in the selector instead of updating to the new defaults:

https://github.com/lastmile-ai/aiconfig/assets/5060851/1c38d6df-96d8-46c1-b164-65e9c16241b8

To fix, we can check the default value compared to the previous value and if they differ (i.e. new prompt schema default value) AND the initialValue (i.e. config value) is null/undefined then we reset the property value to the default:


https://github.com/lastmile-ai/aiconfig/assets/5060851/56837ac5-8d3a-4f52-8c4b-9e6ec0119c97

Also, make sure it works to reset value that is explicitly set:

https://github.com/lastmile-ai/aiconfig/assets/5060851/9a559ccd-32dc-4359-b016-befb27c84162



Some notes:
- General FYI of why we don't use an effect for this: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
- We are NOT doing the same when initialValue (i.e. from config) changes since that would put us in a weird loop where the property value is updating config value on debounced, then the updated initialValue would overwrite the property value

