### PR TITLE
Update getModels to Make Search String Optional

### DIFF
--- a/gradio-notebook/backend/gradio_notebook/templates/component/index.js
+++ b/gradio-notebook/backend/gradio_notebook/templates/component/index.js
@@ -42615,7 +42615,7 @@ const D1e = {
         ".actionTabsPanel": {
           width: "400px"
         },
-        ".parametersContainer": {
+        ".configMetadataContainer": {
           maxWidth: "1250px",
           maxHeight: "-webkit-fill-available",
           padding: "0",
@@ -42807,7 +42807,7 @@ const D1e = {
       borderTopColor: "var(--vscode-notebook-cellBorderColor)",
       marginBottom: "0.5em"
     },
-    ".parametersContainer": {
+    ".configMetadataContainer": {
       width: "100%",
       maxHeight: "-webkit-fill-available",
       margin: "16px auto",

--- a/python/src/aiconfig/editor/client/src/LocalEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/LocalEditor.tsx
@@ -37,7 +37,6 @@ const useStyles = createStyles(() => ({
   },
 }));
 
-
 const MODE = "local";
 
 export default function LocalEditor() {
@@ -75,7 +74,7 @@ export default function LocalEditor() {
         sessionSampleRate: 100,
       });
 
-      datadogLogs.setGlobalContextProperty('mode', MODE);
+      datadogLogs.setGlobalContextProperty("mode", MODE);
     }
   }, []);
 
@@ -91,7 +90,7 @@ export default function LocalEditor() {
     return res;
   }, []);
 
-  const getModels = useCallback(async (search: string) => {
+  const getModels = useCallback(async (search?: string) => {
     // For now, rely on caching and handle client-side search filtering
     // We will use server-side search filtering for Gradio
     const res = await ufetch.get(ROUTE_TABLE.LIST_MODELS);
@@ -289,11 +288,7 @@ export default function LocalEditor() {
           <Loader size="xl" />
         </Flex>
       ) : (
-        <AIConfigEditor
-          aiconfig={aiconfig}
-          callbacks={callbacks}
-          mode={MODE}
-        />
+        <AIConfigEditor aiconfig={aiconfig} callbacks={callbacks} mode={MODE} />
       )}
     </div>
   );

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -125,7 +125,7 @@ export type AIConfigCallbacks = {
   deletePrompt: (promptName: string) => Promise<void>;
   download?: () => Promise<void>;
   openInTextEditor?: () => Promise<void>;
-  getModels: (search: string) => Promise<string[]>;
+  getModels: (search?: string) => Promise<string[]>;
   getServerStatus?: () => Promise<{ status: "OK" | "ERROR" }>;
   logEventHandler?: (event: LogEvent, data?: LogEventData) => void;
   runPrompt: (

--- a/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
+++ b/python/src/aiconfig/editor/client/src/components/AIConfigEditor.tsx
@@ -44,7 +44,6 @@ import {
   getPrompt,
 } from "../utils/aiconfigStateUtils";
 import { debounce, uniqueId } from "lodash";
-import GlobalParametersContainer from "./GlobalParametersContainer";
 import AIConfigContext from "../contexts/AIConfigContext";
 import ConfigNameDescription from "./ConfigNameDescription";
 import {
@@ -66,6 +65,7 @@ import NotificationProvider, {
   AIConfigEditorNotification,
 } from "./notifications/NotificationProvider";
 import NotificationContext from "./notifications/NotificationContext";
+import ConfigMetadataContainer from "./global/ConfigMetadataContainer";
 
 type Props = {
   aiconfig: AIConfig;
@@ -1154,8 +1154,8 @@ function AIConfigEditorBase({
             setName={onSetName}
           />
         </div>
-        <GlobalParametersContainer
-          initialValue={aiconfigState?.metadata?.parameters ?? {}}
+        <ConfigMetadataContainer
+          metadata={aiconfigState?.metadata}
           onUpdateParameters={onUpdateGlobalParameters}
         />
         <PromptsContainer

--- a/python/src/aiconfig/editor/client/src/components/global/ConfigMetadataContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/global/ConfigMetadataContainer.tsx
@@ -1,43 +1,44 @@
 import { Accordion, Text, createStyles } from "@mantine/core";
 import { JSONObject } from "aiconfig";
 import { memo, useContext, useState } from "react";
-import ParametersRenderer from "./ParametersRenderer";
-import AIConfigContext from "../contexts/AIConfigContext";
-import { PROMPT_CELL_LEFT_MARGIN_PX } from "../utils/constants";
+import AIConfigContext from "../../contexts/AIConfigContext";
+import { PROMPT_CELL_LEFT_MARGIN_PX } from "../../utils/constants";
+import ParametersRenderer from "../ParametersRenderer";
 
 type Props = {
-  initialValue: JSONObject;
+  metadata: JSONObject;
   onUpdateParameters: (newParameters: JSONObject) => void;
 };
 
 const useStyles = createStyles(() => ({
-  parametersContainer: {
+  configMetadataContainer: {
     margin: `16px auto 16px ${PROMPT_CELL_LEFT_MARGIN_PX}px`,
   },
-  parametersContainerReadonly: {
+  configMetadataContainerReadonly: {
     margin: "16px auto",
   },
 }));
 
-export default memo(function GlobalParametersContainer({
-  initialValue,
+export default memo(function ConfigMetadataContainer({
+  metadata,
   onUpdateParameters,
 }: Props) {
-  const [isParametersDrawerOpen, setIsParametersDrawerOpen] = useState(false);
-
   const { classes } = useStyles();
   const { readOnly } = useContext(AIConfigContext);
+  const [openPanel, setOpenPanel] = useState<string | null>(null);
 
   return (
     // Set local and global classname. Global will override if specified
-    // Local is readonly or not. Global will always have parametersContainer class
-    // and if readonly, will also have parametersContainerReadonly class (to allow overrides)
+    // Local is readonly or not. Global will always have configMetadataContainer class
+    // and if readonly, will also have configMetadataContainerReadonly class (to allow overrides)
     <div
       className={`${
         readOnly
-          ? classes.parametersContainerReadonly
-          : classes.parametersContainer
-      } parametersContainer ${readOnly ? "parametersContainerReadonly" : ""}`}
+          ? classes.configMetadataContainerReadonly
+          : classes.configMetadataContainer
+      } configMetadataContainer ${
+        readOnly ? "configMetadataContainerReadonly" : ""
+      }`}
     >
       <Accordion
         styles={{
@@ -49,16 +50,16 @@ export default memo(function GlobalParametersContainer({
             fontSize: "0.85em",
           },
         }}
-        onChange={(value) => setIsParametersDrawerOpen(value === "parameters")}
+        onChange={(value) => setOpenPanel(value)}
       >
         <Accordion.Item value="parameters">
           <Accordion.Control>
             <Text color="blue">Global Parameters {"{}"}</Text>
           </Accordion.Control>
           <Accordion.Panel>
-            {isParametersDrawerOpen && (
+            {openPanel === "parameters" && (
               <ParametersRenderer
-                initialValue={initialValue}
+                initialValue={metadata?.parameters ?? {}}
                 onUpdateParameters={onUpdateParameters}
                 maxHeight="300px"
               />

--- a/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/AddPromptButton.tsx
@@ -14,7 +14,7 @@ import { PROMPT_CELL_LEFT_MARGIN_PX } from "../../utils/constants";
 
 type Props = {
   addPrompt: (prompt: string) => void;
-  getModels?: (search: string) => Promise<string[]>;
+  getModels?: (search?: string) => Promise<string[]>;
 };
 
 const useStyles = createStyles((theme) => ({
@@ -74,7 +74,7 @@ function ModelMenuItems({
 }
 
 export default memo(function AddPromptButton({ addPrompt, getModels }: Props) {
-  const [modelSearch, setModelSearch] = useState("");
+  const [modelSearch, setModelSearch] = useState<string | undefined>();
   const [isOpen, setIsOpen] = useState(false);
 
   const onAddPrompt = useCallback(
@@ -85,7 +85,7 @@ export default memo(function AddPromptButton({ addPrompt, getModels }: Props) {
     [addPrompt]
   );
 
-  const models = useLoadModels(modelSearch, getModels);
+  const models = useLoadModels(getModels, modelSearch);
   const { classes } = useStyles();
 
   return (

--- a/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/ModelSelector.tsx
@@ -8,7 +8,7 @@ import AIConfigContext from "../../contexts/AIConfigContext";
 
 type Props = {
   prompt: Prompt;
-  getModels?: (search: string) => Promise<string[]>;
+  getModels?: (search?: string) => Promise<string[]>;
   onSetModel: (model?: string) => void;
   defaultConfigModelName?: string;
 };
@@ -30,8 +30,8 @@ export default memo(function ModelSelector({
   );
 
   const models = useLoadModels(
-    showAll ? "" : autocompleteSearch ?? "",
-    getModels
+    getModels,
+    showAll ? undefined : autocompleteSearch
   );
 
   const onSelectModel = (model?: string) => {

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptContainer.tsx
@@ -15,7 +15,7 @@ import { debounce } from "lodash";
 type Props = {
   prompt: ClientPrompt;
   cancel?: (cancellationToken: string) => Promise<void>;
-  getModels?: (search: string) => Promise<string[]>;
+  getModels?: (search?: string) => Promise<string[]>;
   onChangePromptInput: (
     promptId: string,
     newPromptInput: AIConfigPromptInput

--- a/python/src/aiconfig/editor/client/src/components/prompt/PromptsContainer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/PromptsContainer.tsx
@@ -10,7 +10,7 @@ import { JSONObject, PromptInput } from "aiconfig";
 type Props = {
   cancelRunPrompt?: (cancellationToken: string) => Promise<void>;
   defaultModel?: string;
-  getModels?: (search: string) => Promise<string[]>;
+  getModels?: (search?: string) => Promise<string[]>;
   onAddPrompt: (promptIndex: number, model: string) => Promise<void>;
   onChangePromptInput: (
     promptId: string,

--- a/python/src/aiconfig/editor/client/src/hooks/useLoadModels.ts
+++ b/python/src/aiconfig/editor/client/src/hooks/useLoadModels.ts
@@ -3,15 +3,15 @@ import NotificationContext from "../components/notifications/NotificationContext
 import AIConfigContext from "../contexts/AIConfigContext";
 
 export default function useLoadModels(
-  modelSearch: string,
-  getModels?: (search: string) => Promise<string[]>
+  getModels?: (search?: string) => Promise<string[]>,
+  modelSearch?: string
 ) {
   const [models, setModels] = useState<string[]>([]);
   const { showNotification } = useContext(NotificationContext);
   const { readOnly } = useContext(AIConfigContext);
 
   const loadModels = useCallback(
-    async (modelSearch: string) => {
+    async (modelSearch?: string) => {
       if (!getModels || readOnly) {
         return;
       }

--- a/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/GradioTheme.ts
@@ -313,7 +313,7 @@ export const GRADIO_THEME: MantineThemeOverride = {
           width: "400px",
         },
 
-        ".parametersContainer": {
+        ".configMetadataContainer": {
           maxWidth: "1250px",
           maxHeight: "-webkit-fill-available",
           padding: "0",

--- a/python/src/aiconfig/editor/client/src/themes/LocalTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/LocalTheme.ts
@@ -107,7 +107,7 @@ export const LOCAL_THEME: MantineThemeOverride = {
       width: "400px",
     },
 
-    ".parametersContainer": {
+    ".configMetadataContainer": {
       maxWidth: "1250px",
       maxHeight: "-webkit-fill-available",
       padding: "0",

--- a/python/src/aiconfig/editor/client/src/themes/VSCodeTheme.ts
+++ b/python/src/aiconfig/editor/client/src/themes/VSCodeTheme.ts
@@ -7,7 +7,7 @@ export const VSCODE_THEME: MantineThemeOverride = {
     deg: 45,
   },
 
-  globalStyles: (theme) => ({
+  globalStyles: () => ({
     body: {
       padding: "0 !important",
       color: "var(--vscode-editor-foreground)",
@@ -147,7 +147,7 @@ export const VSCODE_THEME: MantineThemeOverride = {
       marginBottom: "0.5em",
     },
 
-    ".parametersContainer": {
+    ".configMetadataContainer": {
       width: "100%",
       maxHeight: "-webkit-fill-available",
       margin: "16px auto",

--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -199,7 +199,7 @@ export default function VSCodeEditor() {
   }, [setupTelemetryIfAllowed]);
 
   const getModels = useCallback(
-    async (search: string) => {
+    async (search?: string) => {
       // For now, rely on caching and handle client-side search filtering
       // We will use server-side search filtering for Gradio
       const res = await ufetch.get(ROUTE_TABLE.LIST_MODELS(aiConfigServerUrl));

--- a/vscode-extension/editor/src/VSCodeTheme.ts
+++ b/vscode-extension/editor/src/VSCodeTheme.ts
@@ -217,7 +217,7 @@ export const VSCODE_THEME: MantineThemeOverride = {
       marginBottom: "0.5em",
     },
 
-    ".parametersContainer": {
+    ".configMetadataContainer": {
       maxHeight: "-webkit-fill-available",
       margin: "16px auto 16px 36px",
       padding: "0",


### PR DESCRIPTION
Update getModels to Make Search String Optional

# Update getModels to Make Search String Optional

In a few cases, we don't have a search string to use for the getModels call and it's weird to need to pass in an empty string to represent that case. Just updating the implementation to make the search string optional

## Testing:
- Make sure all getModels calls work (add prompt, prompt model selector)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1438).
* #1444
* #1443
* #1442
* #1441
* #1440
* #1439
* __->__ #1438
* #1437