### PR TITLE
Activate extension after VSCode startup

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -15,6 +15,9 @@
     "Other"
   ],
   "main": "./out/extension.js",
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "contributes": {
     "commands": [
       {


### PR DESCRIPTION
Activate extension after VSCode startup

This will trigger the python dependencies to be installed, saving time for when we first open an AIConfig file. This will call the `activate()` method in the `extension.ts` file, which contains this line:

```
  // Run the setup command on activation
  vscode.commands.executeCommand(COMMANDS.INIT);
```

## Test Plan
No functional changes, but activation now gets triggered right away instead of opening an AIConfig file. This still takes a bit of time to startup because we need to run the flask server, but if I didn't have dependencies installed, it would be huge time savings!

Before

https://github.com/lastmile-ai/aiconfig/assets/151060367/c164d180-c7ce-4062-bbe9-5452449e0ffe

After

https://github.com/lastmile-ai/aiconfig/assets/151060367/fb45a79a-7593-4745-bfa2-41fa0856470c

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1274).
* __->__ #1274
* #1273