### PR TITLE
[vscode] Add category to commands instead of hardcoding "AIConfig" in title

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -19,39 +19,48 @@
     "commands": [
       {
         "command": "vscode-aiconfig.init",
-        "title": "AIConfig: Initialize Extension"
+        "title": "Initialize Extension",
+        "category": "AIConfig"
       },
       {
         "command": "vscode-aiconfig.createAIConfigJSON",
-        "title": "AIConfig: Create New (JSON)"
+        "title": "Create New (JSON)",
+        "category": "AIConfig"
       },
       {
         "command": "vscode-aiconfig.createAIConfigYAML",
-        "title": "AIConfig: Create New (YAML)"
+        "title": "Create New (YAML)",
+        "category": "AIConfig"
       },
       {
         "command": "vscode-aiconfig.share",
-        "title": "AIConfig: Share (get permalink)"
+        "title": "Share (get permalink)",
+        "category": "AIConfig"
       },
       {
         "command": "vscode-aiconfig.customModelRegistryPath",
-        "title": "AIConfig: Set Custom Model Registry File Path"
+        "title": "Set Custom Model Registry File Path",
+        "category": "AIConfig"
       },
       {
         "command": "vscode-aiconfig.createCustomModelRegistry",
-        "title": "AIConfig: Create Custom Model Registry"
+        "title": "Create Custom Model Registry",
+        "category": "AIConfig"
       },
       {
         "command": "vscode-aiconfig.openConfigFile",
-        "title": "AIConfig: Open AIConfig File"
+        "title": "Open AIConfig File",
+        "category": "AIConfig"
       },
       {
         "command": "vscode-aiconfig.openModelRegistry",
-        "title": "AIConfig: Open Custom Model Registry File"
+        "title": "Open Custom Model Registry File",
+        "category": "AIConfig"
       },
       {
         "command": "vscode-aiconfig.showWelcome",
-        "title": "AIConfig: Welcome"
+        "title": "Welcome",
+        "category": "AIConfig"
       }
     ],
     "customEditors": [

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -42,13 +42,13 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(setupCommand);
 
   context.subscriptions.push(
-    vscode.commands.registerCommand(COMMANDS.SHOW_WELCOME, async () => {
+    vscode.commands.registerCommand(COMMANDS.SHOW_WELCOME, () => {
       const welcomeFilePath = path.join(
         context.extensionPath,
         "src",
         "welcomePage.md"
       );
-      await vscode.commands.executeCommand(
+      vscode.commands.executeCommand(
         "markdown.showPreview",
         vscode.Uri.file(welcomeFilePath)
       );


### PR DESCRIPTION
[vscode] Add category to commands instead of hardcoding "AIConfig" in title

Just cleaner, noticed it when reading through the docs

Also I removed the async logic from the showWelcome page because that was originally to open webview but now with Markdown it's just simple synchronous function

## Test Plan
<img width="877" alt="Screenshot 2024-02-20 at 17 30 32" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/8dd7b050-6a6b-4979-be6b-260a4f578692">

I also tried changing the command to sanity check that chagnes were indeed made, and not just cached from previous values or something
<img width="883" alt="Screenshot 2024-02-20 at 17 31 07" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/5dbba5eb-f351-4807-aa16-8ee425559211">
