### PR TITLE
Fix Tests Marked as xfail

### DIFF
--- a/python/tests/parsers/test_openai_util.py
+++ b/python/tests/parsers/test_openai_util.py
@@ -46,11 +46,11 @@ def test_refine_chat_completion_params():
     assert "random_attribute" not in refined_params
     assert refined_params["n"] == "3"
 
-@pytest.mark.xfail
+
 @pytest.mark.asyncio
 async def test_get_output_text(set_temporary_env_vars):
     with patch.object(
-        openai.chat.completions,
+        openai.resources.chat.Completions,
         "create",
         side_effect=mock_openai_chat_completion,
     ):

--- a/python/tests/test_run_config.py
+++ b/python/tests/test_run_config.py
@@ -6,7 +6,7 @@ from mock import patch
 from .conftest import mock_openai_chat_completion
 from .util.file_path_utils import get_absolute_file_path_from_relative
 
-@pytest.mark.xfail
+
 @pytest.mark.asyncio
 async def test_load_parametrized_data_config(set_temporary_env_vars):
     """Test loading a parametrized data config and resolving it
@@ -14,7 +14,7 @@ async def test_load_parametrized_data_config(set_temporary_env_vars):
     Config has 2 prompts. Prompt2 uses prompt1.output in its input.
     """
     with patch.object(
-        openai.chat.completions,
+        openai.resources.chat.Completions,
         "create",
         side_effect=mock_openai_chat_completion,
     ):


### PR DESCRIPTION
Fix Tests Marked as xfail

# Fix Tests Marked as xfail
These were marked as `xfail` in https://github.com/lastmile-ai/aiconfig/pull/999 as part of the parser refactor. I noticed in https://github.com/openai/openai-python/issues/715#issuecomment-1809203346 that applying the patch to `openai.resources.chat.Completions.create` seems to fix the tests

Test Plan:
```
(aiconfig) ryanholinshead@Ryans-MBP python % pytest tests/parsers/test_openai_util.py
========================================================== test session starts ===========================================================
platform darwin -- Python 3.12.1, pytest-7.4.3, pluggy-1.4.0
rootdir: /Users/ryanholinshead/Projects/aiconfig/python
plugins: asyncio-0.23.5, hypothesis-6.91.0, cov-4.1.0, mock-3.12.0, anyio-4.2.0
asyncio: mode=Mode.STRICT
collected 3 items

tests/parsers/test_openai_util.py ...                                                                                              [100%]
===================================================== 3 passed, 10 warnings in 0.50s =====================================================
```

```
(aiconfig) ryanholinshead@Ryans-MBP python % pytest tests/test_run_config.py
========================================================== test session starts ===========================================================
platform darwin -- Python 3.12.1, pytest-7.4.3, pluggy-1.4.0
rootdir: /Users/ryanholinshead/Projects/aiconfig/python
plugins: asyncio-0.23.5, hypothesis-6.91.0, cov-4.1.0, mock-3.12.0, anyio-4.2.0
asyncio: mode=Mode.STRICT
collected 1 item

tests/test_run_config.py .
===================================================== 1 passed, 10 warnings in 0.50s =====================================================
```
