### PR TITLE
Support .yml file extensions

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -80,6 +80,9 @@
             "filenamePattern": "*.aiconfig.yaml"
           },
           {
+            "filenamePattern": "*.aiconfig.yml"
+          },
+          {
             "filenamePattern": "*.aiconfig"
           }
         ],

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -23,7 +23,7 @@ export const COMMANDS = {
   SHOW_WELCOME: `${EXTENSION_NAME}.showWelcome`,
 };
 
-export const SUPPORTED_FILE_EXTENSIONS = [".json", ".yaml"];
+export const SUPPORTED_FILE_EXTENSIONS = [".json", ".yaml", ".yml"];
 
 export function isSupportedConfigExtension(fileName: string) {
   return SUPPORTED_FILE_EXTENSIONS.includes(path.extname(fileName));
@@ -102,7 +102,7 @@ export function getModeFromDocument(
   // determine mode from file path
   const documentPath = document.fileName;
   const ext = path.extname(documentPath)?.toLowerCase();
-  if (ext === "yaml" || ext === ".yaml") {
+  if (ext === "yaml" || ext === ".yaml" || ext === "yml" || ext === ".yml") {
     return "yaml";
   }
 


### PR DESCRIPTION
Support .yml file extensions

This was something we noticed at customer offsite where many people tried creating aiconfigs with *.yml extension.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1324).
* __->__ #1324
* #1323
* #1316