### PR TITLE
[vscode] Treat Autosaves as an internalDocumentChange

### DIFF
--- a/vscode-extension/src/aiConfigEditor.ts
+++ b/vscode-extension/src/aiConfigEditor.ts
@@ -308,6 +308,9 @@ export class AIConfigEditorProvider implements vscode.CustomTextEditorProvider {
                   console.log(
                     `${e.document.fileName}: willSaveDocument - creating textedit`
                   );
+                  // Treat this as internal change so that we skip handling it in onDidChangeTextDocument
+                  // The client should already match the server state, so we don't need to update the webview
+                  isInternalDocumentChange = true;
                   resolve([
                     vscode.TextEdit.replace(
                       new vscode.Range(0, 0, e.document.lineCount, 0),


### PR DESCRIPTION
# [vscode] Treat Autosaves as an internalDocumentChange

Currently, turning on autosave with default 1000ms delay causes a ton of buggy behaviour in the editor webview:
- typing can lose focus from the input
- execution gets cut off and outputs lost


https://github.com/lastmile-ai/aiconfig/assets/5060851/56123039-2245-4b6b-81ce-24b6c26ac0d1



The cause of this behaviour is that we subscribe to the document save event, obtaining the config contents from the server and propagating the change to the TextDocument. However, this change the the TextDocument is resulting in our `onDidChangeTextDocument` event firing and updating the webview (as well as pushing update back to the sever state). The result is that our webview has a new `aiconfig` value passed as prop to the editor and does a full re-render of the editor.

To fix, we should simply treat this save scenario as an `internalDocumentChange` event, which will then be skipped within the `onDidChangeTextDocument` listener. This should be safe since:
- server state is source of truth
- webview state should match server
- saving loads the state from the server, so pushing it back to the client webview (and server) is entirely redundant

Now, no issues:

https://github.com/lastmile-ai/aiconfig/assets/5060851/a0e8055a-84bf-4fff-abdb-3e439deed6b7


