### PR TITLE
wip: solution for #196

### DIFF
--- a/python/src/aiconfig/schema.py
+++ b/python/src/aiconfig/schema.py
@@ -228,6 +228,7 @@ class ConfigMetadata(BaseModel):
 
     class Config:
         extra = "allow"
+        protected_namespaces = ()
 
 
 class AIConfig(BaseModel):


### PR DESCRIPTION
rfc: solution for #196

see #196

Protected namespaces are for warnings, shouldn't cause an error.


## Testplan

Import aiconfig in my interpreter -> no pydantic warning

https://github.com/lastmile-ai/aiconfig/assets/141073967/cad68bd9-5ab7-4f5e-ae90-6e249b2e439d
