### PR TITLE
[vscode] Fix package.json path parsing issue

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -10,7 +10,7 @@
   "engines": {
     "vscode": "^1.85.0"
   },
-  "icon": "./static/Logo.png",
+  "icon": "static/Logo.png",
   "categories": [
     "Other"
   ],


### PR DESCRIPTION
[vscode] Fix package.json path parsing issue

Summary:

Ran into trouble when attempting to package the vscode extension due to errors parsing the logo path.

Running `vsce package` locally resulted in the following error:

` ERROR  The specified icon 'extension/./static/Logo.png' wasn't found in the extension.`

This diff attempts to fix that.

Test Plan:

`vsce package` and installed locally

<img width="233" alt="Screenshot 2024-03-11 at 1 40 27 PM" src="https://github.com/lastmile-ai/aiconfig/assets/141073967/94830007-5c81-4bf5-8497-09274db09d01">

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1423).
* __->__ #1423
* #1422