### PR TITLE
[vscode] Give Option to Change Python Interpreter if Server Fails to Start

### DIFF
--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -488,22 +488,23 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
         vscode.window
           .showErrorMessage(
             "Failed to start aiconfig server. You can view the aiconfig but cannot modify it.",
-            ...["Details", "Retry"]
+            ...["Details", "Retry", "Change Python Interpreter"]
           )
-          .then((selection) => {
+          .then(async (selection) => {
             if (selection === "Details") {
               this.extensionOutputChannel.error(
                 e?.message ?? JSON.stringify(e)
               );
               this.extensionOutputChannel.show(/*preserveFocus*/ true);
-            }
-
-            if (selection === "Retry") {
+            } else if (selection === "Retry") {
               this.initializeServerStateWithRetry(
                 serverUrl,
                 document,
                 webviewPanel
               );
+            } else if (selection === "Change Python Interpreter") {
+              // Change interpreter will prompt to restart the editor server
+              await vscode.commands.executeCommand("python.setInterpreter");
             }
           });
       });


### PR DESCRIPTION
# [vscode] Give Option to Change Python Interpreter if Server Fails to Start

Currently, if the server fails to start we just have the option to show details or retry. In cases where it will never start (e.g. current interpreter doesn't have the right packages) this leaves the user stuck. So, provide the option to "Change Python Interpreter" so that the user can try a different one. Note, changing interpreter will automatically show the 'Restart editor servers' notification for the user to restart the server. It would be nice to automatically do this, but I wasn't able to figure out a clean way to handle that (i.e. don't show our 'global' listener's notification in this case). Maybe we can do that as a P1 followup?


https://github.com/lastmile-ai/aiconfig/assets/5060851/9e65f38e-ae70-4d64-9c1d-645bfe897804


