### PR TITLE
[vscode] Fix Outputs Propagating to Text Document

### DIFF
--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -283,18 +283,28 @@ export default function VSCodeEditor() {
         {
           output_chunk: (data) => {
             onStream({ type: "output_chunk", data: data as Output });
+            // Don't notify dirty since output chunks are very frequent
           },
           aiconfig_chunk: (data) => {
             onStream({ type: "aiconfig_chunk", data: data as AIConfig });
+            if (vscode) {
+              notifyDocumentDirty(vscode);
+            }
           },
           stop_streaming: (_data) => {
             onStream({ type: "stop_streaming", data: null });
+            if (vscode) {
+              notifyDocumentDirty(vscode);
+            }
           },
           error: (data) => {
             onError({
               type: "error",
               data: data as RunPromptStreamErrorEvent["data"],
             });
+            if (vscode) {
+              notifyDocumentDirty(vscode);
+            }
           },
         }
       );


### PR DESCRIPTION
# [vscode] Fix Outputs Propagating to Text Document

Currently, the webview only notifies the extension of dirty document (on the server) before/after the run request to the server. For long-running/streaming prompts, the request's response is actually returned well before the streaming responses are completed, meaning the document is not actually notified when the stream completes with the new output.

To fix, we can call `notifyDocumentDirty` to [update the text document in the extension with the server state](https://github.com/lastmile-ai/aiconfig/blob/main/vscode-extension/src/aiConfigEditor.ts#L282) whenever any of the stream responses are obtained (excluding `output_chunk` since that happens very frequently and would lead to the extension host loading the file from the server too frequently)

## Testing:
Running a prompt now shows the output in the text document:

https://github.com/lastmile-ai/aiconfig/assets/5060851/1211cc1e-676f-4415-8d01-4b176296f4b5


