### PR TITLE
[ez][ts lint] remove unused statements in editor Client

### DIFF
--- a/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputAttachmentsSchemaRenderer.tsx
+++ b/python/src/aiconfig/editor/client/src/components/prompt/prompt_input/schema_renderer/PromptInputAttachmentsSchemaRenderer.tsx
@@ -1,10 +1,9 @@
 import { PromptInputObjectAttachmentsSchema } from "../../../../utils/promptUtils";
 import type { Attachment as InputAttachment, JSONObject } from "aiconfig";
-import { memo, useContext, useState } from "react";
+import { memo, useState } from "react";
 import AttachmentContainer from "../attachments/AttachmentContainer";
 import AttachmentUploader from "../attachments/AttachmentUploader";
 import { Container } from "@mantine/core";
-import AIConfigContext from "../../../../contexts/AIConfigContext";
 
 type Props = {
   schema: PromptInputObjectAttachmentsSchema;
@@ -26,7 +25,6 @@ function EditableAttachmentRenderer({
   onRemoveAttachment?: () => void;
 }) {
   const [showUploader, setShowUploader] = useState(attachment?.data == null);
-  const {readOnly} = useContext(AIConfigContext);
 
   return (
     <Container m="xs">


### PR DESCRIPTION
[ez][ts lint] remove unused statements in editor Client

These warnings are surfaced by`Yarn lint` or `yarn build`

## testplan

```
ankush@ap-mbp client % yarn build
yarn run v1.22.21
$ react-scripts build
Creating an optimized production build...
Compiled successfully.

File sizes after gzip:

  316.5 kB  build/static/js/main.dde99e89.js

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  yarn global add serve
  serve -s build

Find out more about deployment here:

  https://cra.link/deployment

$ node postbuild.js
✨  Done in 12.41s.

```
