### PR TITLE
9/n Server init env file Validation

### DIFF
--- a/python/src/aiconfig/editor/server/server.py
+++ b/python/src/aiconfig/editor/server/server.py
@@ -38,6 +38,7 @@ from aiconfig.editor.server.server_utils import (
     run_aiconfig_operation_with_request_json,
     safe_load_from_disk,
     safe_run_aiconfig_static_method,
+    validate_env_file_path,
 )
 from aiconfig.model_parser import InferenceOptions
 from aiconfig.registry import ModelParserRegistry
@@ -848,40 +849,13 @@ def set_env_path() -> FlaskResponse:
     # Validate
     request_env_path = request_json.get("env_file_path")
     
-    if request_env_path is None:
-        return FlaskResponse(({"message": "No .env file path provided."}, 400))
+    env_file_path_is_valid, message = validate_env_file_path(request_env_path)
 
-    if not isinstance(request_env_path, str):
+    if not env_file_path_is_valid:
         return FlaskResponse(
             (
                 {
-                    "message": "Invalid request, specified .env file path is not a string."
-                },
-                400,
-            )
-        )
-
-    # Check if path exists / is accessible
-    path_exists = os.path.exists(request_env_path)
-
-    # Check if filename format is correct
-    filename_format_correct = request_env_path.endswith(".env")
-
-    if filename_format_correct is False:
-        return FlaskResponse(
-            (
-                {
-                    "message": "Specified env file path is not a .env file.",
-                },
-                400,
-            )
-        )
-
-    if path_exists is False:
-        return FlaskResponse(
-            (
-                {
-                    "message": "Specified .env file path does not exist.",
+                    "message": f'Invalid request, {message}: {request_env_path}',
                 },
                 400,
             )

--- a/python/src/aiconfig/editor/server/server_utils.py
+++ b/python/src/aiconfig/editor/server/server_utils.py
@@ -10,7 +10,7 @@ from enum import Enum
 from textwrap import dedent
 from threading import Event
 from types import ModuleType
-from typing import Any, Callable, NewType, Type, TypeVar, cast, Optional
+from typing import Any, Callable, NewType, Type, TypeVar, cast, Optional, Tuple
 
 import lastmile_utils.lib.core.api as core_utils
 import result
@@ -301,7 +301,11 @@ def init_server_state(
     )
     state = get_server_state(app)
     state.aiconfigrc_path = aiconfigrc_path
-    state.env_file_path = initialization_settings.env_file_path
+    env_file_path_is_valid, message = validate_env_file_path(initialization_settings.env_file_path)
+    if not env_file_path_is_valid:
+        LOGGER.warning(f"{message}: '{initialization_settings.env_file_path}'")
+    else:
+        state.env_file_path = initialization_settings.env_file_path
 
     if isinstance(initialization_settings, StartServerConfig):
         # The aiconfig will be loaded later, when the editor sends the payload.
@@ -501,3 +505,29 @@ def run_aiconfig_operation_with_request_json(
                 code=400,
                 aiconfig=None,
             ).to_flask_format()
+
+def validate_env_file_path(request_env_path: str | None | Any) -> Tuple[bool, str]:
+    """
+    Validates the given env file path. If its not valid, returns a tuple of (False, str) with a message.
+
+    Returns: (bool, str)
+    """
+    if request_env_path is None:
+        return False, "No .env file path provided"
+
+    if not isinstance(request_env_path, str):
+        return False, "Specified .env file path is not a string"
+
+    # Check if path exists / is accessible
+    path_exists = os.path.exists(request_env_path)
+
+    if path_exists is False:
+        return False, "Specified .env file path does not exist"
+
+    # Check if filename format is correct
+    filename_format_correct = request_env_path.endswith(".env")
+
+    if filename_format_correct is False:
+        return False, "Specified env file path is not a .env file"
+    
+    return True, f".env file path {request_env_path} is valid"


### PR DESCRIPTION
9/n Server init env file Validation

Summary:

- Refactored Env File Validation to a helper method
- Added env file validation to aiconfig server start. Does not block on an invalid file, and instead logs error message

Test Plan:

```
aiconfig edit --env-file-path=testfiledoesntexist
[WARNING] 2024-03-06 11:59:44,800 server_utils.py:306: Specified env file path is not a .env file: 'testfiledoesntexist'
```
```
aiconfig edit --env-file-path=testfiledoesntexist.env
[WARNING] 2024-03-06 12:00:13,063 server_utils.py:306: Specified .env file path does not exist: 'testfiledoesntexist.env'
```
Note: while testing I noticed that argparse handles no argument passed as an empty string.

## Dependencies

* __->__ #1404
* #1398
