### PR TITLE
1/n [vscode & server] Reload Environment when invoking the Run Step

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import ctypes
+import dotenv
 import json
 import logging
 import threading
@@ -330,6 +331,11 @@ def run() -> FlaskResponse:
         "callback_manager": True,
     }
     state = get_server_state(app)
+
+    # Allow user to modify their environment keys without reloading the server.
+    # Execution time of `0.001s` is arbitrary, but should be small enough to not be noticeable.
+    dotenv.load_dotenv()
+
     aiconfig = state.aiconfig
     request_json = request.get_json()
     cancellation_token_id: str | None = None


### PR DESCRIPTION
1/n [vscode & server] Reload Environment when invoking the Run Step

This diff modifies the AIConfig backend server to reload the environment everytime the Run Step is invoked. This will allow api keys that are newly added to be picked up from the aiconfig server, without the need to restart the server.

I validated that `load_dotenv` does not add any noticeable latency.
```
import time
import dotenv

start = time.time()
dotenv.load_dotenv()
end = time.time()
print(end-start)
_____
0.0010402202606201172s
```

Surfaced from #1371, a restart of the server will no longer be required.

Ontop of this, we can pass a .env path directly the server initialization, instead of relying on a set of lowest-common-ancestor checks

Discussed offline with @saqadri

## Testplan

https://github.com/lastmile-ai/aiconfig/assets/141073967/c67cbb5c-785a-40b4-9aac-6cccfaff0004
