### PR TITLE
[3/n] Restart Editor Servers on Python Interpreter Change

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -179,6 +179,7 @@
   },
   "dependencies": {
     "@vscode/python-extension": "^1.0.5",
+    "async-mutex": "^0.4.1",
     "oboe": "^2.1.5",
     "portfinder": "^1.0.32",
     "ufetch": "^1.6.0"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -58,6 +58,11 @@
         "category": "AIConfig"
       },
       {
+        "command": "vscode-aiconfig.restartActiveEditorServer",
+        "title": "Restart Active Editor Server",
+        "category": "AIConfig"
+      },
+      {
         "command": "vscode-aiconfig.setApiKeys",
         "title": "Set API Keys",
         "category": "AIConfig"

--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -15,7 +15,7 @@ import {
   AIConfigEditorManager,
   AIConfigEditorState,
 } from "./aiConfigEditorManager";
-import { EditorServer, EditorServerState } from "./editorServer";
+import { EditorServer, EditorServerState } from "./editor_server/editorServer";
 
 /**
  * Provider for AIConfig editors.

--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -15,7 +15,7 @@ import {
   AIConfigEditorManager,
   AIConfigEditorState,
 } from "./aiConfigEditorManager";
-import { EditorServer } from "./editorServer";
+import { EditorServer, EditorServerState } from "./editorServer";
 
 /**
  * Provider for AIConfig editors.
@@ -57,7 +57,9 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel: vscode.WebviewPanel,
     _token: vscode.CancellationToken
   ): Promise<void> {
-    let editorServer: EditorServer | null = null;
+    const editorServer: EditorServer = new EditorServer(
+      getCurrentWorkingDirectory(document)
+    );
     let isWebviewDisposed = false;
 
     // TODO: saqadri - clean up console log
@@ -95,43 +97,81 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
     // Update webview immediately so we unblock the render; server init will happen in the background.
     updateWebview();
 
-    // Do not start the server until we ensure the Python setup is ready
-    initializePythonFlow(this.context, this.extensionOutputChannel).then(
-      async () => {
-        // Start the AIConfig editor server process. Don't await at the top level here since that blocks the
-        // webview render (which happens only when resolveCustomTextEditor returns)
-        this.startEditorServer(document).then(async (startedServer) => {
-          editorServer = startedServer;
+    const setupServerState = async (server: EditorServer) => {
+      // Wait for server ready
+      await waitUntilServerReady(server.url);
 
-          this.aiconfigEditorManager.addEditor(
-            new AIConfigEditorState(
-              document,
-              webviewPanel,
-              startedServer,
-              this.aiconfigEditorManager
-            )
-          );
+      // Now set up the server with the latest document content
+      await this.initializeServerStateWithRetry(
+        server.url,
+        document,
+        webviewPanel
+      );
 
-          // Wait for server ready
-          await waitUntilServerReady(startedServer.url);
-
-          // Now set up the server with the latest document content
-          await this.startServerWithRetry(
-            startedServer.url,
-            document,
-            webviewPanel
-          );
-
-          // Inform the webview of the server URL
-          if (!isWebviewDisposed) {
-            webviewPanel.webview.postMessage({
-              type: "set_server_url",
-              url: startedServer.url,
-            });
-          }
+      // Inform the webview of the server URL
+      if (!isWebviewDisposed) {
+        webviewPanel.webview.postMessage({
+          type: "set_server_url",
+          url: server.url,
         });
       }
+    };
+
+    // Do not start the server until we ensure the Python setup is ready
+    // Don't await at the top level here since that blocks the webview render (which happens
+    // only when resolveCustomTextEditor returns)
+    initializePythonFlow(this.context, this.extensionOutputChannel).then(() =>
+      this.startEditorServer(editorServer, document).then(
+        async (startedServer) => {
+          const editor = new AIConfigEditorState(
+            document,
+            webviewPanel,
+            startedServer,
+            this.aiconfigEditorManager
+          );
+
+          this.aiconfigEditorManager.addEditor(editor);
+          await setupServerState(startedServer);
+        }
+      )
     );
+
+    const serverStateChangeSubscription = editorServer.onDidChangeState(
+      async (state) => {
+        switch (state) {
+          case EditorServerState.Stopped:
+            // Webview should be readonly until the server state is ready
+            if (!isWebviewDisposed) {
+              webviewPanel.webview.postMessage({
+                type: "set_readonly_state",
+                isReadOnly: true,
+              });
+            }
+            break;
+          case EditorServerState.Starting:
+            // Show notification with server starting progress if webview is focused
+            if (!isWebviewDisposed && webviewPanel.active) {
+              await vscode.window.withProgress(
+                {
+                  location: vscode.ProgressLocation.Notification,
+                  title: "Starting editor server...",
+                  cancellable: false,
+                },
+                async (progress) => {
+                  progress.report({
+                    increment: 50,
+                  });
+                }
+              );
+            }
+            break;
+        }
+      }
+    );
+
+    const serverRestartSubscription = editorServer.onRestart(async (server) => {
+      await setupServerState(server);
+    });
 
     // Hook up event handlers so that we can synchronize the webview with the text document.
     //
@@ -232,7 +272,7 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
           updateWebview();
 
           // Notify server of updated document
-          if (editorServer) {
+          if (editorServer.url) {
             await updateServerWithRetry(editorServer.url, e.document);
           }
         }
@@ -277,12 +317,11 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
       console.log(`${document.fileName}: Webview disposed`);
 
       changeDocumentSubscription.dispose();
+      serverRestartSubscription.dispose();
+      serverStateChangeSubscription.dispose();
       willSaveDocumentSubscription.dispose();
 
-      if (editorServer) {
-        editorServer.stop();
-        editorServer = null;
-      }
+      editorServer.stop();
     });
 
     // Receive message from the webview.
@@ -415,13 +454,19 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
         if (e.webviewPanel.active) {
           if (!isWebviewDisposed) {
             updateWebviewEditorThemeMode(webviewPanel.webview);
+
+            // Inform the webview if editor server updated in the background
+            webviewPanel.webview.postMessage({
+              type: "set_server_url",
+              url: editorServer.url,
+            });
           }
         }
       });
     }
   }
 
-  private startServerWithRetry(
+  private initializeServerStateWithRetry(
     serverUrl: string,
     document: vscode.TextDocument,
     webviewPanel: vscode.WebviewPanel
@@ -454,7 +499,11 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
             }
 
             if (selection === "Retry") {
-              this.startServerWithRetry(serverUrl, document, webviewPanel);
+              this.initializeServerStateWithRetry(
+                serverUrl,
+                document,
+                webviewPanel
+              );
             }
           });
       });
@@ -465,27 +514,27 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
   }
 
   private async startEditorServer(
+    editorServer: EditorServer,
     document: vscode.TextDocument
   ): Promise<EditorServer> {
     this.extensionOutputChannel.info(
       this.prependMessage("Starting editor server", document)
     );
 
-    const editorServer = new EditorServer(getCurrentWorkingDirectory(document));
     await editorServer.start();
 
-    editorServer.serverProc.stdout.on("data", (data) => {
+    editorServer.onStdout((data) => {
       this.extensionOutputChannel.info(this.prependMessage(data, document));
       console.log(`server stdout: ${data}`);
     });
 
     // TODO: saqadri - stderr is very noisy for some reason (duplicating INFO logs). Figure out why before enabling this.
-    editorServer.serverProc.stderr.on("data", (data) => {
+    editorServer.onStderr((data) => {
       this.extensionOutputChannel.error(this.prependMessage(data, document));
       console.error(`server stderr: ${data}`);
     });
 
-    editorServer.serverProc.on("spawn", () => {
+    editorServer.onSpawn(() => {
       this.extensionOutputChannel.info(
         this.prependMessage(
           `Started server at port=${editorServer.port}, pid=${editorServer.pid}`,
@@ -495,7 +544,7 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
       console.log(`server spawned: ${editorServer.pid}`);
     });
 
-    editorServer.serverProc.on("close", (code) => {
+    editorServer.onClose((code) => {
       if (code !== 0) {
         this.extensionOutputChannel.error(
           this.prependMessage(
@@ -503,7 +552,9 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
             document
           )
         );
-        console.error(`server terminated unexpectedly: exit code=${code}`);
+        console.error(
+          `Server at port=${editorServer.port}, pid=${editorServer.pid} terminated unexpectedly: exit code=${code}`
+        );
       } else {
         this.extensionOutputChannel.info(
           this.prependMessage(
@@ -515,7 +566,7 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
       }
     });
 
-    editorServer.serverProc.on("error", (err) => {
+    editorServer.onError((err) => {
       this.extensionOutputChannel.error(
         this.prependMessage(JSON.stringify(err), document)
       );

--- a/vscode-extension/src/aiConfigEditorManager.ts
+++ b/vscode-extension/src/aiConfigEditorManager.ts
@@ -1,5 +1,5 @@
 import vscode from "vscode";
-import { EditorServer } from "./editorServer";
+import { EditorServer } from "./editor_server/editorServer";
 
 export class AIConfigEditorState {
   constructor(

--- a/vscode-extension/src/aiConfigEditorManager.ts
+++ b/vscode-extension/src/aiConfigEditorManager.ts
@@ -1,11 +1,11 @@
 import vscode from "vscode";
-import { ServerInfo } from "./util";
+import { EditorServer } from "./editorServer";
 
 export class AIConfigEditorState {
   constructor(
     public document: vscode.TextDocument,
     public readonly webviewPanel: vscode.WebviewPanel,
-    public editorServer: ServerInfo | null,
+    public editorServer: EditorServer | null,
     private readonly manager: AIConfigEditorManager
   ) {
     // Listen to when the panel's view state changes and update the active editor

--- a/vscode-extension/src/editorServer.ts
+++ b/vscode-extension/src/editorServer.ts
@@ -4,6 +4,12 @@ import { EXTENSION_NAME } from "./util";
 import { getPythonPath } from "./utilities/pythonSetupUtils";
 import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 
+export enum EditorServerState {
+  Starting = "Starting",
+  Running = "Running",
+  Stopped = "Stopped",
+}
+
 /**
  * Provider for AIConfig editors.
  *
@@ -12,66 +18,135 @@ import { ChildProcessWithoutNullStreams, spawn } from "child_process";
  */
 export class EditorServer {
   private cwd: string;
+  private _onDidChangeState = new vscode.EventEmitter<EditorServerState>();
+  private _onRestart = new vscode.EventEmitter<EditorServer>();
+
+  // Readable and process listeners. Maintain at the class level so that subscribers don't
+  // need to care about underlying server process
+  private _onStdout = new vscode.EventEmitter<any>();
+  private _onStderr = new vscode.EventEmitter<any>();
+  private _onSpawn = new vscode.EventEmitter<void>();
+  private _onClose = new vscode.EventEmitter<number>();
+  private _onError = new vscode.EventEmitter<Error>();
 
   public pid: number | null = null;
   public port: number | null = null;
+
   // TODO: Should make this private and expose subscriptions to .stderr, .stdout, and .on
   public serverProc: ChildProcessWithoutNullStreams | null = null;
+  public serverState: EditorServerState = EditorServerState.Stopped;
   public url: string | null = null;
+
+  public readonly onDidChangeState = this._onDidChangeState.event;
+  public readonly onRestart = this._onRestart.event;
+
+  public readonly onStdout = this._onStdout.event;
+  public readonly onStderr = this._onStderr.event;
+  public readonly onSpawn = this._onSpawn.event;
+  public readonly onClose = this._onClose.event;
+  public readonly onError = this._onError.event;
 
   constructor(workingDirectory: string) {
     this.cwd = workingDirectory;
   }
 
-  public async start(): Promise<EditorServer> {
+  private updateServerState(state: EditorServerState) {
+    this.serverState = state;
+    this._onDidChangeState.fire(state);
+  }
+
+  public async start(): Promise<void> {
     if (this.serverProc) {
       console.log(
         `Server process ${this.pid} already started, port ${this.port}`
       );
-      return this;
+      return;
     }
 
-    // If there is a custom model registry path, pass it to the server
-    const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
-    const modelRegistryPath = config.get<string>("modelRegistryPath");
-    const modelRegistryPathArgs = modelRegistryPath
-      ? ["--parsers-module-path", modelRegistryPath]
-      : [];
+    console.log("Starting editor server process");
+    this.updateServerState(EditorServerState.Starting);
 
-    this.port = await getPortPromise();
+    try {
+      // If there is a custom model registry path, pass it to the server
+      const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
+      const modelRegistryPath = config.get<string>("modelRegistryPath");
+      const modelRegistryPathArgs = modelRegistryPath
+        ? ["--parsers-module-path", modelRegistryPath]
+        : [];
 
-    const pythonPath = await getPythonPath();
+      this.port = await getPortPromise();
 
-    // TODO: saqadri - specify parsers_module_path
-    // `aiconfig` command not useable here because it relies on python. Instead invoke the module directly.
-    const startServer = spawn(
-      pythonPath,
-      [
-        "-m",
-        "aiconfig.scripts.aiconfig_cli",
-        "start",
-        "--server-port",
-        this.port.toString(),
-        ...modelRegistryPathArgs,
-      ],
-      {
-        cwd: this.cwd,
-      }
-    );
+      const pythonPath = await getPythonPath();
 
-    this.pid = startServer.pid;
-    this.serverProc = startServer;
-    this.url = `http://localhost:${this.port}`;
+      // TODO: saqadri - specify parsers_module_path
+      // `aiconfig` command not useable here because it relies on python. Instead invoke the module directly.
+      const startServer = spawn(
+        pythonPath,
+        [
+          "-m",
+          "aiconfig.scripts.aiconfig_cli",
+          "start",
+          "--server-port",
+          this.port.toString(),
+          ...modelRegistryPathArgs,
+        ],
+        {
+          cwd: this.cwd,
+        }
+      );
 
-    return this;
+      this.pid = startServer.pid;
+      this.serverProc = startServer;
+      this.url = `http://localhost:${this.port}`;
+
+      startServer.stdout.on("data", (data) => {
+        this._onStdout.fire(data);
+      });
+
+      startServer.stderr.on("data", (data) => {
+        this._onStderr.fire(data);
+      });
+
+      startServer.on("spawn", () => {
+        this._onSpawn.fire();
+      });
+
+      startServer.on("close", (code) => {
+        this._onClose.fire(code);
+      });
+
+      startServer.on("error", (err) => {
+        this._onError.fire(err);
+      });
+
+      this.updateServerState(EditorServerState.Running);
+
+      console.log(
+        `Started editor server process ${this.pid}, port ${this.port}`
+      );
+    } catch (e) {
+      console.error("Error starting editor server process", e);
+      this.updateServerState(EditorServerState.Stopped);
+      throw e;
+    }
   }
 
   public stop() {
-    console.log(`Killing editor server process ${this.pid}`);
-    this.serverProc.kill();
+    console.log(`Killing editor server process ${this.pid}, port ${this.port}`);
+    this.serverProc?.kill();
     this.serverProc = null;
     this.pid = null;
     this.port = null;
     this.url = null;
+    this.updateServerState(EditorServerState.Stopped);
+  }
+
+  public async restart(): Promise<void> {
+    console.log(
+      `Restarting editor server process ${this.pid}, port ${this.port}`
+    );
+    this.stop();
+    await this.start();
+    this._onRestart.fire(this);
   }
 }

--- a/vscode-extension/src/editorServer.ts
+++ b/vscode-extension/src/editorServer.ts
@@ -1,0 +1,77 @@
+import * as vscode from "vscode";
+import { getPortPromise } from "portfinder";
+import { EXTENSION_NAME } from "./util";
+import { getPythonPath } from "./utilities/pythonSetupUtils";
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+
+/**
+ * Provider for AIConfig editors.
+ *
+ * AIConfig editors are used for `.aiconfig`, `.aiconfig.json` and `.aiconfig.yaml` files.
+ * These files are backed by a JSON schema under the hood.
+ */
+export class EditorServer {
+  private cwd: string;
+
+  public pid: number | null = null;
+  public port: number | null = null;
+  // TODO: Should make this private and expose subscriptions to .stderr, .stdout, and .on
+  public serverProc: ChildProcessWithoutNullStreams | null = null;
+  public url: string | null = null;
+
+  constructor(workingDirectory: string) {
+    this.cwd = workingDirectory;
+  }
+
+  public async start(): Promise<EditorServer> {
+    if (this.serverProc) {
+      console.log(
+        `Server process ${this.pid} already started, port ${this.port}`
+      );
+      return this;
+    }
+
+    // If there is a custom model registry path, pass it to the server
+    const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
+    const modelRegistryPath = config.get<string>("modelRegistryPath");
+    const modelRegistryPathArgs = modelRegistryPath
+      ? ["--parsers-module-path", modelRegistryPath]
+      : [];
+
+    this.port = await getPortPromise();
+
+    const pythonPath = await getPythonPath();
+
+    // TODO: saqadri - specify parsers_module_path
+    // `aiconfig` command not useable here because it relies on python. Instead invoke the module directly.
+    const startServer = spawn(
+      pythonPath,
+      [
+        "-m",
+        "aiconfig.scripts.aiconfig_cli",
+        "start",
+        "--server-port",
+        this.port.toString(),
+        ...modelRegistryPathArgs,
+      ],
+      {
+        cwd: this.cwd,
+      }
+    );
+
+    this.pid = startServer.pid;
+    this.serverProc = startServer;
+    this.url = `http://localhost:${this.port}`;
+
+    return this;
+  }
+
+  public stop() {
+    console.log(`Killing editor server process ${this.pid}`);
+    this.serverProc.kill();
+    this.serverProc = null;
+    this.pid = null;
+    this.port = null;
+    this.url = null;
+  }
+}

--- a/vscode-extension/src/editor_server/editorServer.ts
+++ b/vscode-extension/src/editor_server/editorServer.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import { getPortPromise } from "portfinder";
-import { EXTENSION_NAME } from "./util";
-import { getPythonPath } from "./utilities/pythonSetupUtils";
+import { EXTENSION_NAME } from "../util";
+import { getPythonPath } from "../utilities/pythonSetupUtils";
 import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import serverPortManager from "./serverPortManager";
 
 export enum EditorServerState {
   Starting = "Starting",
@@ -74,7 +74,7 @@ export class EditorServer {
         ? ["--parsers-module-path", modelRegistryPath]
         : [];
 
-      this.port = await getPortPromise();
+      this.port = await serverPortManager.getPort();
 
       const pythonPath = await getPythonPath();
 

--- a/vscode-extension/src/editor_server/serverPortManager.ts
+++ b/vscode-extension/src/editor_server/serverPortManager.ts
@@ -1,0 +1,25 @@
+import { Mutex } from "async-mutex";
+import { getPortPromise } from "portfinder";
+
+/**
+ * Super simple class to manage server port allocation using a lock mechanism. If
+ * we don't do this, restarting multiple servers simultaneously can result in
+ * obtaining the same port for multiple servers.
+ */
+class ServerPortManager {
+  private lock;
+
+  constructor() {
+    this.lock = new Mutex();
+  }
+
+  async getPort(): Promise<number> {
+    const release = await this.lock.acquire();
+    const port = await getPortPromise();
+    release();
+    return port;
+  }
+}
+
+const serverPortManager = new ServerPortManager();
+export default serverPortManager;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -129,6 +129,15 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(openModelParserCommand);
 
+  const restartActiveEditorCommand = vscode.commands.registerCommand(
+    COMMANDS.RESTART_ACTIVE_EDITOR_SERVER,
+    async () => {
+      const activeEditor = aiconfigEditorManager.getActiveEditor();
+      activeEditor?.editorServer?.restart();
+    }
+  );
+  context.subscriptions.push(restartActiveEditorCommand);
+
   // Register our custom editor providers
   const aiconfigEditorManager: AIConfigEditorManager =
     new AIConfigEditorManager();

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -182,8 +182,7 @@ export async function activate(context: vscode.ExtensionContext) {
             .then((selection) => {
               if (selection === "Yes") {
                 editors.forEach((editor) => {
-                  // Next PR: refresh editor here
-                  vscode.window.showInformationMessage("Refresh boiiiiii");
+                  editor.editorServer.restart();
                 });
               }
             });

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { type ChildProcessWithoutNullStreams, execSync } from "child_process";
 import { setTimeout } from "timers/promises";
 import { ufetch } from "ufetch";
 
@@ -43,11 +42,6 @@ export const EDITOR_SERVER_ROUTE_TABLE = {
     urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/load_content"),
   LOAD_MODEL_PARSER_MODULE: (hostUrl: string) =>
     urlJoin(hostUrl, EDITOR_SERVER_API_ENDPOINT, "/load_model_parser_module"),
-};
-
-export type ServerInfo = {
-  proc: ChildProcessWithoutNullStreams;
-  url: string;
 };
 
 export async function isServerReady(serverUrl: string) {

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -17,6 +17,7 @@ export const COMMANDS = {
   CREATE_CUSTOM_MODEL_REGISTRY: `${EXTENSION_NAME}.createCustomModelRegistry`,
   OPEN_CONFIG_FILE: `${EXTENSION_NAME}.openConfigFile`,
   OPEN_MODEL_REGISTRY: `${EXTENSION_NAME}.openModelRegistry`,
+  RESTART_ACTIVE_EDITOR_SERVER: `${EXTENSION_NAME}.restartActiveEditorServer`,
   SET_API_KEYS: `${EXTENSION_NAME}.setApiKeys`,
   SHARE: `${EXTENSION_NAME}.share`,
   SHOW_WELCOME: `${EXTENSION_NAME}.showWelcome`,

--- a/vscode-extension/yarn.lock
+++ b/vscode-extension/yarn.lock
@@ -338,6 +338,13 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+async-mutex@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.4.1.tgz#bccf55b96f2baf8df90ed798cb5544a1f6ee4c2c"
+  integrity sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==
+  dependencies:
+    tslib "^2.4.0"
+
 async@^2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
@@ -1457,6 +1464,11 @@ ts-api-utils@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.3.tgz#f12c1c781d04427313dbac808f453f050e54a331"
   integrity sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==
+
+tslib@^2.4.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
# [3/n] Restart Editor Servers on Python Interpreter Change

When interpreter changes restart all editors if the user selects it. We need to leverage async locking mechanism for managing the server port otherwise each of the simultaneously-restarted servers could end up with duplicate port number.

Seems that even with just the lock it won't work, so need to explicitly manage the starting port in the search (to a reasonable max, before restarting search at 8000 again).


https://github.com/lastmile-ai/aiconfig/assets/5060851/7708c288-2878-420e-9130-4074ca9a11b5



---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1328).
* __->__ #1328
* #1319
* #1318