### PR TITLE
[ez][vscode] Remove Initialization Flow from Extension Activation

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -123,8 +123,6 @@ export function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(openModelParserCommand);
 
-  // Run the setup command on activation
-  vscode.commands.executeCommand(COMMANDS.INIT);
 
   // Register our custom editor providers
   const aiconfigEditorManager: AIConfigEditorManager =


### PR DESCRIPTION
[ez][vscode] Remove Initialization Flow from Extension Activation

This diff removes the Initialization flow from ocurring on Extension Activation.

The landing page directs the user to invoke this command.

The Opening an AIConfig may invoke this if dependencies are not installed (not implemented yet)

Invoking the Initialize Command will no longer automatically install dependencies on the pre-selection python interpreter.

## Testplan

https://github.com/lastmile-ai/aiconfig/assets/141073967/04031cdc-2c9d-47e8-b43d-a9d2f6aa769d
