### PR TITLE
[editor] Bump aiconfig-editor Version to 0.2.0

### DIFF
--- a/vscode-extension/editor/package.json
+++ b/vscode-extension/editor/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^5.7.0",
     "@emotion/react": "^11.11.1",
-    "@lastmileai/aiconfig-editor": "^0.1.21",
+    "@lastmileai/aiconfig-editor": "^0.2.0",
     "@mantine/carousel": "^6.0.7",
     "@mantine/core": "^6.0.7",
     "@mantine/dates": "^6.0.16",

--- a/vscode-extension/editor/yarn.lock
+++ b/vscode-extension/editor/yarn.lock
@@ -1780,10 +1780,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lastmileai/aiconfig-editor@^0.1.21":
-  version "0.1.21"
-  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.1.21.tgz#1110f36a7a43270f7315833643034bcdcbd998a5"
-  integrity sha512-SaY/nwnSYV/AzBvFeERBIMeuptlh28+koXiiaY8ssvK1XTeNNTmUS3sjlQaGeAJtfGpompXyDxAUMcIkv5I41A==
+"@lastmileai/aiconfig-editor@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.0.tgz#8ed65c160d0f7e4460f655962b95479b5369d04e"
+  integrity sha512-iLrfgvLTWLqVUuL+hsK+9p3EZR2AmQdcIBp5DnnkrFGFzvUUXrYdS4Rq/pY+xTK3EDinYEl5+EBnqv+j4tNUsQ==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@mantine/carousel" "^6.0.7"


### PR DESCRIPTION
# [editor] Bump aiconfig-editor Version to 0.2.0

Bump the version to now have the changes from #1261. Ensure the editor works. Also, undo/redo now works:

https://github.com/lastmile-ai/aiconfig/assets/5060851/6abb5f4c-072e-491b-84ba-769ebbcd2e42


