### PR TITLE
[vscode] Bump aiconfig-editor dependency to 0.2.1

### DIFF
--- a/vscode-extension/editor/package.json
+++ b/vscode-extension/editor/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^5.7.0",
     "@emotion/react": "^11.11.1",
-    "@lastmileai/aiconfig-editor": "^0.2.0",
+    "@lastmileai/aiconfig-editor": "^0.2.1",
     "@mantine/carousel": "^6.0.7",
     "@mantine/core": "^6.0.7",
     "@mantine/dates": "^6.0.16",

--- a/vscode-extension/editor/yarn.lock
+++ b/vscode-extension/editor/yarn.lock
@@ -1780,10 +1780,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lastmileai/aiconfig-editor@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.0.tgz#8ed65c160d0f7e4460f655962b95479b5369d04e"
-  integrity sha512-iLrfgvLTWLqVUuL+hsK+9p3EZR2AmQdcIBp5DnnkrFGFzvUUXrYdS4Rq/pY+xTK3EDinYEl5+EBnqv+j4tNUsQ==
+"@lastmileai/aiconfig-editor@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.1.tgz#a46ca7088d8dd408fbc1ba75df991eddd89edc9a"
+  integrity sha512-74iVx38Fy9Eb2u760DLxa7ztB7mUhA3TeQGqjWV0sACDPYsVVup+J83V+flz8eP2otuxA53z/zr2U6CFEBCOWw==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@mantine/carousel" "^6.0.7"


### PR DESCRIPTION
[vscode] Bump aiconfig-editor dependency to 0.2.1

- Fix for not calling getModels callback in readOnly

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1309).
* #1306
* __->__ #1309