### PR TITLE
{wip} Scaffolding to set and get python path on init

### DIFF
--- a/vscode-extension/src/aiConfigEditorManager.ts
+++ b/vscode-extension/src/aiConfigEditorManager.ts
@@ -72,10 +72,7 @@ export class AIConfigEditorManager {
 
   removeEditorByUri(uri: string) {
     this.editorsByUri.delete(uri);
-    if (
-      this.activeEditorUri === uri ||
-      this.activeEditor?.document?.uri.toString() === uri
-    ) {
+    if (this.activeEditorUri === uri || this.activeEditor?.document?.uri.toString() === uri) {
       this.activeEditor = null;
       this.activeEditorUri = null;
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -27,9 +27,7 @@ import { AIConfigEditorManager } from "./aiConfigEditorManager";
 export function activate(context: vscode.ExtensionContext) {
   // Use the console to output diagnostic information (console.log) and errors (console.error)
   // This line of code will only be executed once when your extension is activated
-  console.log(
-    `Congratulations, your extension ${EXTENSION_NAME} is now active!`
-  );
+  console.log(`Congratulations, your extension ${EXTENSION_NAME} is now active!`);
 
   // Create an output channel for the extension
   const extensionOutputChannel = vscode.window.createOutputChannel("AIConfig", {
@@ -43,96 +41,59 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand(COMMANDS.SHOW_WELCOME, async () => {
-      const welcomeFilePath = path.join(
-        context.extensionPath,
-        "src",
-        "welcomePage.md"
-      );
-      await vscode.commands.executeCommand(
-        "markdown.showPreview",
-        vscode.Uri.file(welcomeFilePath)
-      );
+      const welcomeFilePath = path.join(context.extensionPath, "src", "welcomePage.md");
+      await vscode.commands.executeCommand("markdown.showPreview", vscode.Uri.file(welcomeFilePath));
     })
   );
 
-  const createAIConfigJSONCommand = vscode.commands.registerCommand(
-    COMMANDS.CREATE_NEW_JSON,
-    async () => {
-      return await createNewAIConfig(context, aiconfigEditorManager, "json");
-    }
-  );
+  const createAIConfigJSONCommand = vscode.commands.registerCommand(COMMANDS.CREATE_NEW_JSON, async () => {
+    return await createNewAIConfig(context, aiconfigEditorManager, "json");
+  });
   context.subscriptions.push(createAIConfigJSONCommand);
 
-  const createAIConfigYAMLCommand = vscode.commands.registerCommand(
-    COMMANDS.CREATE_NEW_YAML,
-    async () => {
-      return await createNewAIConfig(context, aiconfigEditorManager, "yaml");
-    }
-  );
+  const createAIConfigYAMLCommand = vscode.commands.registerCommand(COMMANDS.CREATE_NEW_YAML, async () => {
+    return await createNewAIConfig(context, aiconfigEditorManager, "yaml");
+  });
   context.subscriptions.push(createAIConfigYAMLCommand);
 
-  const shareModelParserCommand = vscode.commands.registerCommand(
-    COMMANDS.SHARE,
-    async () => {
-      return await shareAIConfig(context, aiconfigEditorManager);
-    }
-  );
+  const shareModelParserCommand = vscode.commands.registerCommand(COMMANDS.SHARE, async () => {
+    return await shareAIConfig(context, aiconfigEditorManager);
+  });
   context.subscriptions.push(shareModelParserCommand);
 
-  const customModelParserCommand = vscode.commands.registerCommand(
-    COMMANDS.CUSTOM_MODEL_REGISTRY_PATH,
-    async () => {
-      return await registerCustomModelRegistry(aiconfigEditorManager);
-    }
-  );
+  const customModelParserCommand = vscode.commands.registerCommand(COMMANDS.CUSTOM_MODEL_REGISTRY_PATH, async () => {
+    return await registerCustomModelRegistry(aiconfigEditorManager);
+  });
   context.subscriptions.push(customModelParserCommand);
 
-  const createCustomModelRegistryCommand = vscode.commands.registerCommand(
-    COMMANDS.CREATE_CUSTOM_MODEL_REGISTRY,
-    async () => {
-      return await createCustomModelRegistry(context, aiconfigEditorManager);
-    }
-  );
+  const createCustomModelRegistryCommand = vscode.commands.registerCommand(COMMANDS.CREATE_CUSTOM_MODEL_REGISTRY, async () => {
+    return await createCustomModelRegistry(context, aiconfigEditorManager);
+  });
   context.subscriptions.push(createCustomModelRegistryCommand);
 
-  const openConfigFileCommand = vscode.commands.registerCommand(
-    COMMANDS.OPEN_CONFIG_FILE,
-    async () => {
-      return await openConfigFile();
-    }
-  );
+  const openConfigFileCommand = vscode.commands.registerCommand(COMMANDS.OPEN_CONFIG_FILE, async () => {
+    return await openConfigFile();
+  });
   context.subscriptions.push(openConfigFileCommand);
 
-  const openModelParserCommand = vscode.commands.registerCommand(
-    COMMANDS.OPEN_MODEL_REGISTRY,
-    async () => {
-      return await openModelRegistry(context, aiconfigEditorManager);
-    }
-  );
+  const openModelParserCommand = vscode.commands.registerCommand(COMMANDS.OPEN_MODEL_REGISTRY, async () => {
+    return await openModelRegistry(context, aiconfigEditorManager);
+  });
   context.subscriptions.push(openModelParserCommand);
 
   // Run the setup command on activation
   vscode.commands.executeCommand(COMMANDS.INIT);
 
   // Register our custom editor providers
-  const aiconfigEditorManager: AIConfigEditorManager =
-    new AIConfigEditorManager();
+  const aiconfigEditorManager: AIConfigEditorManager = new AIConfigEditorManager();
 
-  context.subscriptions.push(
-    AIConfigEditorProvider.register(
-      context,
-      extensionOutputChannel,
-      aiconfigEditorManager
-    )
-  );
+  context.subscriptions.push(AIConfigEditorProvider.register(context, extensionOutputChannel, aiconfigEditorManager));
 
   // Also handle file renames/moves -- inform the EditorManager of the change
   context.subscriptions.push(
     vscode.workspace.onDidRenameFiles((e) => {
       e.files.forEach(async (file) => {
-        const editor = aiconfigEditorManager.getEditorByUri(
-          file.oldUri.toString()
-        );
+        const editor = aiconfigEditorManager.getEditorByUri(file.oldUri.toString());
         if (editor) {
           aiconfigEditorManager.removeEditorByUri(file.oldUri.toString());
           aiconfigEditorManager.addEditor(editor, file.newUri.toString());
@@ -150,14 +111,8 @@ export function deactivate() {
 /**
  * Creates a new AIConfig file in the editor.
  */
-async function createNewAIConfig(
-  context: vscode.ExtensionContext,
-  aiconfigEditorManager: AIConfigEditorManager,
-  mode: "json" | "yaml" = "json"
-) {
-  const workspaceUri = vscode.workspace.workspaceFolders
-    ? vscode.workspace.workspaceFolders[0].uri
-    : null;
+async function createNewAIConfig(context: vscode.ExtensionContext, aiconfigEditorManager: AIConfigEditorManager, mode: "json" | "yaml" = "json") {
+  const workspaceUri = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri : null;
   const untitledUri = workspaceUri
     ? workspaceUri.with({
         scheme: "untitled",
@@ -166,17 +121,9 @@ async function createNewAIConfig(
     : vscode.Uri.parse(`untitled:untitled.aiconfig.${mode}`);
 
   // Specify the initial content here
-  const newAIConfigJSON = vscode.Uri.joinPath(
-    context.extensionUri,
-    "static",
-    "untitled.aiconfig.json"
-  );
+  const newAIConfigJSON = vscode.Uri.joinPath(context.extensionUri, "static", "untitled.aiconfig.json");
 
-  const newAIConfigYAML = vscode.Uri.joinPath(
-    context.extensionUri,
-    "static",
-    "untitled.aiconfig.yaml"
-  );
+  const newAIConfigYAML = vscode.Uri.joinPath(context.extensionUri, "static", "untitled.aiconfig.yaml");
 
   const fileContentPath = mode === "json" ? newAIConfigJSON : newAIConfigYAML;
 
@@ -194,11 +141,7 @@ async function createNewAIConfig(
     viewColumn: vscode.ViewColumn.One,
   });
 
-  await vscode.commands.executeCommand(
-    "vscode.openWith",
-    doc.uri,
-    AIConfigEditorProvider.viewType
-  );
+  await vscode.commands.executeCommand("vscode.openWith", doc.uri, AIConfigEditorProvider.viewType);
 }
 
 /**
@@ -223,11 +166,7 @@ async function openConfigFile() {
   if (openUri) {
     const doc = await vscode.workspace.openTextDocument(openUri[0]);
 
-    await vscode.commands.executeCommand(
-      "vscode.openWith",
-      doc.uri,
-      AIConfigEditorProvider.viewType
-    );
+    await vscode.commands.executeCommand("vscode.openWith", doc.uri, AIConfigEditorProvider.viewType);
   }
 }
 
@@ -235,18 +174,12 @@ async function openConfigFile() {
  * Opens the currently registered custom model registry file in the editor.
  * If none is found, prompts the user to create a new one or use a pre-existing one.
  */
-async function openModelRegistry(
-  context: vscode.ExtensionContext,
-  aiconfigEditorManager: AIConfigEditorManager
-) {
+async function openModelRegistry(context: vscode.ExtensionContext, aiconfigEditorManager: AIConfigEditorManager) {
   const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
   const savedModelRegistryPath = config.get<string>("modelRegistryPath");
   if (!savedModelRegistryPath) {
     vscode.window
-      .showWarningMessage(
-        "No custom model registry path has been set. Please set one first.",
-        ...["Create", "Use Existing"]
-      )
+      .showWarningMessage("No custom model registry path has been set. Please set one first.", ...["Create", "Use Existing"])
       .then((selection) => {
         if (selection === "Create") {
           createCustomModelRegistry(context, aiconfigEditorManager);
@@ -262,10 +195,7 @@ async function openModelRegistry(
     vscode.window.showTextDocument(doc);
   } else {
     vscode.window
-      .showErrorMessage(
-        `Error opening model registry file ${savedModelRegistryPath}`,
-        ...["Create New", "Use Existing"]
-      )
+      .showErrorMessage(`Error opening model registry file ${savedModelRegistryPath}`, ...["Create New", "Use Existing"])
       .then((selection) => {
         if (selection === "Create") {
           createCustomModelRegistry(context, aiconfigEditorManager);
@@ -279,26 +209,18 @@ async function openModelRegistry(
 /**
  * Creates a new custom model registry file and registers it with the extension.
  */
-async function createCustomModelRegistry(
-  context: vscode.ExtensionContext,
-  aiconfigEditorManager: AIConfigEditorManager
-) {
+async function createCustomModelRegistry(context: vscode.ExtensionContext, aiconfigEditorManager: AIConfigEditorManager) {
   let closestDirectory = null;
   const activeEditor = aiconfigEditorManager.getActiveEditor();
   if (activeEditor?.document && !activeEditor.document.isUntitled) {
     closestDirectory = path.dirname(activeEditor.document.fileName);
   } else if (vscode.window.activeTextEditor?.document) {
-    closestDirectory = path.dirname(
-      vscode.window.activeTextEditor.document.fileName
-    );
+    closestDirectory = path.dirname(vscode.window.activeTextEditor.document.fileName);
   } else {
     closestDirectory = getCurrentWorkingDirectory(null);
   }
 
-  let defaultModelRegistryPath = path.join(
-    closestDirectory,
-    "aiconfig_model_registry.py"
-  );
+  let defaultModelRegistryPath = path.join(closestDirectory, "aiconfig_model_registry.py");
 
   const modelRegistryPath = await vscode.window.showInputBox({
     prompt: "Enter the path to create the model registry file",
@@ -318,46 +240,28 @@ async function createCustomModelRegistry(
   }
 
   // Create the model registry file from the sample
-  const sampleModelRegistryPath = vscode.Uri.joinPath(
-    context.extensionUri,
-    "static",
-    "example_aiconfig_model_registry.py"
-  );
+  const sampleModelRegistryPath = vscode.Uri.joinPath(context.extensionUri, "static", "example_aiconfig_model_registry.py");
 
   try {
-    await vscode.workspace.fs.copy(
-      sampleModelRegistryPath,
-      vscode.Uri.file(modelRegistryPath),
-      { overwrite: false }
-    );
+    await vscode.workspace.fs.copy(sampleModelRegistryPath, vscode.Uri.file(modelRegistryPath), { overwrite: false });
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error creating new file ${modelRegistryPath}. Error is ${err}`
-    );
+    vscode.window.showErrorMessage(`Error creating new file ${modelRegistryPath}. Error is ${err}`);
   }
 
   const doc = await vscode.workspace.openTextDocument(modelRegistryPath);
   if (doc) {
     vscode.window.showTextDocument(doc);
-    vscode.window.showInformationMessage(
-      "Please customize your new model registry."
-    );
+    vscode.window.showInformationMessage("Please customize your new model registry.");
   }
 
   let config = vscode.workspace.getConfiguration(EXTENSION_NAME);
-  await handleCustomModelRegistryUpdate(
-    config,
-    aiconfigEditorManager,
-    modelRegistryPath
-  );
+  await handleCustomModelRegistryUpdate(config, aiconfigEditorManager, modelRegistryPath);
 }
 
 /**
  * Registers (and persists) the custom model registry path with the extension and all open aiconfig editors.
  */
-async function registerCustomModelRegistry(
-  aiconfigEditorManager: AIConfigEditorManager
-) {
+async function registerCustomModelRegistry(aiconfigEditorManager: AIConfigEditorManager) {
   let config = vscode.workspace.getConfiguration(EXTENSION_NAME);
   let savedModelRegistryPath = config.get<string>("modelRegistryPath");
 
@@ -384,42 +288,29 @@ async function handleCustomModelRegistryUpdate(
   modelRegistryPath: string
 ) {
   // TODO: saqadri - ask the user if they want us to apply the setting globally
-  await config.update(
-    "modelRegistryPath",
-    modelRegistryPath,
-    vscode.ConfigurationTarget.Workspace
-  );
+  await config.update("modelRegistryPath", modelRegistryPath, vscode.ConfigurationTarget.Workspace);
 
-  vscode.window.showInformationMessage(
-    `Custom model registry path updated to ${modelRegistryPath}`
-  );
+  vscode.window.showInformationMessage(`Custom model registry path updated to ${modelRegistryPath}`);
 
   // Now go through all the open AIConfig documents and update the model registry for their servers
   const aiconfigEditors = aiconfigEditorManager.getRegisteredEditors();
   const promises: Promise<string>[] = [];
   for (const editor of aiconfigEditors) {
     if (editor.editorServer) {
-      promises.push(
-        updateModelRegistryPath(editor.editorServer.url, modelRegistryPath)
-      );
+      promises.push(updateModelRegistryPath(editor.editorServer.url, modelRegistryPath));
     }
   }
 
   // TODO: saqadri - this by itself isn't enough -- we also need to reload the aiconfigs
   await Promise.allSettled(promises);
 
-  vscode.window.showInformationMessage(
-    `Updated model registry for open aiconfigs to ${modelRegistryPath}`
-  );
+  vscode.window.showInformationMessage(`Updated model registry for open aiconfigs to ${modelRegistryPath}`);
 }
 
 /**
  * Installs the dependencies required for the AIConfig extension to work
  */
-async function installDependencies(
-  context: vscode.ExtensionContext,
-  outputChannel: vscode.LogOutputChannel
-) {
+async function installDependencies(context: vscode.ExtensionContext, outputChannel: vscode.LogOutputChannel) {
   vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
@@ -464,10 +355,7 @@ async function installDependencies(
       });
 
       // Check if requirements need to be installed
-      const requirementsInstalled = await checkRequirements(
-        context,
-        outputChannel
-      );
+      const requirementsInstalled = await checkRequirements(context, outputChannel);
       if (requirementsInstalled) {
         outputChannel.append(" -- SUCCESS");
         // Requirements are already installed
@@ -484,17 +372,10 @@ async function installDependencies(
           message: "Installing dependencies",
         });
 
-        const installationResult = await installRequirements(
-          context,
-          progress,
-          cancellationToken,
-          outputChannel
-        );
+        const installationResult = await installRequirements(context, progress, cancellationToken, outputChannel);
         if (!installationResult) {
           // The installation encountered issues -- the installRequirements function will have already shown an error message
-          outputChannel.error(
-            "Failed to install dependencies. Please try again."
-          );
+          outputChannel.error("Failed to install dependencies. Please try again.");
           return;
         } else {
           // Installation was successful
@@ -523,22 +404,11 @@ async function installRequirements(
   outputChannel: vscode.LogOutputChannel
 ) {
   const extensionPath = context.extensionPath;
-  const requirementsPath = path.join(
-    extensionPath,
-    "python",
-    "requirements.txt"
-  );
+  const requirementsPath = path.join(extensionPath, "python", "requirements.txt");
   const pythonPath = await getPythonPath();
 
   return new Promise((resolve, _reject) => {
-    const pipInstall = spawn(pythonPath, [
-      "-m",
-      "pip",
-      "install",
-      "-r",
-      requirementsPath,
-      "--upgrade",
-    ]);
+    const pipInstall = spawn(pythonPath, ["-m", "pip", "install", "-r", requirementsPath, "--upgrade"]);
 
     pipInstall.stdout.on("data", (data) => {
       progress.report({
@@ -557,18 +427,10 @@ async function installRequirements(
       if (code !== 0) {
         console.log(`pip install process exited with code ${code}`);
         vscode.window
-          .showErrorMessage(
-            `Failed to install dependencies. Pip exited with code ${code}. Please try again later`,
-            ...["Retry"]
-          )
+          .showErrorMessage(`Failed to install dependencies. Pip exited with code ${code}. Please try again later`, ...["Retry"])
           .then((selection) => {
             if (selection === "Retry") {
-              installRequirements(
-                context,
-                progress,
-                cancellationToken,
-                outputChannel
-              );
+              installRequirements(context, progress, cancellationToken, outputChannel);
             }
           });
         resolve(false);
@@ -582,32 +444,16 @@ async function installRequirements(
 /**
  * Runs the check_requirements.py script to check if any requirements need to be updated or installed.
  */
-async function checkRequirements(
-  context: vscode.ExtensionContext,
-  outputChannel: vscode.LogOutputChannel
-) {
+async function checkRequirements(context: vscode.ExtensionContext, outputChannel: vscode.LogOutputChannel) {
   const extensionPath = context.extensionPath;
-  const checkRequirementsScriptPath = path.join(
-    extensionPath,
-    "python",
-    "src",
-    "check_requirements.py"
-  );
+  const checkRequirementsScriptPath = path.join(extensionPath, "python", "src", "check_requirements.py");
 
-  const requirementsPath = path.join(
-    extensionPath,
-    "python",
-    "requirements.txt"
-  );
+  const requirementsPath = path.join(extensionPath, "python", "requirements.txt");
 
   const pythonPath = await getPythonPath();
 
   return new Promise((resolve, reject) => {
-    let checkRequirements = spawn(pythonPath, [
-      checkRequirementsScriptPath,
-      "--requirements_path",
-      requirementsPath,
-    ]);
+    let checkRequirements = spawn(pythonPath, [checkRequirementsScriptPath, "--requirements_path", requirementsPath]);
 
     checkRequirements.stdout.on("data", (data) => {
       outputChannel.info(`check_requirements: ${data}`);
@@ -649,20 +495,13 @@ async function checkPython() {
         console.error("retrieved python path: " + pythonPath);
 
         // Guide for installation
-        vscode.window
-          .showErrorMessage(
-            "Python is not installed",
-            ...["Install Python", "Retry"]
-          )
-          .then((selection) => {
-            if (selection === "Install Python") {
-              vscode.env.openExternal(
-                vscode.Uri.parse("https://www.python.org/downloads/")
-              );
-            } else if (selection === "Retry") {
-              vscode.commands.executeCommand(COMMANDS.INIT);
-            }
-          });
+        vscode.window.showErrorMessage("Python is not installed", ...["Install Python", "Retry"]).then((selection) => {
+          if (selection === "Install Python") {
+            vscode.env.openExternal(vscode.Uri.parse("https://www.python.org/downloads/"));
+          } else if (selection === "Retry") {
+            vscode.commands.executeCommand(COMMANDS.INIT);
+          }
+        });
         resolve(false);
       } else {
         resolve(true);
@@ -685,15 +524,10 @@ async function checkPip() {
         console.log("pip is not found");
         // Guide for installation
         vscode.window
-          .showErrorMessage(
-            "pip is not installed, but is needed for AIConfig installation",
-            ...["Install pip", "Retry"]
-          )
+          .showErrorMessage("pip is not installed, but is needed for AIConfig installation", ...["Install pip", "Retry"])
           .then((selection) => {
             if (selection === "Install pip") {
-              vscode.env.openExternal(
-                vscode.Uri.parse("https://pip.pypa.io/en/stable/installation/")
-              );
+              vscode.env.openExternal(vscode.Uri.parse("https://pip.pypa.io/en/stable/installation/"));
             } else if (selection === "Retry") {
               vscode.commands.executeCommand(COMMANDS.INIT);
             }
@@ -707,16 +541,11 @@ async function checkPip() {
   });
 }
 
-async function shareAIConfig(
-  context: vscode.ExtensionContext,
-  aiconfigEditorManager: AIConfigEditorManager
-) {
+async function shareAIConfig(context: vscode.ExtensionContext, aiconfigEditorManager: AIConfigEditorManager) {
   // Get the current active aiconfig editor
   const activeEditor = aiconfigEditorManager.getActiveEditor();
   if (!activeEditor) {
-    vscode.window.showErrorMessage(
-      "No AIConfig file is currently open in the editor. Please open the file you want to share and try again."
-    );
+    vscode.window.showErrorMessage("No AIConfig file is currently open in the editor. Please open the file you want to share and try again.");
     return;
   }
 
@@ -770,37 +599,25 @@ async function shareAIConfig(
   if (response?.id !== null && response?.id !== undefined) {
     const permalink: string = LASTMILE_BASE_URI + `aiconfig/${response?.id}`;
 
-    vscode.window
-      .showInformationMessage(
-        "Would you like to open or copy the link?",
-        ...["Open", "Copy Link"]
-      )
-      .then((selection) => {
-        if (selection === "Open") {
-          vscode.env.openExternal(vscode.Uri.parse(permalink));
-        } else if (selection === "Copy Link") {
-          vscode.env.clipboard.writeText(permalink).then(
-            () => {
-              vscode.window.showInformationMessage(
-                "Link copied to clipboard. Happy sharing!"
-              );
-            },
-            (err) => {
-              vscode.window.showErrorMessage("Failed to copy link: " + err);
-            }
-          );
-        }
-      });
+    vscode.window.showInformationMessage("Would you like to open or copy the link?", ...["Open", "Copy Link"]).then((selection) => {
+      if (selection === "Open") {
+        vscode.env.openExternal(vscode.Uri.parse(permalink));
+      } else if (selection === "Copy Link") {
+        vscode.env.clipboard.writeText(permalink).then(
+          () => {
+            vscode.window.showInformationMessage("Link copied to clipboard. Happy sharing!");
+          },
+          (err) => {
+            vscode.window.showErrorMessage("Failed to copy link: " + err);
+          }
+        );
+      }
+    });
   } else {
-    vscode.window
-      .showErrorMessage(
-        "Failed to upload AIConfig to get a shareable permalink.",
-        ...["Retry"]
-      )
-      .then((selection) => {
-        if (selection === "Retry") {
-          shareAIConfig(context, aiconfigEditorManager);
-        }
-      });
+    vscode.window.showErrorMessage("Failed to upload AIConfig to get a shareable permalink.", ...["Retry"]).then((selection) => {
+      if (selection === "Retry") {
+        shareAIConfig(context, aiconfigEditorManager);
+      }
+    });
   }
 }

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -34,14 +34,10 @@ export const LASTMILE_BASE_URI: string = "https://lastmileai.dev/";
 const EDITOR_SERVER_API_ENDPOINT = `/api`;
 
 export const EDITOR_SERVER_ROUTE_TABLE = {
-  TO_STRING: (hostUrl: string) =>
-    urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/to_string"),
-  SERVER_STATUS: (hostUrl: string) =>
-    urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/server_status"),
-  LOAD_CONTENT: (hostUrl: string) =>
-    urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/load_content"),
-  LOAD_MODEL_PARSER_MODULE: (hostUrl: string) =>
-    urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/load_model_parser_module"),
+  TO_STRING: (hostUrl: string) => urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/to_string"),
+  SERVER_STATUS: (hostUrl: string) => urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/server_status"),
+  LOAD_CONTENT: (hostUrl: string) => urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/load_content"),
+  LOAD_MODEL_PARSER_MODULE: (hostUrl: string) => urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/load_model_parser_module"),
 };
 
 export type ServerInfo = {
@@ -51,9 +47,7 @@ export type ServerInfo = {
 
 export async function isServerReady(serverUrl: string) {
   try {
-    const res = await ufetch.get(
-      EDITOR_SERVER_ROUTE_TABLE.SERVER_STATUS(serverUrl)
-    );
+    const res = await ufetch.get(EDITOR_SERVER_ROUTE_TABLE.SERVER_STATUS(serverUrl));
 
     const status = res.status;
 
@@ -75,8 +69,7 @@ export async function waitUntilServerReady(serverUrl: string) {
 
 export function updateWebviewEditorThemeMode(webview: vscode.Webview) {
   const isDarkMode =
-    vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark ||
-    vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.HighContrast;
+    vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark || vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.HighContrast;
   // ColorThemeKind.Light or ColorThemeKind.HighContrastLight is light mode
   webview.postMessage({
     type: "set_theme",
@@ -84,10 +77,7 @@ export function updateWebviewEditorThemeMode(webview: vscode.Webview) {
   });
 }
 
-export async function updateServerState(
-  serverUrl: string,
-  document: vscode.TextDocument
-) {
+export async function updateServerState(serverUrl: string, document: vscode.TextDocument) {
   return await ufetch.post(EDITOR_SERVER_ROUTE_TABLE.LOAD_CONTENT(serverUrl), {
     content: document.getText(),
     mode: getModeFromDocument(document),
@@ -95,9 +85,7 @@ export async function updateServerState(
 }
 
 // Figure out what kind of AIConfig this is that we are loading
-export function getModeFromDocument(
-  document: vscode.TextDocument
-): "json" | "yaml" {
+export function getModeFromDocument(document: vscode.TextDocument): "json" | "yaml" {
   // determine mode from file path
   const documentPath = document.fileName;
   const ext = path.extname(documentPath)?.toLowerCase();
@@ -109,32 +97,20 @@ export function getModeFromDocument(
   return "json";
 }
 
-export async function getDocumentFromServer(
-  serverUrl: string,
-  document: vscode.TextDocument
-): Promise<string> {
-  const res = await ufetch.post(
-    EDITOR_SERVER_ROUTE_TABLE.TO_STRING(serverUrl),
-    {
-      mode: getModeFromDocument(document),
-      include_outputs: true,
-    }
-  );
+export async function getDocumentFromServer(serverUrl: string, document: vscode.TextDocument): Promise<string> {
+  const res = await ufetch.post(EDITOR_SERVER_ROUTE_TABLE.TO_STRING(serverUrl), {
+    mode: getModeFromDocument(document),
+    include_outputs: true,
+  });
 
   // TODO: saqadri - handle error cases
   return res.aiconfig_string;
 }
 
-export async function updateModelRegistryPath(
-  serverUrl: string,
-  customModelRegistryPath: string
-): Promise<string> {
-  const res = await ufetch.post(
-    EDITOR_SERVER_ROUTE_TABLE.LOAD_MODEL_PARSER_MODULE(serverUrl),
-    {
-      path: customModelRegistryPath,
-    }
-  );
+export async function updateModelRegistryPath(serverUrl: string, customModelRegistryPath: string): Promise<string> {
+  const res = await ufetch.post(EDITOR_SERVER_ROUTE_TABLE.LOAD_MODEL_PARSER_MODULE(serverUrl), {
+    path: customModelRegistryPath,
+  });
 
   // TODO: saqadri - handle error cases
   return res;
@@ -270,11 +246,7 @@ function normalize(strArray) {
   // replace ? and & in parameters with &
   const [beforeHash, afterHash] = str.split("#");
   const parts = beforeHash.split(/(?:\?|&)+/).filter(Boolean);
-  str =
-    parts.shift() +
-    (parts.length > 0 ? "?" : "") +
-    parts.join("&") +
-    (afterHash && afterHash.length > 0 ? "#" + afterHash : "");
+  str = parts.shift() + (parts.length > 0 ? "?" : "") + parts.join("&") + (afterHash && afterHash.length > 0 ? "#" + afterHash : "");
 
   return str;
 }
@@ -296,7 +268,6 @@ export async function getPythonPath(): Promise<string> {
     await pythonExtension.activate();
   }
 
-  const pythonPath =
-    pythonExtension.exports.settings.getExecutionDetails().execCommand[0];
+  const pythonPath = pythonExtension.exports.settings.getExecutionDetails().execCommand[0];
   return pythonPath;
 }


### PR DESCRIPTION
[vscode install] 1/n Scaffolding to set and get python path on init

Add a listener for changes to python interpreter, to retrieve the python interpreter on extension init.

Todo: remove this listener or add abstractions for this listener to work when an editor is already active.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1259).
* #1266
* #1265
* #1262
* __->__ #1259
* #1275