### PR TITLE
3/n Update Initialize to invoke select interpreter

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -181,6 +181,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@vscode/python-extension": "^1.0.5",
     "oboe": "^2.1.5",
     "portfinder": "^1.0.32",
     "ufetch": "^1.6.0"

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -23,6 +23,7 @@ import {
 } from "./util";
 import { AIConfigEditorProvider } from "./aiConfigEditor";
 import { AIConfigEditorManager } from "./aiConfigEditorManager";
+import { PythonExtension } from "@vscode/python-extension";
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -39,7 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const setupCommand = vscode.commands.registerCommand(COMMANDS.INIT, () => {
-    installDependencies(context, extensionOutputChannel);
+    initialize(context, extensionOutputChannel);
   });
   context.subscriptions.push(setupCommand);
 
@@ -905,4 +906,19 @@ async function shareAIConfig(
         }
       });
   }
+}
+
+/**
+ * Selects a Python interpreter and initiates the dependency installation flow.
+ */
+async function initialize(
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.LogOutputChannel
+) {
+  // Make sure Python API is activated
+  const pythonApi: PythonExtension = await PythonExtension.api();
+
+  await vscode.commands.executeCommand("python.setInterpreter");
+
+  installDependencies(context, outputChannel);
 }

--- a/vscode-extension/yarn.lock
+++ b/vscode-extension/yarn.lock
@@ -238,6 +238,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+"@vscode/python-extension@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@vscode/python-extension/-/python-extension-1.0.5.tgz#881878006ad3f4b70e81b20d21a91f56dd577481"
+  integrity sha512-uYhXUrL/gn92mfqhjAwH2+yGOpjloBxj9ekoL4BhUsKcyJMpEg6WlNf3S3si+5x9zlbHHe7FYQNjZEbz1ymI9Q==
+
 "@vscode/test-cli@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@vscode/test-cli/-/test-cli-0.0.4.tgz#eeeb5620ff8b9eb31ae3e5b01af322ca68fcfaae"


### PR DESCRIPTION
3/n Update Initialize to invoke select interpreter

This diff updates the initialize flow to include the Python interpreter selection step. It ensures dependencies are installed only after the interpreter selection is finalized, accommodating the no-op change where the selected interpreter remains unchanged.

Note: If the extension is not activated, invoking the Initialize AIConfig command for an unknown reason installs dependencies on the pre-selected interpreter path


## testplan

Extension initializes on Opening An AIConfig

Test select a new interpreter

Test reselecting the same interpreter

https://github.com/lastmile-ai/aiconfig/assets/141073967/1a51ff89-3889-4fd6-8964-c341453ddf68

## Dependencies
https://github.com/lastmile-ai/aiconfig/pull/1265

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1290).
* #1289
* #1294
* __->__ #1290