### PR TITLE
Use Name Instead of File Contents for Untitled Tab

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -120,7 +120,8 @@
     "configurationDefaults": {
       "workbench.editorAssociations": {
         "{git,gitlens,sapling-diff}:/**/*.{aiconfig.json, aiconfig.yaml}": "default"
-      }
+      },
+      "workbench.editor.untitled.labelFormat": "name"
     },
     "walkthroughs": [
       {


### PR DESCRIPTION
# Use Name Instead of File Contents for Untitled Tab

Currently, untitled yaml config files have the tab name matching the first line of our static untitled yaml template:
![Screenshot 2024-02-26 at 12 03 11 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/775dfa70-e15e-4455-8db6-de2e7e09f200)

This appears to be a result of the `workbench.editor.untitled.labelFormat` setting:
```
// Controls the format of the label for an untitled editor.
  //  - content: The name of the untitled file is derived from the contents of its first line unless it has an associated file path. It will fallback to the name in case the line is empty or contains no word characters.
  //  - name: The name of the untitled file is not derived from the contents of the file.
  "workbench.editor.untitled.labelFormat": "content",
```

We can set this setting for our extension to use the name instead of content (default):
![Screenshot 2024-02-26 at 12 01 05 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/7d071043-fe7f-4be8-bd59-33cf31854ac0)
![Screenshot 2024-02-26 at 12 01 16 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/4a731efa-f02b-4988-b542-e6ed0ac00783)

Alternatively, it seems we could leave the first line of our `untitled.aiconfig.yaml` as a newline, but that seems a bit flaky. We can't use a comment as the first line, though:
![Screenshot 2024-02-26 at 12 07 18 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/8f74453a-c06d-45fb-b928-b3640317fdc0)

