### PR TITLE
[editor][rfc] Skip Updating Webview if there are No Content Changes

### DIFF
--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -193,13 +193,12 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
             return;
           }
 
-          // TODO: Should we skip events with no content changes?
-          // if (e.contentChanges.length === 0) {
-          //   console.log(
-          //     `changeDocumentSubscription ${e.document.uri} - skipping event because there are no content changes`
-          //   );
-          //   return;
-          // }
+          if (e.contentChanges.length === 0) {
+            console.log(
+              `changeDocumentSubscription ${e.document.uri} - skipping event because there are no content changes`
+            );
+            return;
+          }
 
           // TODO: saqadri - instead of sending the entire document to the webview,
           // can ask it to reload the document from the server


### PR DESCRIPTION
# [editor][rfc] Skip Updating Webview if there are No Content Changes

Apparently, `changeDocumentSubscription` event is also fired even when no `contentChanges` exist. When trying to update aiconfig-editor package to support updating aiconfig state via param (from https://github.com/lastmile-ai/aiconfig/pull/1261), this fact causes a bug where the current input is remounted as I'm typing due to the `changeDocumentSubscription` event being called with no changes. We can fix this by preventing this scenario from updating the webview with duplicate content (which would be serialized as a new, but identical, aiconfig object being passed to the AIConfigEditor component).

This is just 1 of 3 possible ways to resolve this issue. The others are:
2. continue updating webview in this case, but do a deep equality check on the client and no-op instead of setting the aiconfig in state there
3. continue update the webview and also update aiconfig in state, but update handling of aiconfig prop in the editor component to do deep equality checks

I picked this since it's the easiest and most performant. I could be easily persuaded to do 2 if it's possible the aiconfig in state could differ from the *existing* document in the extension host (in which case, we would want to update the client even if document content matches existing content).

Not a fan of 3 since it's a larger perf hit and kind of goes against the intentions of memoized component props.

To give an idea of the issue, this is what happens when I update our extension editor to use aiconfig-editor-test package published with the changes from #1261:


https://github.com/lastmile-ai/aiconfig/assets/5060851/53e1ff11-e686-41cc-9604-102449ca8f1e



And, with this PR's changes, the issue is fixed:

https://github.com/lastmile-ai/aiconfig/assets/5060851/80419b4d-ad2b-441e-8d5e-44da97551a94


