### PR TITLE
Cache versions of extension into global settings

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -15,6 +15,10 @@
     "Other"
   ],
   "main": "./out/extension.js",
+  "activationEvents": [
+    "workspaceContains:**.aiconfig.**",
+    "onView:extension"
+  ],
   "contributes": {
     "commands": [
       {
@@ -102,6 +106,11 @@
           "type": "string",
           "default": "",
           "description": "Path to the python interpreter for this VS Code workspace"
+        },
+        "vscode-aiconfig.version": {
+          "type": "string",
+          "default": "",
+          "description": "Version of the AIConfig Editor extension last time it was activated. We use this value to check if the extension has been updated to prompt users to reload VS Code"
         }
       }
     },

--- a/vscode-extension/src/constants.ts
+++ b/vscode-extension/src/constants.ts
@@ -1,1 +1,5 @@
 export const PYTHON_INTERPRETER_CACHE_KEY_NAME = "pythonInterpreter";
+
+// Used for prompting user to reload VS Code window on update, and ensuring
+// that walkthrough gets shown on first install
+export const VERSION_KEY_NAME = "version";

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -25,6 +25,7 @@ import {
   initialize,
   savePythonInterpreterToCache,
 } from "./utilities/pythonSetupUtils";
+import { performVersionInstallAndUpdateActionsIfNeeded } from "./utilities/versionUpdateUtils";
 import { AIConfigEditorProvider } from "./aiConfigEditor";
 import {
   AIConfigEditorManager,
@@ -48,6 +49,8 @@ export async function activate(context: vscode.ExtensionContext) {
   const extensionOutputChannel = vscode.window.createOutputChannel("AIConfig", {
     log: true,
   });
+
+  await performVersionInstallAndUpdateActionsIfNeeded(context);
 
   const setupCommand = vscode.commands.registerCommand(COMMANDS.INIT, () => {
     initialize(context, extensionOutputChannel);
@@ -175,6 +178,10 @@ export async function activate(context: vscode.ExtensionContext) {
           aiconfigEditorManager.getRegisteredEditors()
         );
         if (editors.length > 0) {
+          // TODO: Check if user has set python interpreter, only do it if:
+          // after env is created
+          // python interpreter has actually changed
+
           vscode.window
             .showInformationMessage(
               "Python Interpreter Updated: Would you like to refresh active AIConfig files?",

--- a/vscode-extension/src/utilities/versionUpdateUtils.ts
+++ b/vscode-extension/src/utilities/versionUpdateUtils.ts
@@ -1,0 +1,44 @@
+/**
+ * Utils file for handling actions to perform whenever user
+ * installs or updates the extension.
+ * VS Code automatically checks for version updates
+ * (https://code.visualstudio.com/docs/editor/extension-marketplace#_extension-autoupdate)
+ * but I haven't been able to find a way to use this to trigger any
+ * actions. Also even though the Walkthrough documentation says
+ * that this gets triggered on first install, I haven't been able
+ * to trigger this either, so I am calling this manually
+ * https://code.visualstudio.com/api/references/contribution-points#contributes.walkthroughs
+ */
+
+import * as vscode from "vscode";
+
+import { EXTENSION_NAME } from "../util";
+import { VERSION_KEY_NAME } from "../constants";
+
+export async function performVersionInstallAndUpdateActionsIfNeeded(
+  context: vscode.ExtensionContext
+) {
+  const extension = vscode.extensions.getExtension(context.extension.id);
+  const currExtensionVersion = extension?.packageJSON.version;
+  const config = vscode.workspace.getConfiguration(EXTENSION_NAME);
+  const lastActivatedVersion = config.get<string>(VERSION_KEY_NAME);
+  if (currExtensionVersion !== lastActivatedVersion) {
+    await config.update(
+      VERSION_KEY_NAME,
+      currExtensionVersion,
+      vscode.ConfigurationTarget.Global
+    );
+  }
+
+  if (lastActivatedVersion === undefined || lastActivatedVersion === "") {
+    // First time activating extension, show walkthrough
+    // Will implement next PR
+    // vscode.commands.executeCommand("workbench.action.openWalkthrough");
+  } else if (
+    currExtensionVersion > lastActivatedVersion
+    // TODO: Add check for if version string follows format of %d.%d.%d
+  ) {
+    // Extension has been updated, prompt user to refresh VS Code window
+    // Will implement next PR
+  }
+}


### PR DESCRIPTION
Cache versions of extension into global settings

This is kind of a hack. I'm not sure why the extension walkthrough isn't opening when it first installs, but whatever we need to do this to ensure that walkthrough runs, because it's not running when users first download the extension (could be perhaps that we've already installed it so global settings is aware of it, idk but whatever)

Adding a global config for `vscode-aiconfig.version`, and also changed the activate settings to activate upon vscode startup. This is fine because we moved the initialize step outside of here so there's no negative consequences of activating it.

Will implement the actual functionality next PRs

## Test Plan
Ok I don't know why I can't test directly bvy running the activation command, but instead I just hooked this up to the 'Set API Keys" command and ran it lol

https://github.com/lastmile-ai/aiconfig/assets/151060367/449e599a-4ed7-457f-9543-7e7895337ebe
