### PR TITLE
[server] 5/n Update AIConfig edit|start commands to pass env

### DIFF
--- a/python/src/aiconfig/editor/server/server_utils.py
+++ b/python/src/aiconfig/editor/server/server_utils.py
@@ -10,7 +10,7 @@ from enum import Enum
 from textwrap import dedent
 from threading import Event
 from types import ModuleType
-from typing import Any, Callable, NewType, Type, TypeVar, cast
+from typing import Any, Callable, NewType, Type, TypeVar, cast, Optional
 
 import lastmile_utils.lib.core.api as core_utils
 import result
@@ -66,6 +66,7 @@ class EditServerConfig(core_utils.Record):
     log_level: str | int = "INFO"
     server_mode: ServerMode = ServerMode.PROD
     parsers_module_path: str = "aiconfig_model_registry.py"
+    env_file_path: Optional[str] = None
 
     @field_validator("server_mode", mode="before")
     def convert_to_mode(
@@ -84,6 +85,7 @@ class StartServerConfig(core_utils.Record):
     log_level: str | int = "INFO"
     server_mode: ServerMode = ServerMode.PROD
     parsers_module_path: str = "aiconfig_model_registry.py"
+    env_file_path: Optional[str] = None
 
     @field_validator("server_mode", mode="before")
     def convert_to_mode(
@@ -294,13 +296,12 @@ def init_server_state(
     aiconfigrc_path: str,
 ) -> Result[None, str]:
     LOGGER.info("Initializing server state for 'edit' command")
-    # TODO: saqadri - load specific .env file if specified
-    dotenv.load_dotenv()
     _load_user_parser_module_if_exists(
         initialization_settings.parsers_module_path
     )
     state = get_server_state(app)
     state.aiconfigrc_path = aiconfigrc_path
+    state.env_file_path = initialization_settings.env_file_path
 
     if isinstance(initialization_settings, StartServerConfig):
         # The aiconfig will be loaded later, when the editor sends the payload.


### PR DESCRIPTION
[server] 5/n Update AIConfig edit|start commands to pass env

Summary:

This diff modifies the AIConfig start and edit commands to take in an dot env path.

Due to core utils logic of handling args, the help messages automatically get updated too.

Also Removes the loadenv() on server init. This is okay because loadenv is invoked at the run step. [see 4/n](https://github.com/lastmile-ai/aiconfig/pull/1384)

Test Plan:

```
ankush@ap-mbp aiconfig % aiconfig start -h
/opt/homebrew/lib/python3.11/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_parsers" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
usage: aiconfig start [-h] [--server-port SERVER_PORT] [--log-level LOG_LEVEL] [--server-mode {debug_servers,debug_backend,prod}] [--parsers-module-path PARSERS_MODULE_PATH] [--env-file-path ENV_FILE_PATH]

options:
  -h, --help            show this help message and exit
  --server-port SERVER_PORT
  --log-level LOG_LEVEL
  --server-mode {debug_servers,debug_backend,prod}
  --parsers-module-path PARSERS_MODULE_PATH
  **--env-file-path ENV_FILE_PATH**
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1389).
* #1398
* #1390
* #1387
* __->__ #1389