### PR TITLE
[docs] Remove caution text from Gradio Notebooks Getting Started for incompatible SDK version

### DIFF
--- a/aiconfig-docs/docs/gradio-notebook.md
+++ b/aiconfig-docs/docs/gradio-notebook.md
@@ -152,10 +152,6 @@ Duplicate the [Gradio Notebook Quickstart Space](https://huggingface.co/spaces/l
   - [app.py](https://huggingface.co/spaces/lastmileai/gradio-notebook-template/blob/main/app.py)
   - [requirements.txt](https://huggingface.co/spaces/lastmileai/gradio-notebook-template/blob/main/requirements.txt)
 
-:::caution
-Please ensure the `sdk_version` in your Space's `README.md` is set to `sdk_version: 4.16.0` or lower due to compatibilty issues in higher `gradio` package versions. See https://huggingface.co/spaces/lastmileai/gradio-notebook-template/blob/main/README.md for example.
-:::
-
 ### 2. Design your Space
 
 Use the Gradio Notebook UI in your Space to set up models and prompts.


### PR DESCRIPTION
[docs] Remove caution text from Gradio Notebooks Getting Started for incompatible SDK version

This is now resolved with https://github.com/lastmile-ai/gradio-notebook/pull/199 so we don't need this restriction anymore!

## Before

<img width="898" alt="Screenshot 2024-03-08 at 15 34 54" src="https://github.com/lastmile-ai/aiconfig/assets/151060367/457cbe30-1d00-41f9-8a10-2ab420001e37">
