### PR TITLE
Fix issues when no workspace is opened

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -27,6 +27,7 @@ import {
   SUPPORTED_FILE_EXTENSIONS,
   setupEnvironmentVariables,
   validateNewConfigName,
+  getConfigurationTarget,
 } from "./util";
 import {
   initialize,
@@ -470,7 +471,7 @@ async function handleCustomModelRegistryUpdate(
   await config.update(
     "modelRegistryPath",
     modelRegistryPath,
-    vscode.ConfigurationTarget.Workspace
+    getConfigurationTarget()
   );
 
   vscode.window.showInformationMessage(

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -81,6 +81,12 @@ export function updateWebviewEditorThemeMode(webview: vscode.Webview) {
   });
 }
 
+export function getConfigurationTarget() {
+  return vscode.workspace.workspaceFolders !== undefined
+    ? vscode.ConfigurationTarget.Workspace
+    : vscode.ConfigurationTarget.Global;
+}
+
 export async function updateServerState(
   serverUrl: string,
   document: vscode.TextDocument

--- a/vscode-extension/src/utilities/pythonSetupUtils.ts
+++ b/vscode-extension/src/utilities/pythonSetupUtils.ts
@@ -11,7 +11,7 @@ import * as vscode from "vscode";
 
 import { exec, execSync, spawn } from "child_process";
 import path from "path";
-import { COMMANDS, EXTENSION_NAME } from "../util";
+import { COMMANDS, EXTENSION_NAME, getConfigurationTarget } from "../util";
 import { PythonExtension } from "@vscode/python-extension";
 import { PYTHON_INTERPRETER_CACHE_KEY_NAME } from "../constants";
 
@@ -354,7 +354,7 @@ export async function savePythonInterpreterToCache(): Promise<void> {
   await config.update(
     PYTHON_INTERPRETER_CACHE_KEY_NAME,
     pythonPath,
-    vscode.ConfigurationTarget.Workspace
+    getConfigurationTarget()
   );
 }
 


### PR DESCRIPTION
Fix issues when no workspace is opened

When no workspace folder is opened, we get errors. This is due to the fact that we are trying to save vscode configuration settings in the Workspace context, when none exists.

To fix, if no workspace is opened, we save the settings in the global context.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1335).
* #1336
* __->__ #1335