### PR TITLE
Fix some strict null-checks in error text

### DIFF
--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -367,7 +367,7 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
           // TODO: Create a constant value somewhere in lastmile-utils to
           // centralize string error message for missing API key. This
           // logic is defined in https://github.com/lastmile-ai/aiconfig/blob/33fb852854d0bd64b8ddb4e52320112782008b99/python/src/aiconfig/util/config_utils.py#L41
-          if (message.includes("Missing API key")) {
+          if (message?.includes("Missing API key")) {
             // TODO: Once VS Code supports Markdown in diagnostic links, add
             // support to link to our docs: https://github.com/lastmile-ai/aiconfig/pull/1300/files#r1499920802
             notificationAction = await notificationFn(
@@ -375,11 +375,12 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
               "Set API Keys"
             );
           } else {
+            const buttonOptions = message ? ["Details"] : [];
             // Notification supports 'details' for modal only. For now, just show title
             // in notification toast and full message in output channel.
             notificationAction = await notificationFn(
               notification.title,
-              message ? "Details" : undefined
+              ...buttonOptions
             );
           }
 


### PR DESCRIPTION
Fix some strict null-checks in error text

Some minor nits, just noticed this when running
```
 yarn && yarn compile --strict
```

## Test Plan

Before

<img width="848" alt="Screenshot 2024-02-22 at 21 55 26" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/1d257d08-bb5f-4b95-975e-377e8871e3b5">
<img width="325" alt="Screenshot 2024-02-22 at 21 55 37" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/81d01d22-187c-4e92-a9fc-2e3362343cfb">

After

<img width="324" alt="Screenshot 2024-02-22 at 21 55 43" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/5b8f1229-4c3e-43e6-bb9e-4d2c74193d67">
