### PR TITLE
[ez] Specify content type in Share request based on JSON vs. YAML document

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -26,6 +26,7 @@ import {
   SUPPORTED_FILE_EXTENSIONS,
   setupEnvironmentVariables,
   getConfigurationTarget,
+  getModeFromDocument,
 } from "./util";
 import {
   initialize,
@@ -495,17 +496,13 @@ async function shareAIConfig(
   const fileName: string = activeEditor.document.fileName;
   const sanitizedFileName: string = sanitizeFileName(fileName);
 
-  // TODO: Add back once CORS is resolved
-  // const policyResponse = await fetch(
-  //   "https://lastmileai.dev/api/upload/publicpolicy"
-  // );
-  // const policy = await policyResponse.json();
   const uploadUrl = "https://s3.amazonaws.com/lastmileai.aiconfig.public/";
   const randomPath = Math.round(Math.random() * 10000);
   const uploadKey: string = `aiconfigs/${getTodayDateString()}/${randomPath}/${sanitizedFileName}`;
-
-  // TODO: Will also need to check for yaml files and change the contentType accordingly
-  const contentType = "application/json";
+  const contentType =
+    getModeFromDocument(activeEditor.document) === "json"
+      ? "application/json"
+      : "application/yaml";
 
   const formData = new FormData();
   formData.append("key", uploadKey);


### PR DESCRIPTION
[ez] Specify content type in Share request based on JSON vs. YAML document

TSIA, Sarmad aded change to render it correctly in the lastmile repo (https://github.com/lastmile-ai/lastmile/pull/1380), but still should be changing the content type now:

## Test Plan

It actually still works before, not sure if content-type is a blocker. But just good to specify I guess

https://github.com/lastmile-ai/aiconfig/assets/151060367/4f7e6c8f-7198-45a9-b92c-43560ff5ba0d
