### PR TITLE
[vscode] Don't block on Python Initialization

### DIFF
--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -103,40 +103,42 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
     updateWebview();
 
     // Do not start the server until we ensure the Python setup is ready
-    await initializePythonFlow(this.context, this.extensionOutputChannel);
+    initializePythonFlow(this.context, this.extensionOutputChannel).then(
+      async () => {
+        // Start the AIConfig editor server process. Don't await at the top level here since that blocks the
+        // webview render (which happens only when resolveCustomTextEditor returns)
+        this.startEditorServer(document).then(async (startedServer) => {
+          editorServer = startedServer;
 
-    // Start the AIConfig editor server process. Don't await at the top level here since that blocks the
-    // webview render (which happens only when resolveCustomTextEditor returns)
-    this.startEditorServer(document).then(async (startedServer) => {
-      editorServer = startedServer;
+          this.aiconfigEditorManager.addEditor(
+            new AIConfigEditorState(
+              document,
+              webviewPanel,
+              startedServer,
+              this.aiconfigEditorManager
+            )
+          );
 
-      this.aiconfigEditorManager.addEditor(
-        new AIConfigEditorState(
-          document,
-          webviewPanel,
-          startedServer,
-          this.aiconfigEditorManager
-        )
-      );
+          // Wait for server ready
+          await waitUntilServerReady(startedServer.url);
 
-      // Wait for server ready
-      await waitUntilServerReady(startedServer.url);
+          // Now set up the server with the latest document content
+          await this.startServerWithRetry(
+            startedServer.url,
+            document,
+            webviewPanel
+          );
 
-      // Now set up the server with the latest document content
-      await this.startServerWithRetry(
-        startedServer.url,
-        document,
-        webviewPanel
-      );
-
-      // Inform the webview of the server URL
-      if (!isWebviewDisposed) {
-        webviewPanel.webview.postMessage({
-          type: "set_server_url",
-          url: startedServer.url,
+          // Inform the webview of the server URL
+          if (!isWebviewDisposed) {
+            webviewPanel.webview.postMessage({
+              type: "set_server_url",
+              url: startedServer.url,
+            });
+          }
         });
       }
-    });
+    );
 
     // Hook up event handlers so that we can synchronize the webview with the text document.
     //


### PR DESCRIPTION
[vscode] Don't block on Python Initialization

This diff removes the await statement on the initialize python flow when resolving a custom editor, to ensure that it is not blocking. Now, only the aiconfig server is blocked on python initialization. The webview server is not blocked.


Previously this was blocking the webview and not letting the webview server start.



## Testplan

https://github.com/lastmile-ai/aiconfig/assets/141073967/ee180bb4-7fb7-40c6-a33e-b7dc3546ae70
