### PR TITLE
[1/n] Implement Editor Server as Class

### DIFF
--- a/vscode-extension/src/aiConfigEditorManager.ts
+++ b/vscode-extension/src/aiConfigEditorManager.ts
@@ -1,11 +1,11 @@
 import vscode from "vscode";
-import { ServerInfo } from "./util";
+import { EditorServer } from "./editorServer";
 
 export class AIConfigEditorState {
   constructor(
     public document: vscode.TextDocument,
     public readonly webviewPanel: vscode.WebviewPanel,
-    public editorServer: ServerInfo | null,
+    public editorServer: EditorServer | null,
     private readonly manager: AIConfigEditorManager
   ) {
     // Listen to when the panel's view state changes and update the active editor

--- a/vscode-extension/src/editorServer.ts
+++ b/vscode-extension/src/editorServer.ts
@@ -1,0 +1,77 @@
+import * as vscode from "vscode";
+import { getPortPromise } from "portfinder";
+import { EXTENSION_NAME } from "./util";
+import { getPythonPath } from "./utilities/pythonSetupUtils";
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+
+/**
+ * Provider for AIConfig editors.
+ *
+ * AIConfig editors are used for `.aiconfig`, `.aiconfig.json` and `.aiconfig.yaml` files.
+ * These files are backed by a JSON schema under the hood.
+ */
+export class EditorServer {
+  private cwd: string;
+
+  public pid: number | null = null;
+  public port: number | null = null;
+  // TODO: Should make this private and expose subscriptions to .stderr, .stdout, and .on
+  public serverProc: ChildProcessWithoutNullStreams | null = null;
+  public url: string | null = null;
+
+  constructor(workingDirectory: string) {
+    this.cwd = workingDirectory;
+  }
+
+  public async start(): Promise<EditorServer> {
+    if (this.serverProc) {
+      console.log(
+        `Server process ${this.pid} already started, port ${this.port}`
+      );
+      return this;
+    }
+
+    // If there is a custom model registry path, pass it to the server
+    const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
+    const modelRegistryPath = config.get<string>("modelRegistryPath");
+    const modelRegistryPathArgs = modelRegistryPath
+      ? ["--parsers-module-path", modelRegistryPath]
+      : [];
+
+    this.port = await getPortPromise();
+
+    const pythonPath = await getPythonPath();
+
+    // TODO: saqadri - specify parsers_module_path
+    // `aiconfig` command not useable here because it relies on python. Instead invoke the module directly.
+    const startServer = spawn(
+      pythonPath,
+      [
+        "-m",
+        "aiconfig.scripts.aiconfig_cli",
+        "start",
+        "--server-port",
+        this.port.toString(),
+        ...modelRegistryPathArgs,
+      ],
+      {
+        cwd: this.cwd,
+      }
+    );
+
+    this.pid = startServer.pid;
+    this.serverProc = startServer;
+    this.url = `http://localhost:${this.port}`;
+
+    return this;
+  }
+
+  public stop() {
+    console.log(`Killing editor server process ${this.pid}`);
+    this.serverProc.kill();
+    this.serverProc = null;
+    this.pid = null;
+    this.port = null;
+    this.url = null;
+  }
+}

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { type ChildProcessWithoutNullStreams, execSync } from "child_process";
 import { setTimeout } from "timers/promises";
 import { ufetch } from "ufetch";
 
@@ -43,11 +42,6 @@ export const EDITOR_SERVER_ROUTE_TABLE = {
     urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/load_content"),
   LOAD_MODEL_PARSER_MODULE: (hostUrl: string) =>
     urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/load_model_parser_module"),
-};
-
-export type ServerInfo = {
-  proc: ChildProcessWithoutNullStreams;
-  url: string;
 };
 
 export async function isServerReady(serverUrl: string) {


### PR DESCRIPTION
[1/n] Implement Editor Server as Class

# [1/n] Implement Editor Server as Class

Currently we maintain EditorServer state as an object for the extension, accessing the process and server url from the object. In subsequent PR, we will need to expose the ability to restart the editor server. Instead of creating and exposing a restart function on the object, let's just move the editor server into a class so that we have a proper instance with methods to leverage for starting, stopping and (next PR) restarting.

## Testing:
Open an aiconfig, ensure the server starts and I can run a prompt
Close the config, verify in logging that the server process is properly killed
Open config again. See server start up on 8000 (i.e. the port is open again after server was killed)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1318).
* #1328
* #1319
* __->__ #1318