### PR TITLE
Delete showWelcome command

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -61,11 +61,6 @@
         "command": "vscode-aiconfig.setupEnvironmentVariables",
         "title": "Setup Environment Variables",
         "category": "AIConfig"
-      },
-      {
-        "command": "vscode-aiconfig.showWelcome",
-        "title": "Welcome",
-        "category": "AIConfig"
       }
     ],
     "customEditors": [


### PR DESCRIPTION
Delete showWelcome command

This content was deleted in https://github.com/lastmile-ai/aiconfig/pull/1295/files#diff-637aab27a087b4c7cf87e366e6db33051834d74be94b7b5b478817207f9a6df1 so today this command doesn't open anything

## Test Plan

Before

https://github.com/lastmile-ai/aiconfig/assets/151060367/58a2ac2d-e8e7-41df-b25d-277741619b83

After
No longer part of AIConfig commands

<img width="875" alt="Screenshot 2024-02-23 at 12 25 33" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/1dcbcf5e-5300-4c9c-8e8e-1321cba3bc7f">
