### PR TITLE
[rfc] Show readonly Editor Before Server Is Started

### DIFF
--- a/vscode-extension/editor/package.json
+++ b/vscode-extension/editor/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^5.7.0",
     "@emotion/react": "^11.11.1",
-    "@lastmileai/aiconfig-editor": "^0.2.0",
+    "@lastmileai/aiconfig-editor": "^0.2.1",
     "@mantine/carousel": "^6.0.7",
     "@mantine/core": "^6.0.7",
     "@mantine/dates": "^6.0.16",

--- a/vscode-extension/editor/yarn.lock
+++ b/vscode-extension/editor/yarn.lock
@@ -1780,10 +1780,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lastmileai/aiconfig-editor@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.0.tgz#8ed65c160d0f7e4460f655962b95479b5369d04e"
-  integrity sha512-iLrfgvLTWLqVUuL+hsK+9p3EZR2AmQdcIBp5DnnkrFGFzvUUXrYdS4Rq/pY+xTK3EDinYEl5+EBnqv+j4tNUsQ==
+"@lastmileai/aiconfig-editor@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.1.tgz#a46ca7088d8dd408fbc1ba75df991eddd89edc9a"
+  integrity sha512-74iVx38Fy9Eb2u760DLxa7ztB7mUhA3TeQGqjWV0sACDPYsVVup+J83V+flz8eP2otuxA53z/zr2U6CFEBCOWw==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@mantine/carousel" "^6.0.7"

--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -62,24 +62,13 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
     _token: vscode.CancellationToken
   ): Promise<void> {
     let editorServer: ServerInfo | null = null;
+    let isWebviewDisposed = false;
 
     // TODO: saqadri - clean up console log
     //console.log(`${document.fileName}: resolveCustomTextEditor called`);
 
     // We show the extension output channel so users can see some of the server logs as they use the extension
     this.extensionOutputChannel.show(/*preserveFocus*/ true);
-
-    // Start the AIConfig editor server process.
-    editorServer = await this.startEditorServer(document);
-
-    this.aiconfigEditorManager.addEditor(
-      new AIConfigEditorState(
-        document,
-        webviewPanel,
-        editorServer,
-        this.aiconfigEditorManager
-      )
-    );
 
     // Setup initial content for the webview
     webviewPanel.webview.options = {
@@ -93,10 +82,7 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
         vscode.Uri.joinPath(this.context.extensionUri, "editor", "static"),
       ],
     };
-    webviewPanel.webview.html = this.getHtmlForWebview(
-      webviewPanel.webview,
-      editorServer
-    );
+    webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
 
     function updateWebview() {
       if (isWebviewDisposed) {
@@ -110,6 +96,38 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
       });
     }
 
+    // Update webview immediately so we unblock the render; server init will happen in the background.
+    updateWebview();
+
+    // Start the AIConfig editor server process. Don't await at the top level here since that blocks the
+    // webview render (which happens only when resolveCustomTextEditor returns)
+    this.startEditorServer(document).then(async (editorServer) => {
+      editorServer = editorServer;
+
+      this.aiconfigEditorManager.addEditor(
+        new AIConfigEditorState(
+          document,
+          webviewPanel,
+          editorServer,
+          this.aiconfigEditorManager
+        )
+      );
+
+      // Wait for server ready
+      await waitUntilServerReady(editorServer.url);
+
+      // Now set up the server with the latest document content
+      await this.startServerWithRetry(editorServer.url, document, webviewPanel);
+
+      // Inform the webview of the server URL
+      if (!isWebviewDisposed) {
+        webviewPanel.webview.postMessage({
+          type: "set_server_url",
+          url: editorServer.url,
+        });
+      }
+    });
+
     // Hook up event handlers so that we can synchronize the webview with the text document.
     //
     // The text document acts as our model, so we have to sync change in the document to our
@@ -122,8 +140,6 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
     // This is because we need to ignore these changes to avoid an infinite loop in onDidChangeTextDocument
     // For more details, see https://code.visualstudio.com/api/extension-guides/custom-editors#synchronizing-changes-with-the-textdocument
     let isInternalDocumentChange = false;
-
-    let isWebviewDisposed = false;
 
     function updateServerWithRetry(
       serverUrl: string,
@@ -380,9 +396,6 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
       }
     });
 
-    // Update webview immediately so we unblock the render; server init should happen in the background.
-    updateWebview();
-
     // Set initial dark/light theme mode for the webview and on theme changes. Also, on tab activation.
     if (!isWebviewDisposed) {
       updateWebviewEditorThemeMode(webviewPanel.webview);
@@ -399,20 +412,6 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
             updateWebviewEditorThemeMode(webviewPanel.webview);
           }
         }
-      });
-    }
-
-    // Wait for server ready
-    await waitUntilServerReady(editorServer.url);
-
-    // Now set up the server with the latest document content
-    await this.startServerWithRetry(editorServer.url, document, webviewPanel);
-
-    // Inform the webview of the server URL
-    if (!isWebviewDisposed) {
-      webviewPanel.webview.postMessage({
-        type: "set_server_url",
-        url: editorServer.url,
       });
     }
   }
@@ -554,10 +553,7 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
   /**
    * Get the static html used for the editor webviews.
    */
-  private getHtmlForWebview(
-    webview: vscode.Webview,
-    editorServer: ServerInfo
-  ): string {
+  private getHtmlForWebview(webview: vscode.Webview): string {
     // The JS file from the React build output
     const scriptUri = getUri(
       webview,
@@ -579,7 +575,7 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
 	   <head>
 		 <meta charset="utf-8">
 		 <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
-		 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data: http: https: 'self'; media-src data: http: https: 'self'; connect-src vscode-webview: ${editorServer.url} http: https:; style-src 'unsafe-inline' ${webview.cspSource} https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0 https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/editor/editor.main.css; script-src 'nonce-${nonce}' vscode-resource: https: http: https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0 https://cdn.jsdelivr.net; font-src https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/base/browser/ui/codicons/codicon/codicon.ttf; worker-src blob:;">
+		 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data: http: https: 'self'; media-src data: http: https: 'self'; connect-src vscode-webview: http://localhost:* http: https:; style-src 'unsafe-inline' ${webview.cspSource} https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0 https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/editor/editor.main.css; script-src 'nonce-${nonce}' vscode-resource: https: http: https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0 https://cdn.jsdelivr.net; font-src https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/base/browser/ui/codicons/codicon/codicon.ttf; worker-src blob:;">
 		 </head>
 	   <body>
 		 <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
[rfc] Show readonly Editor Before Server Is Started

# [rfc] Show readonly Editor Before Server Is Started

Currently when opening an aiconfig file, the file contents / editor webview are not rendered at all until the server is started (or attempted to start). This is because the webview isn't rendered until `resolveCustomTextEditor` returns, and we are awaiting a few server-initialization-related calls within the function.

To fix, we can move the `startEditorServer` into a regular `.then`, which will call the Promise without blocking. Within the `.then` we can handle the resolved promise as normal and do the other things that depend on the server process running.

Another thing worth mentioning is that we previously required the server url to set up the csp for the webview HTML. I'm not sure if we actually need to set the `connect-src vscode-webview` at all (didn't seem to make a difference when testing) but for now, just setting to accept any localhost port instead of being dependent on server.

We can immediately set the webview content and see it rendered (in readonly mode by default):

https://github.com/lastmile-ai/aiconfig/assets/5060851/2bf8cd4a-2b4d-4aea-ad1e-8f15f245ba65


NOTE: This currently results in a notification, 'Error loading models' since the (readonly) editor is attempting to load the models before the server is set up. There is a simple fix needed in the editor to address that, so I'll do that and update the package for use in the vscode extension before landing this

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1306).
* __->__ #1306
* #1309