### PR TITLE
[vscode] Add 'Manual Fix' Message when Installing Dependencies fails

### DIFF
--- a/vscode-extension/src/utilities/pythonSetupUtils.ts
+++ b/vscode-extension/src/utilities/pythonSetupUtils.ts
@@ -178,19 +178,32 @@ export async function installRequirements(
         console.log(`pip install process exited with code ${code}`);
         vscode.window
           .showErrorMessage(
-            `Failed to install dependencies. Pip exited with code ${code}. Please try again later`,
-            ...["Select Interpreter", "Retry Install Dependencies"]
+            `Failed to install dependencies. Pip exited with code ${code}. Please try again later\n`,
+            ...["Change Interpreter", "Retry", "Fix Manually"]
           )
           .then((selection) => {
-            if (selection === "Retry Install Dependencies") {
+            if (selection === "Retry") {
               installRequirements(
                 context,
                 progress,
                 cancellationToken,
                 outputChannel
               );
-            } else if (selection === "Select Interpreter") {
+            } else if (selection === "Change Interpreter") {
               vscode.commands.executeCommand(COMMANDS.INIT);
+            } else if (selection === "Fix Manually") {
+              vscode.window
+                .showInformationMessage(
+                  "Try installing 'python-aiconfig' package manually using the command pip3 install python-aiconfig in your terminal/shell.",
+                  ...["Copy command to Clipboard"]
+                )
+                .then((selection) => {
+                  if (selection === "Copy command to Clipboard") {
+                    vscode.env.clipboard.writeText(
+                      "pip3 install python-aiconfig"
+                    );
+                  }
+                });
             }
           });
         resolve(false);


### PR DESCRIPTION
[vscode] Add 'Manual Fix' Message when Installing Dependencies fails

This diff modifies the Information Message that is shown when Installing Dependencies fails.

- Add a Fix Manually which then shows the user a command to pip install, that they can copy to clipboard
- Rename:
- - `Retry Install Dependencies` -> `Retry`
- - `Select Interpreter` -> `Change Interpreter`

## Testplan

Manually Modified the Pip Install spawn process to run `const pipInstall = spawn("sh", ["-c", "exit 1"]);` which will  automatically exit with error.

https://github.com/lastmile-ai/aiconfig/assets/141073967/6a7b8d6f-5d26-40c6-9696-235e713fed93

RFC: Wording =)
