### PR TITLE
[vscode] Bump aiconfig-editor Package to 0.2.3

### DIFF
--- a/vscode-extension/editor/package.json
+++ b/vscode-extension/editor/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^5.7.0",
     "@emotion/react": "^11.11.1",
-    "@lastmileai/aiconfig-editor": "^0.2.2",
+    "@lastmileai/aiconfig-editor": "^0.2.3",
     "@mantine/carousel": "^6.0.7",
     "@mantine/core": "^6.0.7",
     "@mantine/dates": "^6.0.16",

--- a/vscode-extension/editor/yarn.lock
+++ b/vscode-extension/editor/yarn.lock
@@ -1780,10 +1780,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lastmileai/aiconfig-editor@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.2.tgz#7009f357ede540192949e1f020d2dd48482bff03"
-  integrity sha512-wO0eJU41pmxKqPy2/sm8/1+JMstVce4zgedpdsECWgKjoULzusJHBWYG1t7XXDJC3zm9cPKz4zJi5TgiNpADOg==
+"@lastmileai/aiconfig-editor@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.3.tgz#26da8117294decaf94599d02ab260ac3f080c10b"
+  integrity sha512-vkEt50NMe93AOR69vr3U89J2WLIvf+mKCaB/nfYOMnBwX3WQ+BKLcendHuFCopTpa7BdYQnnvOQJW3HfAv39/g==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@mantine/carousel" "^6.0.7"


### PR DESCRIPTION
# [vscode] Bump aiconfig-editor Package to 0.2.3

Includes:
- Fix readonly rendering for undefined model settings w/ no schema (#1358)
- Gemini prompt schema (#1023)
