### PR TITLE
[ez][vscode] Don't set getServerStatus Callback in VSCode

### DIFF
--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -432,9 +432,6 @@ export default function VSCodeEditor() {
     [aiConfigServerUrl, vscode]
   );
 
-  const getServerStatus = useCallback(async () => {
-    return await ufetch.get(ROUTE_TABLE.SERVER_STATUS(aiConfigServerUrl));
-  }, [aiConfigServerUrl]);
 
   const logEventHandler = useCallback(
     (event: LogEvent, data?: LogEventData) => {
@@ -464,7 +461,6 @@ export default function VSCodeEditor() {
       clearOutputs,
       deletePrompt,
       getModels,
-      getServerStatus,
       logEventHandler,
       openInTextEditor,
       runPrompt,
@@ -483,7 +479,6 @@ export default function VSCodeEditor() {
       clearOutputs,
       deletePrompt,
       getModels,
-      getServerStatus,
       logEventHandler,
       openInTextEditor,
       runPrompt,

--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -103,40 +103,42 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
     updateWebview();
 
     // Do not start the server until we ensure the Python setup is ready
-    await initializePythonFlow(this.context, this.extensionOutputChannel);
+    initializePythonFlow(this.context, this.extensionOutputChannel).then(
+      async () => {
+        // Start the AIConfig editor server process. Don't await at the top level here since that blocks the
+        // webview render (which happens only when resolveCustomTextEditor returns)
+        this.startEditorServer(document).then(async (startedServer) => {
+          editorServer = startedServer;
 
-    // Start the AIConfig editor server process. Don't await at the top level here since that blocks the
-    // webview render (which happens only when resolveCustomTextEditor returns)
-    this.startEditorServer(document).then(async (startedServer) => {
-      editorServer = startedServer;
+          this.aiconfigEditorManager.addEditor(
+            new AIConfigEditorState(
+              document,
+              webviewPanel,
+              startedServer,
+              this.aiconfigEditorManager
+            )
+          );
 
-      this.aiconfigEditorManager.addEditor(
-        new AIConfigEditorState(
-          document,
-          webviewPanel,
-          startedServer,
-          this.aiconfigEditorManager
-        )
-      );
+          // Wait for server ready
+          await waitUntilServerReady(startedServer.url);
 
-      // Wait for server ready
-      await waitUntilServerReady(startedServer.url);
+          // Now set up the server with the latest document content
+          await this.startServerWithRetry(
+            startedServer.url,
+            document,
+            webviewPanel
+          );
 
-      // Now set up the server with the latest document content
-      await this.startServerWithRetry(
-        startedServer.url,
-        document,
-        webviewPanel
-      );
-
-      // Inform the webview of the server URL
-      if (!isWebviewDisposed) {
-        webviewPanel.webview.postMessage({
-          type: "set_server_url",
-          url: startedServer.url,
+          // Inform the webview of the server URL
+          if (!isWebviewDisposed) {
+            webviewPanel.webview.postMessage({
+              type: "set_server_url",
+              url: startedServer.url,
+            });
+          }
         });
       }
-    });
+    );
 
     // Hook up event handlers so that we can synchronize the webview with the text document.
     //


### PR DESCRIPTION
[vscode] Don't set getServerStatus Callback in VSCode

This diff removes the `getServerStatus` callback from being passed into the `AIConfigEditor`  since we handle the servers within the vscode extension.

## Testplan

https://github.com/lastmile-ai/aiconfig/assets/141073967/85f8a303-a3c3-440e-a372-301cb57c9bd8

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1320).
* __->__ #1320
* #1315