### PR TITLE
[editor][rfc] Default to readOnly Until Server Is Working

### DIFF
--- a/vscode-extension/editor/src/utils/vscodeUtils.ts
+++ b/vscode-extension/editor/src/utils/vscodeUtils.ts
@@ -11,6 +11,7 @@ import { JSONValue } from "aiconfig";
  */
 export type WebviewState = {
   aiconfigState?: ClientAIConfig;
+  isReadOnly?: boolean;
   serverUrl?: string;
   theme?: "light" | "dark";
 };


### PR DESCRIPTION
[editor][rfc] Default to readOnly Until Server Is Working

[editor][rfc] Default to readOnly Until Server Is Working

# [editor][rfc] Default to readOnly Until Server Is Working

When opening an aiconfig file, we currently open the webview with editable editor component before the server has successfully loaded the config content into state, then show an error message, `"Failed to start aiconfig server. You can view the aiconfig but cannot modify it."` with Retry button. A couple issues with the current state:
- Retry button is only shown once and can't retry again afterwards if it fails again
- Having editable state while the server isn't ready means the user can (confusingly) modify the UI, causing error messages and the changes NOT being reflected in the actual document (because we push to the document from the server)


https://github.com/lastmile-ai/aiconfig/assets/5060851/8ffd0b21-918a-49cf-ab9d-4f825314b952



We can improve this UX by:
- Making sure 'Retry' button is shown again (recursively) if the user clicks it and it still errors
- Setting default editor state to readOnly and updating it to editable only after the server successfully loads the content (and is ready to be used)
- NOTE: To prevent erroneous readOnly state when a non-working server state is "fixed", we assume that successful /load request means the server state is working, and set readOnly to false in that case as well



https://github.com/lastmile-ai/aiconfig/assets/5060851/d29b8b29-d44e-41d4-95d8-f08d06929fe9




## Testing:
- Made an aiconfig with model parsers that aren't loaded (e.g. from HF extension without the extension installed)
- Open the config, see readonly and error message. Click retry a few times, still shown to retry again after erroring again
- Update the config JSON (in another tab) to remove the bad parsers and fix the error. Click 'Retry', see success and now editable editor state
- Toggle between working server editor webview (editable) and one with errors (readonly) and back, ensuring the webview state is properly resaturated
