### PR TITLE
[vscode] 1/n rename create new yaml -> create example yaml

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -56,13 +56,13 @@
         "category": "AIConfig"
       },
       {
-        "command": "vscode-aiconfig.createAIConfigJSON",
-        "title": "Create New AIConfig (json)",
+        "command": "vscode-aiconfig.createExampleAIConfigYAML",
+        "title": "Create AIConfig From Example  (yaml)",
         "category": "AIConfig"
       },
       {
-        "command": "vscode-aiconfig.createAIConfigYAML",
-        "title": "Create New AIConfig (yaml)",
+        "command": "vscode-aiconfig.createExampleAIConfigJSON",
+        "title": "Create AIConfig From Example (json)",
         "category": "AIConfig"
       },
       {
@@ -202,13 +202,13 @@
           {
             "id": "createAIConfig",
             "title": "Create your first AIConfig",
-            "description": "Turn your VS Code into a generative AI studio\n**Note:** Please complete the ``Initialize Extension`` step before opening an AIConfig file!\n[Create .aiconfig.yaml](command:vscode-aiconfig.createAIConfigYAML)\nIf you prefer JSON:\n[Create .aiconfig.json](command:vscode-aiconfig.createAIConfigJSON)",
+            "description": "Turn your VS Code into a generative AI studio\n**Note:** Please complete the ``Initialize Extension`` step before opening an AIConfig file!\n[Create .aiconfig.yaml](command:vscode-aiconfig.createExampleAIConfigYAML)\nIf you prefer JSON:\n[Create .aiconfig.json](command:vscode-aiconfig.createExampleAIConfigJSON)",
             "media": {
               "markdown": "media/createAIConfig.md"
             },
             "completionEvents": [
-              "onCommand:vscode-aiconfig.createAIConfigYAML",
-              "onCommand:vscode-aiconfig.createAIConfigJSON"
+              "onCommand:vscode-aiconfig.createExampleAIConfigYAML",
+              "onCommand:vscode-aiconfig.createExampleAIConfigJSON"
             ]
           },
           {
@@ -242,10 +242,10 @@
       ],
       "file/newFile": [
         {
-          "command": "vscode-aiconfig.createAIConfigJSON"
+          "command": "vscode-aiconfig.createExampleAIConfigJSON"
         },
         {
-          "command": "vscode-aiconfig.createAIConfigYAML"
+          "command": "vscode-aiconfig.createExampleAIConfigYAML"
         }
       ],
       "webview/context": [

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -76,7 +76,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   const createAIConfigJSONCommand = vscode.commands.registerCommand(
-    COMMANDS.CREATE_NEW_JSON,
+    COMMANDS.CREATE_EXAMPLE_JSON,
     async () => {
       return await createNewAIConfig(context, "json");
     }
@@ -84,7 +84,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(createAIConfigJSONCommand);
 
   const createAIConfigYAMLCommand = vscode.commands.registerCommand(
-    COMMANDS.CREATE_NEW_YAML,
+    COMMANDS.CREATE_EXAMPLE_YAML,
     async () => {
       return await createNewAIConfig(context, "yaml");
     }

--- a/vscode-extension/src/util.ts
+++ b/vscode-extension/src/util.ts
@@ -13,8 +13,8 @@ import { ENV_FILE_PATH } from "./constants";
 export const EXTENSION_NAME = "vscode-aiconfig";
 export const COMMANDS = {
   INIT: `${EXTENSION_NAME}.init`,
-  CREATE_NEW_JSON: `${EXTENSION_NAME}.createAIConfigJSON`,
-  CREATE_NEW_YAML: `${EXTENSION_NAME}.createAIConfigYAML`,
+  CREATE_EXAMPLE_YAML: `${EXTENSION_NAME}.createExampleAIConfigYAML`,
+  CREATE_EXAMPLE_JSON: `${EXTENSION_NAME}.createExampleAIConfigJSON`,
   HELLO_WORLD: `${EXTENSION_NAME}.helloWorld`,
   CUSTOM_MODEL_REGISTRY_PATH: `${EXTENSION_NAME}.customModelRegistryPath`,
   CREATE_CUSTOM_MODEL_REGISTRY: `${EXTENSION_NAME}.createCustomModelRegistry`,


### PR DESCRIPTION
[vscode] 1/n rename create new yaml -> create example yaml

VSCode extension needs to have a "create new empty" command. This diff just renames the current create new commands to create example.

rfc: Maybe this should be create template instead of "example" to be more explicit

## testplan

https://github.com/lastmile-ai/aiconfig/assets/141073967/0f79234c-f62c-4df5-995c-9261e9013538

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1447).
* #1448
* __->__ #1447