### PR TITLE
[vscode installation] 1/n Python version validation

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -18,6 +18,7 @@ import {
   getPythonPath,
   isSupportedConfigExtension,
   SUPPORTED_FILE_EXTENSIONS,
+  isPythonVersionAtLeast310,
 } from "./util";
 import { AIConfigEditorProvider } from "./aiConfigEditor";
 import { AIConfigEditorManager } from "./aiConfigEditorManager";
@@ -673,6 +674,12 @@ async function checkPython() {
             }
           });
         resolve(false);
+      } else if (!isPythonVersionAtLeast310(pythonPath)) {
+        console.error(
+          "Python version is not 3.10 or higher. Please upgrade to Python 3.10 or higher."
+        );
+        resolve(false);
+        // show guide for installation
       } else {
         resolve(true);
         console.log("Python is installed");

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import type { ChildProcessWithoutNullStreams } from "child_process";
+import { type ChildProcessWithoutNullStreams, execSync } from "child_process";
 import { setTimeout } from "timers/promises";
 import { ufetch } from "ufetch";
 
@@ -300,4 +300,25 @@ export async function getPythonPath(): Promise<string> {
   const pythonPath =
     pythonExtension.exports.settings.getExecutionDetails().execCommand[0];
   return pythonPath;
+}
+
+/**
+ * Checks if the specified Python interpreter is version 3.10 or higher.
+ * @param pythonPath The path to the Python interpreter.
+ * @returns A promise that resolves to a boolean indicating if the version is >= 3.10.
+ */
+
+export function isPythonVersionAtLeast310(pythonPath: string): boolean {
+  try {
+    // Use Python to check compatible version
+    // This approach circumvents the complexity of parsing version strings from `python --version`,
+    // which can vary in format and require custom parsing and comparison logic to handle different version schemes (e.g., major, minor, micro).
+    const command = `${pythonPath} -c "import sys; print(sys.version_info >= (3, 10))"`;
+    const output = execSync(command).toString().replace(/\s+/g, "").trim(); //replace newlines & whitespace
+
+    return output === "True";
+  } catch (error) {
+    console.debug("Error checking Python version:", error);
+    return false;
+  }
 }


### PR DESCRIPTION
[vscode installation] 1/n Python version validation

Add a helper method to validate the python interpreter version. Simply throws an error on a bad version. Notification dialog in diff on top.

Align's with Python AIConfig's version requirement of python3.10 and higher

## Testplan

Select a python interpreter 3.9, which is less than aiconfig's requirement version of 3.10.

https://github.com/lastmile-ai/aiconfig/assets/141073967/4cfcb153-50aa-40fb-9764-54e964d4b1b8

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1262).
* #1265
* __->__ #1262