### PR TITLE
[vscode installation] 5/n show view only when dependencies are not installed

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -181,6 +181,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@vscode/python-extension": "^1.0.5",
     "oboe": "^2.1.5",
     "portfinder": "^1.0.32",
     "ufetch": "^1.6.0"

--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -386,9 +386,6 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
       });
     }
 
-    // Wait for server ready
-    await waitUntilServerReady(editorServer.url);
-
     // Now set up the server with the latest document content
     await this.startServerWithRetry(editorServer.url, document, webviewPanel);
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -23,6 +23,7 @@ import {
 } from "./util";
 import { AIConfigEditorProvider } from "./aiConfigEditor";
 import { AIConfigEditorManager } from "./aiConfigEditorManager";
+import { PythonExtension } from "@vscode/python-extension";
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -39,7 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const setupCommand = vscode.commands.registerCommand(COMMANDS.INIT, () => {
-    installDependencies(context, extensionOutputChannel);
+    initialize(context, extensionOutputChannel);
   });
   context.subscriptions.push(setupCommand);
 
@@ -905,4 +906,19 @@ async function shareAIConfig(
         }
       });
   }
+}
+
+/**
+ * Selects a Python interpreter and initiates the dependency installation flow.
+ */
+async function initialize(
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.LogOutputChannel
+) {
+  // Make sure Python API is activated
+  const pythonApi: PythonExtension = await PythonExtension.api();
+
+  await vscode.commands.executeCommand("python.setInterpreter");
+
+  installDependencies(context, outputChannel);
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -571,16 +571,18 @@ async function installRequirements(
         vscode.window
           .showErrorMessage(
             `Failed to install dependencies. Pip exited with code ${code}. Please try again later`,
-            ...["Retry"]
+            ...["Select Interpreter", "Retry Install Dependencies"]
           )
           .then((selection) => {
-            if (selection === "Retry") {
+            if (selection === "Retry Install Dependencies") {
               installRequirements(
                 context,
                 progress,
                 cancellationToken,
                 outputChannel
               );
+            } else if (selection === "Select Interpreter") {
+              vscode.commands.executeCommand(COMMANDS.INIT);
             }
           });
         resolve(false);

--- a/vscode-extension/yarn.lock
+++ b/vscode-extension/yarn.lock
@@ -238,6 +238,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+"@vscode/python-extension@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@vscode/python-extension/-/python-extension-1.0.5.tgz#881878006ad3f4b70e81b20d21a91f56dd577481"
+  integrity sha512-uYhXUrL/gn92mfqhjAwH2+yGOpjloBxj9ekoL4BhUsKcyJMpEg6WlNf3S3si+5x9zlbHHe7FYQNjZEbz1ymI9Q==
+
 "@vscode/test-cli@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@vscode/test-cli/-/test-cli-0.0.4.tgz#eeeb5620ff8b9eb31ae3e5b01af322ca68fcfaae"


### PR DESCRIPTION
[vscode installation] 5/n show view only when dependencies are not installed

This diff removes blocking on server being ready. Now a user can view the aiconfig in readonly mode if their dependencies are not installed. Consequently so, any errors on dependency installation will be shown

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1289).
* __->__ #1289
* #1294
* #1290