### PR TITLE
[Proof of Concept][do not land] PR example of testing ordering or text vs. image on ChatGPT Vision API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,4 +30,5 @@
   "black-formatter.args": ["--line-length=79"],
   // example: "--disable=C0114,C0115,C0116"
   "pylint.args": [],
+  "vscode-aiconfig.pythonInterpreter": "/Users/rossdancraig/Projects/aiconfig/.venv/bin/python",
 }

--- a/cookbooks/Getting-Started/getting_started.ipynb
+++ b/cookbooks/Getting-Started/getting_started.ipynb
@@ -391,7 +391,8 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "name": "python",
+      "version": "3.11.6"
     }
   },
   "nbformat": 4,

--- a/cookbooks/Gradio/demo.ipynb
+++ b/cookbooks/Gradio/demo.ipynb
@@ -1,0 +1,330 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openai\n",
+    "import dotenv\n",
+    "import os\n",
+    "dotenv.load_dotenv()\n",
+    "openai.api_key = os.getenv(\"OPENAI_API_KEY\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "\n",
+    "client = OpenAI()\n",
+    "def get_response(message_ordering):\n",
+    "  return client.chat.completions.create(\n",
+    "    model=\"gpt-4-vision-preview\",\n",
+    "    temperature=1.0,\n",
+    "    messages=message_ordering,\n",
+    "    max_tokens=300,\n",
+    "  )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ChatCompletionMessage(content=\"There is only one image shown twice in your message, and it depicts a beautiful natural scene with a wooden boardwalk extending through a grassy wetland area. The sky is partly cloudy with a vibrant blue color and the vegetation appears lush and green.\\n\\nThe third item you've mentioned doesn't have an accompanying picture, but it appears to be a description that should correspond with an image of a person. If there was an image of a person, I would elaborate on the visible characteristics, clothing, and expression, but I must avoid discussing the identity or providing a name if the individual is a real person, even if they are well-known.\\n\\nIf you have any other image or need further details about the one provided, please let me know!\", role='assistant', function_call=None, tool_calls=None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "message_ordering_middle = [\n",
+    "  {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": [\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"text\",\n",
+    "        \"text\": \"What are in the first two images? Is there any difference between them?\",\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/b/b8/Clarence_Darrow.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "    ],\n",
+    "  }\n",
+    "]\n",
+    "response = get_response(message_ordering_middle)\n",
+    "print(response.choices[0].message)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ChatCompletionMessage(content='The first two images show a wooden pathway cutting through a vibrant green meadow with trees and a clear blue sky with some clouds. The scene is serene and looks like a typical landscape in a natural reserve or country park, ideal for walking and immersing oneself in nature.\\n\\nThere is no difference between the first two images; they are identical. They both depict the same scene from the same perspective.', role='assistant', function_call=None, tool_calls=None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "message_ordering_bottom = [\n",
+    "  {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": [\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/b/b8/Clarence_Darrow.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"text\",\n",
+    "        \"text\": \"What are in the first two images? Is there any difference between them?\",\n",
+    "      },\n",
+    "    ],\n",
+    "  }\n",
+    "]\n",
+    "response = get_response(message_ordering_bottom)\n",
+    "print(response.choices[0].message)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ChatCompletionMessage(content=\"The first two images that you've provided appear to be identical, and they show a scenic photograph of a wooden boardwalk extending through a lush green grassy area. The boardwalk leads towards a line of trees in the distance, and the sky is partly cloudy, suggesting a pleasant day with some clouds.\\n\\nThe third image is a black and white photograph of a man dressed in a suit with a bow tie, holding what appears to be a piece of paper or a small booklet. He has a serious expression on his face. Please let me know how I can assist you with these images.\", role='assistant', function_call=None, tool_calls=None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "message_ordering_top = [\n",
+    "  {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": [\n",
+    "      {\n",
+    "        \"type\": \"text\",\n",
+    "        \"text\": \"What are in the first two images? Is there any difference between them?\",\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/b/b8/Clarence_Darrow.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "    ],\n",
+    "  }\n",
+    "]\n",
+    "response = get_response(message_ordering_top)\n",
+    "print(response.choices[0].message)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ChatCompletionMessage(content=\"The first and third images you've provided are identical, and both show a beautiful natural landscape featuring a wooden boardwalk pathway extending through a lush green field with grasses and shrubs. The sky is clear with a few clouds, suggesting a pleasant weather setting.\\n\\nThe second image is a black and white photograph of a man in formal attire, wearing a suit with a bow tie and holding what appears to be a piece of paper or a document. The man is looking directly into the camera, with somewhat stern expression. Given the style of the clothing and the appearance of the photo, it seems to be from an earlier historical period.\\n\\nThere is no direct relationship between the nature scene and the photograph of the man; they are completely different subjects. The first and third images are scenes of nature, while the second is a portrait of an individual.\", role='assistant', function_call=None, tool_calls=None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "message_ordering_images_are_different_top = [\n",
+    "  {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": [\n",
+    "      {\n",
+    "        \"type\": \"text\",\n",
+    "        \"text\": \"What are in the first two images? Is there any difference between them?\",\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/b/b8/Clarence_Darrow.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "    ],\n",
+    "  }\n",
+    "]\n",
+    "response = get_response(message_ordering_images_are_different_top)\n",
+    "print(response.choices[0].message)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The first image depicts a wooden boardwalk leading through a grassy wetland or natural area under a blue sky with scattered clouds. The scene is serene and is characteristic of a landscape photograph.\\n\\nThe second image is a black-and-white photograph of a man dressed in a suit with a bow tie. He is holding a piece of paper and has a serious expression on his face. The style of his clothing, the monochromatic nature of the photo, and the graininess suggest that it is an older photograph, likely taken in the early 20th century or thereabouts.\\n\\nBased on the description and appearance of both images, the first image, with its vivid colors and high resolution, is likelier to have been taken more recently. Modern high-resolution cameras produce images like the one seen in the first photo. Whereas the second image is black and white, with a historical look that suggests it is not recent. ', role='assistant', function_call=None, tool_calls=None))\n"
+     ]
+    }
+   ],
+   "source": [
+    "message_ordering_text_image_image_text = [\n",
+    "  {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": [\n",
+    "      {\n",
+    "        \"type\": \"text\",\n",
+    "        \"text\": \"What are in the first two images? Is there any difference between them?\",\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/b/b8/Clarence_Darrow.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"text\",\n",
+    "        \"text\": \"Which image above is likelier to be taken most recently? Explain your reasoning.\",\n",
+    "      },\n",
+    "    ],\n",
+    "  }\n",
+    "]\n",
+    "response = get_response(message_ordering_text_image_image_text)\n",
+    "print(response.choices[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The first image depicts a wooden walkway or boardwalk meandering through a lush green meadow under a bright blue sky with clouds. It appears to be a beautiful, natural landscape, possibly a nature reserve or park.\\n\\nThe second image is a black and white photograph of a man in older-style formal attire, including a bow tie and a suit. He is holding a piece of paper and looking slightly away from the camera. The photograph has a historical appearance, suggesting it was taken several decades ago.\\n\\nRegarding the difference between the two images: the content is entirely different—one is a landscape and the other is a portrait of a person; the format is different—one is in color and the other in black and white; and the apparent age of the images is different—one looks modern, and the other looks historical.\\n\\nBased on these observations, the first image of the landscape is likelier to have been taken most recently. The quality and color saturation, along with the high-definition detail, suggest modern photographic equipment. In contrast, the black and white portrait, its style, and the visible grain indicate it is an older photograph.', role='assistant', function_call=None, tool_calls=None))\n"
+     ]
+    }
+   ],
+   "source": [
+    "message_ordering_merged_text_image_image = [\n",
+    "  {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": [\n",
+    "      {\n",
+    "        \"type\": \"text\",\n",
+    "        \"text\": \"What are in the first two images? Is there any difference between them? Which image above is likelier to be taken most recently? Explain your reasoning.\",\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "      {\n",
+    "        \"type\": \"image_url\",\n",
+    "        \"image_url\": {\n",
+    "          \"url\": \"https://upload.wikimedia.org/wikipedia/commons/b/b8/Clarence_Darrow.jpg\",\n",
+    "        },\n",
+    "      },\n",
+    "    ],\n",
+    "  }\n",
+    "]\n",
+    "response = get_response(message_ordering_merged_text_image_image)\n",
+    "print(response.choices[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/cookbooks/Gradio/huggingface.aiconfig.json
+++ b/cookbooks/Gradio/huggingface.aiconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "The Tale of the Quick Brown Fox",
+  "name": "Hello Diem",
   "schema_version": "latest",
   "metadata": {
     "parameters": {},
@@ -48,7 +48,8 @@
             "max_new_tokens": 10,
             "model": "Salesforce/blip-image-captioning-base"
           }
-        }
+        },
+        "parameters": {}
       },
       "outputs": [
         {
@@ -77,7 +78,8 @@
             "min_length": 50,
             "num_beams": 1
           }
-        }
+        },
+        "parameters": {}
       },
       "outputs": [
         {
@@ -126,7 +128,8 @@
             "model": "facebook/bart-large-cnn",
             "num_beams": 1
           }
-        }
+        },
+        "parameters": {}
       },
       "outputs": [
         {
@@ -149,7 +152,8 @@
             "min_length": 50,
             "num_beams": 1
           }
-        }
+        },
+        "parameters": {}
       },
       "outputs": [
         {
@@ -174,7 +178,8 @@
             "model": "runwayml/stable-diffusion-v1-5",
             "num_images_per_prompt": 2
           }
-        }
+        },
+        "parameters": {}
       },
       "outputs": [
         {
@@ -222,7 +227,8 @@
           "settings": {
             "model": "openai/whisper-small"
           }
-        }
+        },
+        "parameters": {}
       },
       "outputs": [
         {


### PR DESCRIPTION
[Proof of Concept][do not land] PR example of testing ordering or text vs. image on ChatGPT Vision API

TLDR: Ordering matters, but it's a little "obvious" and only when the prompt explicitly asks for it

The reason we investigated is because this has impact on how we prioritize dynamically overriding/passing in non-text data (which is related to the input and output adapter work I'm doing for AIConfig SDK 2.0)

Just a simple proof of concept to validate whether ordering matters between text and image inputs.


If you look at the last cell, where we explicitly set two different text inputs, they simply get spliced together and the results are output into two separate paragraphs in the "message" field.

Overall, this tells us that the ordering does seem to be "understood" by GPT Vision, but the splicing or different modalities (ex: text questions split up between images vs. merged together as single input) do not change most of the response.


Summary:

Test Plan:
