### PR TITLE
[server] 2/n Add env path to Server State

### DIFF
--- a/python/src/aiconfig/editor/server/server_utils.py
+++ b/python/src/aiconfig/editor/server/server_utils.py
@@ -102,6 +102,7 @@ class ServerState:
     aiconfigrc_path: str = os.path.join(os.path.expanduser("~"), ".aiconfigrc")
     aiconfig: AIConfigRuntime | None = None
     events: dict[str, Event] = field(default_factory=dict)
+    env_file_path: str | None = None
 
 
 class AIConfigRC(core_utils.Record):


### PR DESCRIPTION
[server] 2/n Add env path to Server State

Summary:

Stack contains changes that updates overall environment setup flow for vscode extension.

No functional Changes in this diff.

Test Plan:

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1382).
* #1384
* #1383
* __->__ #1382