### PR TITLE
[wip] Don't Create Duplicate Text Editor for new Config

### DIFF
--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -381,6 +381,28 @@ export async function setupEnvironmentVariables(
   }
 }
 
+export function validateNewConfigName(name: string, mode: "json" | "yaml") {
+  if (name === "") {
+    return "Filename is required";
+  }
+  if (mode === "json" && !name.endsWith(".aiconfig.json")) {
+    return "Filename must end with .aiconfig.json";
+  }
+  if (
+    mode === "yaml" &&
+    !name.endsWith(".aiconfig.yaml") &&
+    !name.endsWith(".aiconfig.yml")
+  ) {
+    return "Filename must end with .aiconfig.yaml or .aiconfig.yml";
+  }
+
+  if (fs.existsSync(name)) {
+    return "File already exists";
+  }
+
+  return null;
+}
+
 function validateEnvPath(
   inputPath: string,
   workspacePath: string | null


### PR DESCRIPTION
[wip] Don't Create Duplicate Text Editor for new Config

Still looking into this a bit. We can create a new aiconfig doc with aiconfig scheme and that will go through our content provider to get the initial content. However, this now results in a significant bug where the new file isn't marked as dirty (even with changes), so I think there's some disconnection between the text document and editor :s

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1342).
* __->__ #1342
* #1337