### PR TITLE
[ez] vscode extension - fix diff editor

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -128,7 +128,7 @@
     },
     "configurationDefaults": {
       "workbench.editorAssociations": {
-        "{git,gitlens,sapling-diff}:/**/*.{aiconfig.json, aiconfig.yaml}": "default"
+        "{git,gitlens,sapling-diff}:/**/*.{aiconfig,aiconfig.json,aiconfig.yaml}": "default"
       },
       "workbench.editor.untitled.labelFormat": "name"
     },


### PR DESCRIPTION
[ez] vscode extension - fix diff editor

The bug is a simple spacebar between`aiconfig.json,<SPACE>aiconfig.yaml`. This affects the regex used to apply the editor association.

Tested that now opening both aiconfig.yaml and aiconfig.json files in diff editor open them in regular text editor.

For good measure, also added support for *.aiconfig files, and tested that too.
