### PR TITLE
Cache Python interpreter to VS Code settings

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -94,6 +94,11 @@
           "type": "string",
           "default": "",
           "description": "Path to the custom model registry file."
+        },
+        "vscode-aiconfig.pythonInterpreter": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the python interpreter for this VS Code workspace"
         }
       }
     },

--- a/vscode-extension/src/constants.ts
+++ b/vscode-extension/src/constants.ts
@@ -1,0 +1,1 @@
+export const PYTHON_INTERPRETER_CACHE_KEY_NAME = "pythonInterpreter";

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -21,6 +21,7 @@ import {
   isPythonVersionAtLeast310,
   showGuideForPythonInstallation,
   setupEnvironmentVariables,
+  savePythonInterpreterToCache,
 } from "./util";
 import { AIConfigEditorProvider } from "./aiConfigEditor";
 import { AIConfigEditorManager } from "./aiConfigEditorManager";
@@ -123,7 +124,6 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
   context.subscriptions.push(openModelParserCommand);
-
 
   // Register our custom editor providers
   const aiconfigEditorManager: AIConfigEditorManager =
@@ -451,6 +451,7 @@ async function installDependencies(
         outputChannel.appendLine("Python is not installed");
         return;
       }
+      await savePythonInterpreterToCache();
 
       outputChannel.append(" -- SUCCESS");
       outputChannel.appendLine("2. Making sure pip is installed");

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -7,6 +7,7 @@ import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import { PYTHON_INTERPRETER_CACHE_KEY_NAME } from "./constants";
 
 export const EXTENSION_NAME = "vscode-aiconfig";
 export const COMMANDS = {
@@ -300,6 +301,20 @@ export async function getPythonPath(): Promise<string> {
   const pythonPath =
     pythonExtension.exports.settings.getExecutionDetails().execCommand[0];
   return pythonPath;
+}
+
+/**
+ * Save the python interpreter path to the VS Code extension workspace settings
+ * @returns void
+ */
+export async function savePythonInterpreterToCache(): Promise<void> {
+  const pythonPath = await getPythonPath();
+  const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
+  await config.update(
+    PYTHON_INTERPRETER_CACHE_KEY_NAME,
+    pythonPath,
+    vscode.ConfigurationTarget.Workspace
+  );
 }
 
 /**


### PR DESCRIPTION
Cache Python interpreter to VS Code settings

Do this after we run the `checkPython()` flow

It's just a simple write. We'll be using it later in two flows:

1. On open/create AIConfig file init to determine if interpter path is set (see Ankush PR in here for more details: https://github.com/lastmile-ai/aiconfig/pull/1301)
2. When updating interpter to loop over existing open AIConfig editor windows

Got this code to update from https://github.com/lastmile-ai/aiconfig/blob/826565f7079bc30e228a1477541ccbf17702d4f6/vscode-extension/src/extension.ts#L398-L402

## Test Plan
When AIConfig Editor is activated, check that it's saved to VS Code settings

https://github.com/lastmile-ai/aiconfig/assets/151060367/b7977c08-5a5a-4ca9-bff8-3bce7914e52e
