### PR TITLE
Render Attachment before Data When Both Exist in Input

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputSchemaRenderer.tsx
@@ -45,18 +45,18 @@ function SchemaRenderer({ input, schema, onChangeInput }: SchemaRendererProps) {
 
   return (
     <Flex direction="column">
-      {dataSchema && (
-        <DataRenderer
-          schema={dataSchema}
-          data={data}
-          onChangeData={onChangeData}
-        />
-      )}
       {attachmentsSchema && (
         <AttachmentsRenderer
           schema={attachmentsSchema}
           onChangeAttachments={onChangeAttachments}
           attachments={attachments ?? []}
+        />
+      )}
+      {dataSchema && (
+        <DataRenderer
+          schema={dataSchema}
+          data={data}
+          onChangeData={onChangeData}
         />
       )}
       {/* <JSONRenderer properties={restProperties} data={restData}/> */}

--- a/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceVisualQuestionAnsweringRemoteInferencePromptSchema.ts
+++ b/python/src/aiconfig/editor/client/src/shared/prompt_schemas/HuggingFaceVisualQuestionAnsweringRemoteInferencePromptSchema.ts
@@ -1,0 +1,42 @@
+import { PromptSchema } from "../../utils/promptUtils";
+
+export const HuggingFaceVisualQuestionAnsweringRemoteInferencePromptSchema: PromptSchema =
+  {
+    // See https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/inference/_client.py#L1780 for supported params.
+    // The settings below are supported settings specified in the HuggingFaceVisualQuestionAnsweringRemoteInference refine_completion_params implementation.
+    input: {
+      type: "object",
+      required: ["attachments", "data"],
+      properties: {
+        attachments: {
+          type: "array",
+          items: {
+            type: "attachment",
+            required: ["data"],
+            mime_types: ["image/*"],
+            properties: {
+              data: {
+                type: "string",
+              },
+            },
+          },
+          max_items: 1,
+        },
+        data: {
+          // The question to ask about the image
+          type: "string",
+        },
+      },
+    },
+    model_settings: {
+      type: "object",
+      properties: {
+        model: {
+          type: "string",
+          description: `Hugging Face model to use. Can be a model ID hosted on the Hugging Face Hub or a URL 
+        to a deployed Inference Endpoint`,
+          default: "dandelin/vilt-b32-finetuned-vqa",
+        },
+      },
+    },
+  };

--- a/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
+++ b/python/src/aiconfig/editor/client/src/utils/promptUtils.ts
@@ -22,9 +22,9 @@ import { HuggingFaceTextGenerationRemoteInferencePromptSchema } from "../shared/
 import { HuggingFaceTextSummarizationRemoteInferencePromptSchema } from "../shared/prompt_schemas/HuggingFaceTextSummarizationRemoteInferencePromptSchema";
 import { HuggingFaceTextTranslationRemoteInferencePromptSchema } from "../shared/prompt_schemas/HuggingFaceTextTranslationRemoteInferencePromptSchema";
 import { HuggingFaceImage2TextRemoteInferencePromptSchema } from "../shared/prompt_schemas/HuggingFaceImage2TextRemoteInferencePromptSchema";
+import { HuggingFaceVisualQuestionAnsweringRemoteInferencePromptSchema } from "../shared/prompt_schemas/HuggingFaceVisualQuestionAnsweringRemoteInferencePromptSchema";
 import { ClaudeBedrockPromptSchema } from "../shared/prompt_schemas/ClaudeBedrockPromptSchema";
 import { HuggingFaceConversationalRemoteInferencePromptSchema } from "../shared/prompt_schemas/HuggingFaceConversationalRemoteInferencePromptSchema";
-
 
 /**
  * Get the name of the model for the specified prompt. The name will either be specified in the prompt's
@@ -117,6 +117,9 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   HuggingFaceTextTranslationRemoteInference:
     HuggingFaceTextTranslationRemoteInferencePromptSchema,
 
+  HuggingFaceVisualQuestionAnsweringRemoteInference:
+    HuggingFaceVisualQuestionAnsweringRemoteInferencePromptSchema,
+
   // PaLMTextParser
   "models/text-bison-001": PaLMTextParserPromptSchema,
 
@@ -162,6 +165,8 @@ export const PROMPT_SCHEMAS: Record<string, PromptSchema> = {
   Summarization: HuggingFaceTextSummarizationRemoteInferencePromptSchema,
   Translation: HuggingFaceTextTranslationRemoteInferencePromptSchema,
   Conversational: HuggingFaceConversationalRemoteInferencePromptSchema,
+  "Visual Question Answering":
+    HuggingFaceVisualQuestionAnsweringRemoteInferencePromptSchema,
 
   "Automatic Speech Recognition (Local)":
     HuggingFaceAutomaticSpeechRecognitionPromptSchema,


### PR DESCRIPTION
# Render Attachment before Data When Both Exist in Input

See comment in https://github.com/lastmile-ai/aiconfig/pull/1396#pullrequestreview-1915432291

When we have a Prompt Input with both attachment and data, most likely the attachment will be the main focus (e.g. Visual Question Answering) so we can show it first in the prompt input:

![Screenshot 2024-03-04 at 5 08 17 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/40ec0a8d-9255-44b7-aebb-f0e46dee44aa)
![Screenshot 2024-03-04 at 5 08 44 PM](https://github.com/lastmile-ai/aiconfig/assets/5060851/9568cae3-e48f-4a1d-a608-e011234c83b4)

Was initially thinking we could order it based on the properties order in the schema, but just doing this for now since property order in schema may not be guaranteed when we define it in python and then serialize it to to client (will just be passing JSON object in response)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1397).
* __->__ #1397
* #1396