### PR TITLE
[local editor] Don't poll server status when in read only view

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -1033,7 +1033,7 @@ function AIConfigEditorBase({
   // Don't poll if server status is in an error state since it won't automatically recover
   const getServerStatusCallback = callbacks?.getServerStatus;
   useEffect(() => {
-    if (!getServerStatusCallback || serverStatus !== "OK") {
+    if (readOnly || !getServerStatusCallback || serverStatus !== "OK") {
       return;
     }
 
@@ -1047,7 +1047,7 @@ function AIConfigEditorBase({
     }, SERVER_HEARTBEAT_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [getServerStatusCallback, serverStatus]);
+  }, [getServerStatusCallback, readOnly, serverStatus]);
 
   const runningPromptId: string | undefined = aiconfigState._ui.runningPromptId;
 


### PR DESCRIPTION
[local editor] Don't poll server status when in read only view

In order to prevent showing status error message when in read only view, this diff makes sure that the aiconfig editor client does not poll the server status when in read only mode.

See #1320 for more context

## Testplan
1. Manually set readonly prop to True
2. Load local editor (Loaded in prod mode, I first built the editor with yarn build)
3. kill the python process that is hosting the aiconfig server.

| Before  | After |
| ------------- | ------------- |
| <img width="1913" alt="after" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/ce3487ba-0174-4ca7-b58e-7e10aed6409d">  | <img width="1909" alt="before" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/cba7b817-d09e-435f-b2e8-da7c13109459"> |

Note: the `killpython` command in my testplan is a custom alias I have defined that tries to kill all pid's that have the descriptor "python" in its name.
