### PR TITLE
Fix error starting server on new aiconfig yaml

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -180,6 +180,7 @@
   "dependencies": {
     "@vscode/python-extension": "^1.0.5",
     "async-mutex": "^0.4.1",
+    "js-yaml": "^4.1.0",
     "oboe": "^2.1.5",
     "portfinder": "^1.0.32",
     "ufetch": "^1.6.0"

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import yaml from "js-yaml";
 import { setTimeout } from "timers/promises";
 import { ufetch } from "ufetch";
 
@@ -95,6 +96,22 @@ export function getModeFromDocument(
   document: vscode.TextDocument
 ): "json" | "yaml" {
   // determine mode from file path
+
+  if (document.isUntitled) {
+    // If the document is untitled, we cannot infer the mode from the file path, so
+    // we try to parse the document as JSON or YAML to determine the mode
+    const text = document.getText();
+    try {
+      // Try parsing the string as JSON first
+      JSON.parse(text);
+      return "json";
+    } catch (e) {
+      // If that fails, try parsing the string as YAML
+      yaml.load(text);
+      return "yaml";
+    }
+  }
+
   const documentPath = document.fileName;
   const ext = path.extname(documentPath)?.toLowerCase();
   if (ext === "yaml" || ext === ".yaml" || ext === "yml" || ext === ".yml") {


### PR DESCRIPTION
Fix error starting server on new aiconfig yaml

When you create a new aiconfig yaml, the server fails to start.

This is because of changes to the flow where we are calling `updateServerState` in the launch flow of the editor, which in turn calls `getModeForDocument`. This function uses the file extension to determine if the document is JSON or YAML, but in the case of Untitled documents, there is no file URI.

Since it is reasonable to expect this flow for Untitled documents, the fix here is to use the document's content to determine the mode (try parsing it as JSON or as YAML).

https://github.com/lastmile-ai/lastmile/assets/25641935/1c96d099-d970-4e5f-9b58-3768451e591c
