### PR TITLE
[docs] fixed duplication on extension readme

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -12,8 +12,6 @@ The prompts and model settings get saved in a `.aiconfig.yaml` or `.aiconfig.jso
 
 [**Demo Video**](https://github.com/lastmile-ai/aiconfig/assets/25641935/a790d650-e7be-4b1b-8b99-d5854dda4ac6)
 
-![DemoVideo](https://github.com/lastmile-ai/aiconfig/assets/25641935/a790d650-e7be-4b1b-8b99-d5854dda4ac6)
-
 ### Getting Started
 
 #### First use


### PR DESCRIPTION
Small fix on readme that removed duplication for the video

## Before Change:
![image](https://github.com/lastmile-ai/aiconfig/assets/48507154/cb0bf5c0-1b64-4e08-88d1-e7897907d2fe)

## After Change: 
![image](https://github.com/lastmile-ai/aiconfig/assets/48507154/afe852f1-b2a1-41a4-a3a6-db9e7e1ef811)
