### PR TITLE
Hard-code extension id for opening walkthrough

### DIFF
--- a/vscode-extension/src/utilities/versionUpdateUtils.ts
+++ b/vscode-extension/src/utilities/versionUpdateUtils.ts
@@ -34,7 +34,7 @@ export async function performVersionInstallAndUpdateActionsIfNeeded(
     // First time activating extension, show walkthrough
     vscode.commands.executeCommand(
       "workbench.action.openWalkthrough",
-      `${extension.id}#welcomeWalkthrough`
+      "lastmile-ai.vscode-aiconfig#welcomeWalkthrough"
     );
   } else if (
     currExtensionVersion > lastActivatedVersion


### PR DESCRIPTION
Hard-code extension id for opening walkthrough

This flow is being triggered and Tanya is opening the main `Help:Welcome` page, but this isn't opening our specific walktrough for Tanya when she's testing for some reason. HOpefully hardcoding this fixes it

## Test Plan

https://github.com/lastmile-ai/aiconfig/assets/151060367/0d392d07-8e2c-40a5-92b9-832fae7107c1
