### PR TITLE
[vscode] Fix Setting editorServer

### DIFF
--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -107,29 +107,33 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
 
     // Start the AIConfig editor server process. Don't await at the top level here since that blocks the
     // webview render (which happens only when resolveCustomTextEditor returns)
-    this.startEditorServer(document).then(async (editorServer) => {
-      editorServer = editorServer;
+    this.startEditorServer(document).then(async (startedServer) => {
+      editorServer = startedServer;
 
       this.aiconfigEditorManager.addEditor(
         new AIConfigEditorState(
           document,
           webviewPanel,
-          editorServer,
+          startedServer,
           this.aiconfigEditorManager
         )
       );
 
       // Wait for server ready
-      await waitUntilServerReady(editorServer.url);
+      await waitUntilServerReady(startedServer.url);
 
       // Now set up the server with the latest document content
-      await this.startServerWithRetry(editorServer.url, document, webviewPanel);
+      await this.startServerWithRetry(
+        startedServer.url,
+        document,
+        webviewPanel
+      );
 
       // Inform the webview of the server URL
       if (!isWebviewDisposed) {
         webviewPanel.webview.postMessage({
           type: "set_server_url",
-          url: editorServer.url,
+          url: startedServer.url,
         });
       }
     });


### PR DESCRIPTION
# [vscode] Fix Setting editorServer

Realized when looking into restarting the server that the `editorServer` global var was not being set properly (was null on dispose). The problem was using the same name for the resolved started server. This fixes by using a different name

## Testing:
- Ensure the editorServer value is right when disposing the webview
- Close webview and open again and ensure new server at port 8000
- Make changes to JSON for a config and toggle back to the editor webview and see the changes reflected there
