### PR TITLE
[vscode] add session id to telemetry

### DIFF
--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -31,6 +31,8 @@ import { VSCODE_THEME } from "./VSCodeTheme";
 // TODO: Update package to export AIConfigEditorNotification and ThemeMode types
 import { AIConfigEditorNotification } from "@lastmileai/aiconfig-editor/dist/components/notifications/NotificationProvider";
 import { ThemeMode } from "@lastmileai/aiconfig-editor/dist/shared/types";
+import {v4 as uuidv4} from "uuid";
+
 
 const useStyles = createStyles(() => ({
   editorBackground: {
@@ -175,6 +177,7 @@ export default function VSCodeEditor() {
     );
 
     const enableTelemetry = res.allow_usage_data_sharing;
+    const sessionId: string = uuidv4();
 
     if (enableTelemetry) {
       datadogLogs.init({
@@ -187,6 +190,7 @@ export default function VSCodeEditor() {
       });
 
       datadogLogs.setGlobalContextProperty("mode", MODE);
+      datadogLogs.setGlobalContextProperty("session_id_internal", sessionId);
     }
   }, [aiConfigServerUrl]);
 


### PR DESCRIPTION
[vscode] add session id to telemetry

Summary:

in an effort to understand distinct session users, this diff adds a unique session identifier to telemetry.

Unfortunately, it looks like the "default" sessionID that comes with datadog browser telemetry is not being sent, similar to what we noticed with [gradio](https://github.com/lastmile-ai/gradio-notebook/pull/184). Hence the need to define this explicitly

Note: This does not collect new metrics. This will allow for the LastMile team to understand how many users are using our vscode extension.

Test Plan:
