### PR TITLE
[server] 3/n Endpoint for set_env

### DIFF
--- a/python/src/aiconfig/editor/server/server_utils.py
+++ b/python/src/aiconfig/editor/server/server_utils.py
@@ -102,6 +102,7 @@ class ServerState:
     aiconfigrc_path: str = os.path.join(os.path.expanduser("~"), ".aiconfigrc")
     aiconfig: AIConfigRuntime | None = None
     events: dict[str, Event] = field(default_factory=dict)
+    env_file_path: str | None = None
 
 
 class AIConfigRC(core_utils.Record):


### PR DESCRIPTION
[server] 3/n Endpoint for set_env

Summary:

Stack contains changes that updates overall environment setup flow for vscode extension.

This diff implements the server side endpoint. Will test on top with vscode

Test Plan:
```
payload={'env_file_path': {}}
Status Code: 400
Response JSON: {'message': 'Invalid request, specified .env file path is not a string.'}

payload={'env_file_path': '/hi'}
Status Code: 400
Response JSON: {'message': 'Specified .env file path does not exist.'}

payload={'env_file_path': '.env'}
Status Code: 200
Response JSON: {'message': 'Updated .env file path.'}
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1383).
* #1384
* __->__ #1383
* #1382