### PR TITLE
[vscode installation] 2/n refactor error message for invalid python install

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -19,6 +19,7 @@ import {
   isSupportedConfigExtension,
   SUPPORTED_FILE_EXTENSIONS,
   isPythonVersionAtLeast310,
+  showGuideForPythonInstallation,
 } from "./util";
 import { AIConfigEditorProvider } from "./aiConfigEditor";
 import { AIConfigEditorManager } from "./aiConfigEditorManager";
@@ -657,24 +658,17 @@ async function checkPython() {
       if (error) {
         console.error("Python was not found, can't install requirements");
         console.error("retrieved python path: " + pythonPath);
+        console.error("error: " + error);
 
         // Guide for installation
-        vscode.window
-          .showErrorMessage(
-            "Python is not installed",
-            ...["Install Python", "Retry"]
-          )
-          .then((selection) => {
-            if (selection === "Install Python") {
-              vscode.env.openExternal(
-                vscode.Uri.parse("https://www.python.org/downloads/")
-              );
-            } else if (selection === "Retry") {
-              vscode.commands.executeCommand(COMMANDS.INIT);
-            }
-          });
+        showGuideForPythonInstallation(
+          "Specified Python Interpreter is not valid"
+        );
         resolve(false);
       } else if (!isPythonVersionAtLeast310(pythonPath)) {
+        showGuideForPythonInstallation(
+          "Python version is not 3.10 or higher. Please upgrade to Python 3.10 or higher."
+        );
         console.error(
           "Python version is not 3.10 or higher. Please upgrade to Python 3.10 or higher."
         );

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -322,3 +322,18 @@ export function isPythonVersionAtLeast310(pythonPath: string): boolean {
     return false;
   }
 }
+
+export function showGuideForPythonInstallation(message: string): void {
+  // Guide for installation
+  vscode.window
+    .showErrorMessage(message, ...["Install Python", "Retry"])
+    .then((selection) => {
+      if (selection === "Install Python") {
+        vscode.env.openExternal(
+          vscode.Uri.parse("https://www.python.org/downloads/")
+        );
+      } else if (selection === "Retry") {
+        vscode.commands.executeCommand(COMMANDS.INIT);
+      }
+    });
+}


### PR DESCRIPTION
[vscode installation] 2/n refactor error message for invalid python install

Added a helper method for showing user friendly error when python install doesn't go well.

## Testplan

Select Interpreter version 3.9.4. Open an editor and expect an error notification.

https://github.com/lastmile-ai/aiconfig/assets/141073967/5bda86e0-690f-4e43-9e94-f9279e3b2f34

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1265).
* #1294
* #1289
* #1290
* __->__ #1265