### PR TITLE
[vscode] Prompt User for Name When Creating New AIConfig

### DIFF
--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -381,6 +381,28 @@ export async function setupEnvironmentVariables(
   }
 }
 
+export function validateNewConfigName(name: string, mode: "json" | "yaml") {
+  if (name === "") {
+    return "Filename is required";
+  }
+  if (mode === "json" && !name.endsWith(".aiconfig.json")) {
+    return "Filename must end with .aiconfig.json";
+  }
+  if (
+    mode === "yaml" &&
+    !name.endsWith(".aiconfig.yaml") &&
+    !name.endsWith(".aiconfig.yml")
+  ) {
+    return "Filename must end with .aiconfig.yaml or .aiconfig.yml";
+  }
+
+  if (fs.existsSync(name)) {
+    return "File already exists";
+  }
+
+  return null;
+}
+
 function validateEnvPath(
   inputPath: string,
   workspacePath: string | null


### PR DESCRIPTION
[vscode] Prompt User for Name When Creating New AIConfig

# [vscode] Prompt User for Name When Creating New AIConfig

VS Code api for creating new/untitled files does not allow specifying the extension to use for the file on save. This results in untitled files being prompted to save with either .json or .yaml extension, NOT .aiconfig.json or .aiconfig.yaml. This is a big problem, since using the non-aiconfig extension will result in the file not opening with our custom editor next time it's opened.

As a workaround, we can default the untilted filename to untitle.aiconfig.json/yaml and prompt the user for the proper name when creating it (before showing the contents). See #1334 for the alternative, of saving the file immediately as untitled and requiring the user to rename manually if they want afterwards.


https://github.com/lastmile-ai/aiconfig/assets/5060851/57a0978a-e377-4c88-bc9f-48dcfc03c8bb

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1337).
* #1342
* __->__ #1337