### PR TITLE
Update openai to 1.13.3

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,7 +12,7 @@ lastmile-utils==0.0.23
 mock
 nest_asyncio
 nltk
-openai >= 1.0.0, < 1.5
+openai >= 1.13.3
 prompt_toolkit
 pybars3
 pydantic>=2.1


### PR DESCRIPTION
Update openai to 1.13.3

# Update openai to 1.13.3


Summary:
Updating the openai version to latest (1.13.3) so that we can use the image messages for gpt-4-v in the next PR

Test Plan:
- pytest works without errors
- WIP: Testing all relevant cookbooks

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1415).
* #1419
* #1418
* #1417
* #1416
* __->__ #1415