### PR TITLE
[editor] Fix Readonly Rendering of Undefined Model Settings

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/JSONRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/JSONRenderer.tsx
@@ -16,12 +16,27 @@ export default memo(function JSONRenderer({
   schema,
 }: Props) {
   const { readOnly } = useContext(AIConfigContext);
-  // Prism is a read only renderer.
-  return !onChange || readOnly ? (
-    <Prism language="json" styles={{ code: { textWrap: "pretty" } }}>
-      {JSON.stringify(content, null, 2)}
-    </Prism>
-  ) : (
-    <JSONEditor content={content} onChangeContent={onChange} schema={schema} />
-  );
+  let renderer = null;
+
+  if (!onChange || readOnly) {
+    if (content != null) {
+      // Prism is a read only renderer, but requires a string input. Just render
+      // null if the content is empty in readonly
+      renderer = (
+        <Prism language="json" styles={{ code: { textWrap: "pretty" } }}>
+          {JSON.stringify(content, null, 2)}
+        </Prism>
+      );
+    }
+  } else {
+    renderer = (
+      <JSONEditor
+        content={content}
+        onChangeContent={onChange}
+        schema={schema}
+      />
+    );
+  }
+
+  return renderer;
 });


### PR DESCRIPTION
# [editor] Fix Readonly Rendering of Undefined Model Settings

Currently when rendering the editor in readonly, opening the model settings for a prompt which has no metadata and which has no prompt schema, results in a js/render error:
![Screenshot 2024-02-26 at 2 54 14 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/ca6bdc9e-2218-46cc-92a5-ee069aee642a)
![Screenshot 2024-02-26 at 2 54 32 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/d3ae77a5-9b94-4c9e-ae5a-e5437f2044d8)

This is actually the problem Zak surfaced for the vscode doc of a blank screen when opening the settings for an aiconfig in vscode.

The problem is that Prism expects the contents to be a string, which obviously isn't the case if there is no metadata (it's undefined). To fix, just don't render anything in this specific scenario.

## Testing:
- Make sure rendering in and out of readonly works:
![Screenshot 2024-02-26 at 2 52 00 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/54318593-7145-4be3-b8bb-86cf9a0bd613)
![Screenshot 2024-02-26 at 2 52 20 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/e3bad205-b92a-4a05-bc10-42fb993e488e)

