### PR TITLE
Check interpreter (initalize if needed) and call install dependency flow before starting editor server

### DIFF
--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -10,7 +10,10 @@ import {
   updateWebviewEditorThemeMode,
   waitUntilServerReady,
 } from "./util";
-import { getPythonPath } from "./utilities/pythonSetupUtils";
+import {
+  getPythonPath,
+  initializePythonFlow,
+} from "./utilities/pythonSetupUtils";
 import { getNonce } from "./utilities/getNonce";
 import { getUri } from "./utilities/getUri";
 
@@ -98,6 +101,9 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
 
     // Update webview immediately so we unblock the render; server init will happen in the background.
     updateWebview();
+
+    // Do not start the server until we ensure the Python setup is ready
+    await initializePythonFlow(this.context, this.extensionOutputChannel);
 
     // Start the AIConfig editor server process. Don't await at the top level here since that blocks the
     // webview render (which happens only when resolveCustomTextEditor returns)


### PR DESCRIPTION
Check interpreter (initalize if needed) and call install dependency flow before starting editor server

Three main things we do here:

1. Check if interpreter is defined in workspace settings (set in https://github.com/lastmile-ai/aiconfig/pull/1304)
2. Call either `initialize()` or `installDependencies()` depending on that result
3. Implement the `initializePythonFlow()` inside of `resolveCustomTextEditor()`

## Test Plan

Before (does not invoke flow)

https://github.com/lastmile-ai/aiconfig/assets/151060367/8f1e308c-975d-4a79-8f9a-127c0322f065

After (does invoke flow)

https://github.com/lastmile-ai/aiconfig/assets/151060367/28f97461-3e7c-4340-af2c-fb4993562c24
