### PR TITLE
Don't Show Server Update Error for Untitled Configs

### DIFF
--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -208,6 +208,11 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
               "Ignoring server update error due to webview disposal"
             );
             return;
+          } else if (document.isUntitled) {
+            // Saving untitled document triggers content change (i.e. setting full document
+            // content) but the server can't load from untitled:/ file scheme. Just ignore
+            // this scenario instead of showing the notification
+            console.info("Ignoring server update error for untitled document");
           }
 
           webviewPanel.webview.postMessage({


### PR DESCRIPTION
# Don't Show Server Update Error for Untitled Configs

Currently when creating a new config file and saving it, the initial `untitled:/` document webview is disposed and quickly reloaded with that of the `file:/` document. Before the `untitled:/` is disposed, though, the text document emits a change event with the full contents of the file. This change event results in our extension attempting to update the server with the state from the changed file (on the server, it will attempt to load the content at the document's path), which fails because this untitled file does not exist on disk. Heres' the logging for this flow:

```
changeDocumentSubscription untitled:/Users/ryanholinshead/Projects/aiconfig/cookbooks/untitled.aiconfig.json -- updating webview (at console.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:140:57439))
console.ts:137 [Extension Host] updateServerWithRetry http://localhost:8001, isWebviewDisposed=false (at console.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:140:57439))
console.ts:137 [Extension Host]% {document: {…}, contentChanges: Array(1)}contentChanges: Array(1)0: range: Array(2)0: character: 0line: 0[[Prototype]]: Object1: character: 0line: 81[[Prototype]]: Objectlength: 2[[Prototype]]: Array(0)rangeLength: 2518rangeOffset: 0text: ""[[Prototype]]: Objectlength: 1[[Prototype]]: Array(0)document: eol: 1fileName: "/Users/ryanholinshead/Projects/aiconfig/cookbooks/untitled.aiconfig.json"isClosed: falseisDirty: trueisUntitled: truelanguageId: "json"lineCount: 1uri: {$mid: 1, fsPath: '/Users/ryanholinshead/Projects/aiconfig/cookbooks/untitled.aiconfig.json', external: 'untitled:/Users/ryanholinshead/Projects/aiconfig/cookbooks/untitled.aiconfig.json', path: '/Users/ryanholinshead/Projects/aiconfig/cookbooks/untitled.aiconfig.json', scheme: 'untitled'}version: 3[[Prototype]]: Object[[Prototype]]: Object (at console.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:140:57439))
log.ts:437   ERR [Extension Host] server stderr: [ERROR] 2024-02-26 11:11:08,638 app.py:828: Exception on /api/load_content [POST]
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/flask/app.py", line 1463, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/flask/app.py", line 872, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/flask_cors/extension.py", line 176, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
                                                ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/flask/app.py", line 870, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/flask/app.py", line 855, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/aiconfig/editor/server/server.py", line 236, in load_content
    aiconfig = AIConfigRuntime.load_yaml(content)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/aiconfig/Config.py", line 153, in load_yaml
    return cls.load_json(config_json)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/aiconfig/Config.py", line 137, in load_json
    config_runtime = cls.model_validate_json(config_json)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/pydantic/main.py", line 538, in model_validate_json
    return cls.__pydantic_validator__.validate_json(json_data, strict=strict, context=context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for AIConfigRuntime
  Input should be an object [type=model_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.6/v/model_type

console.ts:137 [Extension Host] server stderr: [ERROR] 2024-02-26 11:11:08,638 app.py:828: Exception on /api/load_content [POST]
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/flask/app.py", line 1463, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/flask/app.py", line 872, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/flask_cors/extension.py", line 176, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
                                                ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/flask/app.py", line 870, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/flask/app.py", line 855, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/aiconfig/editor/server/server.py", line 236, in load_content
    aiconfig = AIConfigRuntime.load_yaml(content)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/aiconfig/Config.py", line 153, in load_yaml
    return cls.load_json(config_json)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/aiconfig/Config.py", line 137, in load_json
    config_runtime = cls.model_validate_json(config_json)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/aiconfig/lib/python3.12/site-packages/pydantic/main.py", line 538, in model_validate_json
    return cls.__pydantic_validator__.validate_json(json_data, strict=strict, context=context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for AIConfigRuntime
  Input should be an object [type=model_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.6/v/model_type
 (at console.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:140:57439))
p @ console.ts:137
$logExtensionHostMessage @ mainThreadConsole.ts:39
S @ rpcProtocol.ts:458
Q @ rpcProtocol.ts:443
M @ rpcProtocol.ts:373
L @ rpcProtocol.ts:299
(anonymous) @ rpcProtocol.ts:161
y @ event.ts:1127
fire @ event.ts:1158
fire @ ipc.net.ts:650
x.onmessage @ localProcessExtensionHost.ts:376
notificationsAlerts.ts:42 Failed to update aiconfig server. You can view the aiconfig but cannot modify it.
```

Note that load_content fails and then the pydantic validation fails because the aiconfig in server state is None.

To fix, we can intentionally skip showing this specific error message when the document is untitled, since there's nothing actionable for the user when this happens (retrying would always fail due to the untitled file not on disk):


https://github.com/lastmile-ai/aiconfig/assets/5060851/f4964802-b54e-43fc-b200-83415d3b08ab




