### PR TITLE
[editor] Remount Model Settings Renderer on Model Change

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptActionBar.tsx
@@ -4,6 +4,7 @@ import { ClientPrompt } from "../../shared/types";
 import {
   PromptSchema,
   checkParametersSupported,
+  getPromptModelName,
 } from "../../utils/promptUtils";
 import { ActionIcon, Container, Flex, ScrollArea, Tabs } from "@mantine/core";
 import { IconClearAll } from "@tabler/icons-react";
@@ -13,6 +14,7 @@ import { JSONObject } from "aiconfig";
 import { PROMPT_CONTAINER_HEIGHT_MAP } from "./PromptContainer";
 
 type Props = {
+  defaultConfigModelName?: string;
   prompt: ClientPrompt;
   promptSchema?: PromptSchema;
   onUpdateModelSettings: (settings: Record<string, unknown>) => void;
@@ -58,6 +60,7 @@ const MIN_ACTION_BAR_HEIGHT = 300;
 const ADD_PARAMETER_BOTTOM_HEIGHT = 46;
 
 export default memo(function PromptActionBar({
+  defaultConfigModelName,
   prompt,
   promptSchema,
   onUpdateModelSettings,
@@ -107,6 +110,7 @@ export default memo(function PromptActionBar({
                   style={{ overflowY: "auto" }}
                 >
                   <ModelSettingsRenderer
+                    model={getPromptModelName(prompt, defaultConfigModelName)}
                     settings={getModelSettings(prompt)}
                     schema={modelSettingsSchema}
                     onUpdateModelSettings={onUpdateModelSettings}

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
@@ -174,6 +174,7 @@ export default memo(function PromptContainer({
       </Card>
       <div className="sidePanel">
         <PromptActionBar
+          defaultConfigModelName={defaultConfigModelName}
           prompt={prompt}
           promptSchema={promptSchema}
           onUpdateModelSettings={updateModelSettings}

--- a/python/src/aiconfig/editor/client/src/components/prompt/model_settings/ModelSettingsRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/model_settings/ModelSettingsRenderer.tsx
@@ -8,6 +8,7 @@ import JSONEditorToggleButton from "../../JSONEditorToggleButton";
 import { ErrorBoundary, useErrorBoundary } from "react-error-boundary";
 
 type Props = {
+  model?: string;
   settings?: JSONObject;
   schema?: GenericPropertiesSchema;
   onUpdateModelSettings: (settings: Record<string, unknown>) => void;
@@ -52,6 +53,7 @@ function SettingsErrorFallback({
 }
 
 export default memo(function ModelSettingsRenderer({
+  model,
   settings,
   schema,
   onUpdateModelSettings,
@@ -75,6 +77,8 @@ export default memo(function ModelSettingsRenderer({
           {/* // Only show the toggle if there is a schema to toggle between JSON and custom schema renderer */}
           {schema && rawJSONToggleButton}
           <JSONRenderer
+            // Use the model name as the key to force re-mount / updated state when model changes
+            key={model}
             content={settings}
             onChange={(val) =>
               onUpdateModelSettings(val as Record<string, unknown>)
@@ -93,6 +97,8 @@ export default memo(function ModelSettingsRenderer({
         >
           {rawJSONToggleButton}
           <ModelSettingsSchemaRenderer
+            // Use the model name as the key to force re-mount / updated state when model changes
+            key={model}
             settings={settings}
             schema={schema}
             onUpdateModelSettings={onUpdateModelSettings}


### PR DESCRIPTION
# [editor] Remount Model Settings Renderer on Model Change

Currently, the model settings state is retained when changing models in the selector instead of updating to the new defaults:

https://github.com/lastmile-ai/aiconfig/assets/5060851/1c38d6df-96d8-46c1-b164-65e9c16241b8

To fix, we can force the model settings renderer to remount when the prompt model value changes by passing the model name as the `key` prop to the component. Specifically, this handles the scenario outlined in discussion here: https://github.com/lastmile-ai/aiconfig/pull/1256#discussion_r1491743289


https://github.com/lastmile-ai/aiconfig/assets/5060851/60263416-dbb0-41d1-947b-be679e80bf75


