### PR TITLE
[editor][ez] Fix Resaturation of Editor with Bad Server State

### DIFF
--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -46,9 +46,10 @@ export default function VSCodeEditor() {
 
   // TODO: saqadri - does this need to be wrapped in a memo?
   const webviewState = getWebviewState(vscode);
-  console.log(`webviewState = ${JSON.stringify(webviewState)}`);
 
-  const [aiconfig, setAIConfig] = useState<AIConfig | undefined>();
+  const [aiconfig, setAIConfig] = useState<AIConfig | undefined>(
+    webviewState?.aiconfigState
+  );
   const [aiConfigServerUrl, setAIConfigServerUrl] = useState<string>(
     webviewState?.serverUrl ?? ""
   );
@@ -65,23 +66,25 @@ export default function VSCodeEditor() {
 
   const { classes } = useStyles();
 
-  const updateContent = useCallback(async (text: string) => {
-    // TODO: saqadri - this won't work for YAML -- the handling of the text needs to include the logic from AIConfig.load
+  const updateContent = useCallback(
+    async (text: string) => {
+      if (text != null) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let updatedConfig: any = {};
+        try {
+          // Try parsing the string as JSON first
+          updatedConfig = JSON.parse(text);
+        } catch (e) {
+          // If that fails, try parsing the string as YAML
+          updatedConfig = yaml.load(text);
+        }
 
-    if (text != null) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let updatedConfig: any = {};
-      try {
-        // Try parsing the string as JSON first
-        updatedConfig = JSON.parse(text);
-      } catch (e) {
-        // If that fails, try parsing the string as YAML
-        updatedConfig = yaml.load(text);
+        setAIConfig(updatedConfig);
+        updateWebviewState(vscode, { aiconfigState: updatedConfig });
       }
-
-      setAIConfig(updatedConfig);
-    }
-  }, []);
+    },
+    [vscode]
+  );
 
   // Register an event listener to handle messages from the extension host
   // This is how we'll receive updates to the webview's content
@@ -136,11 +139,13 @@ export default function VSCodeEditor() {
   const loadConfig = useCallback(async () => {
     const route = ROUTE_TABLE.LOAD(aiConfigServerUrl);
     const res = await ufetch.post(route, {});
-    // console.log(`IN LOAD: route=${route}, res=${JSON.stringify(res)}`);
     setAIConfig(res.aiconfig);
     // If we can load the config from the server, we assume it's in a good state
     setIsReadOnly(false);
-    updateWebviewState(vscode, { isReadOnly: false });
+    updateWebviewState(vscode, {
+      aiconfigState: res.aiconfig,
+      isReadOnly: false,
+    });
   }, [aiConfigServerUrl, vscode]);
 
   useEffect(() => {

--- a/vscode-extension/editor/src/utils/vscodeUtils.ts
+++ b/vscode-extension/editor/src/utils/vscodeUtils.ts
@@ -1,6 +1,5 @@
 import { WebviewApi } from "vscode-webview";
-import { ClientAIConfig } from "@lastmileai/aiconfig-editor/dist/shared/types";
-import { JSONValue } from "aiconfig";
+import type { AIConfig, JSONValue } from "aiconfig";
 
 /**
  * State that gets serialized and restored when the webview is recreated.
@@ -10,7 +9,7 @@ import { JSONValue } from "aiconfig";
  * For more information, see https://code.visualstudio.com/api/extension-guides/webview#getstate-and-setstate
  */
 export type WebviewState = {
-  aiconfigState?: ClientAIConfig;
+  aiconfigState?: AIConfig;
   isReadOnly?: boolean;
   serverUrl?: string;
   theme?: "light" | "dark";


### PR DESCRIPTION
[editor][ez] Fix Resaturation of Editor with Bad Server State

# [editor][ez] Fix Resaturation of Editor with Bad Server State

Currently, when re-saturating the webview for an editor with bad server state (e.g. invalid model parsers in the config), the /load call will fail and leave the webview with the loading spinner:


https://github.com/lastmile-ai/aiconfig/assets/5060851/3949274d-fbb1-479f-a54a-9ac8870e617c


To fix, we can serialize the config in webview context and then use it to re-saturate the aiconfig state in the webview:

https://github.com/lastmile-ai/aiconfig/assets/5060851/5d67dc31-7b68-4782-af73-a8b6294a5452


For a webview with working state, note that /load is called successfully after the webview loads and will update the aiconfig state in the editor as needed (now that aiconfig prop updates the editor state)
