### PR TITLE
[ez] gh action remove uneeded step

### DIFF
--- a/.github/workflows/publish_python_sdk.yml
+++ b/.github/workflows/publish_python_sdk.yml
@@ -32,12 +32,6 @@ jobs:
       id-token: write
 
     steps:
-      - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
-
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
[ez] gh action remove uneeded step

This github action does not need to store builds. It should be fine to build and publish within the same action
