### PR TITLE
[vscode] Enable Find Widget in Editor

### DIFF
--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -36,7 +36,12 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
     );
     const providerRegistration = vscode.window.registerCustomEditorProvider(
       AIConfigEditorProvider.viewType,
-      provider
+      provider,
+      {
+        webviewOptions: {
+          enableFindWidget: true,
+        },
+      }
     );
     return providerRegistration;
   }


### PR DESCRIPTION
# [vscode] Enable Find Widget in Editor

Enable the find widget in our custom editor using the `enabledFindWidget` option when registering our custom editor provider. The default is false. In our case, setting to true works since it's just a regular text search in the DOM elements.

https://code.visualstudio.com/api/references/vscode-api#WebviewPanelOptions


https://github.com/lastmile-ai/aiconfig/assets/5060851/0a9d4c4d-af90-4cb0-8c1b-8ef9258dc657


