### PR TITLE
[vscode] Prompt User to restart Vscode after installing python

### DIFF
--- a/vscode-extension/src/utilities/pythonSetupUtils.ts
+++ b/vscode-extension/src/utilities/pythonSetupUtils.ts
@@ -420,8 +420,21 @@ export function showGuideForPythonInstallation(message: string): void {
         vscode.env.openExternal(
           vscode.Uri.parse("https://www.python.org/downloads/")
         );
+        showNotificationToRestartVsCode();
       } else if (selection === "Retry") {
         vscode.commands.executeCommand(COMMANDS.INIT);
       }
     });
+}
+
+export async function showNotificationToRestartVsCode(): Promise<void> {
+  // block on selection. Otherwise, the installation flow continues and will eventually cache the wrongly selected interpreter.
+  const selection = await vscode.window.showInformationMessage(
+    "After installing Python, please restart VS Code to complete the installation of the AIConfig extension",
+    "Restart"
+  );
+
+  if (selection === "Restart") {
+    vscode.commands.executeCommand("workbench.action.reloadWindow");
+  }
 }


### PR DESCRIPTION
[vscode] Prompt User to restart Vscode after installing python

As part of the vscode extension installation flow, if the user doesn't have a valid python interpreter, they are prompted with a vscode notification asking them if they would like to install python.

If they do install python, vscode will need to be restarted in order to have the new interpreter available to select.

This diff shows the user a notification with the option to restart vscode for them, if they click on `Install Python` as mentioned above.

RFC: Python Extension API exposes  functionality to [Detect new environments discovered in the system](https://github.com/microsoft/vscode-python/wiki/Python-Environment-APIs#detect-new-environments-or-changes-to-the-interpreters-discovered-in-the-system) but I felt it would be easier to just have the user restart the vscode window.

## Testplan:

1. Load vscode extension as if its a new workspace
2. select interpreter with incompatible version (3.9.4)
-> Click install python
-> User is prompted with restart vscode
-> reload vscode window
-> successfully goes through initialize flow again

https://github.com/lastmile-ai/aiconfig/assets/141073967/6568d9ca-a7d1-47dd-abf4-8a2276658061
