### PR TITLE
Add ModelSettings Renderers to sl

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/models/model_settings/ModelSettingsRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/models/model_settings/ModelSettingsRenderer.tsx
@@ -1,0 +1,110 @@
+import ModelSettingsSchemaRenderer from "./ModelSettingsSchemaRenderer";
+import { GenericPropertiesSchema } from "../../../utils/promptUtils";
+import { Flex, Text, createStyles } from "@mantine/core";
+import { JSONObject } from "aiconfig";
+import { memo, useState } from "react";
+import JSONRenderer from "../../JSONRenderer";
+import JSONEditorToggleButton from "../../JSONEditorToggleButton";
+import { ErrorBoundary, useErrorBoundary } from "react-error-boundary";
+
+type Props = {
+  model?: string;
+  settings?: JSONObject;
+  schema?: GenericPropertiesSchema;
+  onUpdateModelSettings: (settings: Record<string, unknown>) => void;
+};
+
+const useStyles = createStyles(() => ({
+  settingsContainer: {
+    overflow: "auto",
+    paddingTop: "0.5em",
+    width: "100%",
+  },
+}));
+
+type ErrorFallbackProps = {
+  settings?: JSONObject;
+  toggleJSONEditor: () => void;
+};
+
+function SettingsErrorFallback({
+  settings,
+  toggleJSONEditor,
+}: ErrorFallbackProps) {
+  const { resetBoundary: clearRenderError } = useErrorBoundary();
+  return (
+    <Flex direction="column">
+      <Text color="red" size="sm">
+        <Flex justify="flex-end">
+          <JSONEditorToggleButton
+            isRawJSON={false}
+            setIsRawJSON={() => {
+              clearRenderError();
+              toggleJSONEditor();
+            }}
+          />
+        </Flex>
+        Invalid settings format for model. Toggle JSON editor to update. Set to
+        {" {}"} in JSON editor and toggle back to reset.
+      </Text>
+      <JSONRenderer content={settings} />
+    </Flex>
+  );
+}
+
+export default memo(function ModelSettingsRenderer({
+  model,
+  settings,
+  schema,
+  onUpdateModelSettings,
+}: Props) {
+  const { classes } = useStyles();
+  const [isRawJSON, setIsRawJSON] = useState(schema == null);
+
+  const rawJSONToggleButton = (
+    <Flex justify="flex-end">
+      <JSONEditorToggleButton
+        isRawJSON={isRawJSON}
+        setIsRawJSON={setIsRawJSON}
+      />
+    </Flex>
+  );
+
+  return (
+    <Flex direction="column" className={classes.settingsContainer}>
+      {isRawJSON || !schema ? (
+        <>
+          {/* // Only show the toggle if there is a schema to toggle between JSON and custom schema renderer */}
+          {schema && rawJSONToggleButton}
+          <JSONRenderer
+            // Use the model name as the key to force re-mount / updated state when model changes
+            key={model}
+            content={settings}
+            onChange={(val) =>
+              onUpdateModelSettings(val as Record<string, unknown>)
+            }
+            // schema={schema} TODO: Add schema after fixing z-index issue
+          />
+        </>
+      ) : (
+        <ErrorBoundary
+          fallbackRender={() => (
+            <SettingsErrorFallback
+              settings={settings}
+              toggleJSONEditor={() => setIsRawJSON(true)}
+            />
+          )}
+        >
+          {rawJSONToggleButton}
+          <ModelSettingsSchemaRenderer
+            // Use the model name as the key to force re-mount / updated state when model changes
+            key={model}
+            settings={settings}
+            schema={schema}
+            onUpdateModelSettings={onUpdateModelSettings}
+          />
+        </ErrorBoundary>
+      )}
+    </Flex>
+  );
+});

--- a/python/src/aiconfig/editor/client/src/components/models/model_settings/ModelSettingsSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/models/model_settings/ModelSettingsSchemaRenderer.tsx
@@ -1,0 +1,46 @@
+import SettingsPropertyRenderer, {
+  SetStateFn,
+} from "../../SettingsPropertyRenderer";
+import { GenericPropertiesSchema } from "../../../utils/promptUtils";
+import { JSONObject, JSONValue } from "aiconfig";
+import { memo, useMemo } from "react";
+import { debounce } from "lodash";
+
+type Props = {
+  schema: GenericPropertiesSchema;
+  settings?: JSONObject;
+  onUpdateModelSettings: (settings: Record<string, unknown>) => void;
+};
+
+export default memo(function ModelSettingsSchemaRenderer({
+  schema,
+  settings,
+  onUpdateModelSettings,
+}: Props) {
+  const debouncedConfigUpdate = useMemo(
+    () =>
+      debounce(
+        (newSettings: JSONObject) => onUpdateModelSettings(newSettings),
+        250
+      ),
+    [onUpdateModelSettings]
+  );
+
+  const setValue: SetStateFn = (
+    newValue: ((prev: JSONValue) => void) | JSONValue
+  ) => {
+    const newSettings =
+      typeof newValue === "function" ? newValue(settings) : newValue;
+    debouncedConfigUpdate(newSettings);
+  };
+
+  return (
+    <SettingsPropertyRenderer
+      propertyName={""}
+      property={schema}
+      isRequired={false}
+      initialValue={settings}
+      setValue={setValue}
+    />
+  );
+});


### PR DESCRIPTION
# Add ModelSettings Renderers to git/sl

I have no idea what's going on with sl but it didn't properly mark the file moves from the ModelSettingsRenderer components as moves in https://github.com/lastmile-ai/aiconfig/pull/1440/commits/c44889a1a83ab78b9802cdf7b9ad745fab2ae456, so manually adding them again here so that they exist in git

## Testing
- Make sure the model settings renderers render correctly
