### PR TITLE
[vscode][ez] Use Default Diff View for .aiconfig.json/yaml Diff View

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -82,6 +82,11 @@
           "description": "Path to the custom model registry file."
         }
       }
+    },
+    "configurationDefaults": {
+      "workbench.editorAssociations": {
+        "{git,gitlens,sapling-diff}:/**/*.{aiconfig.json, aiconfig.yaml}": "default"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
# [vscode][ez] Use Default Diff View for .aiconfig.json/yaml Diff View

Following the example outlined in https://github.com/microsoft/vscode/issues/138525#issuecomment-1847679100 to make the view for diff-related views (noted by `git`, `gitlens`, `sapling-diff` as schema at the start of the document URI) fall back to the default diff view


https://github.com/lastmile-ai/aiconfig/assets/5060851/258d5ae6-d5f8-497d-8a99-c44e9be579c1

