### PR TITLE
[Python sdk] Remove test dependencies from Main Package Dependencies

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,7 +9,6 @@ google-generativeai>=0.3.1
 huggingface-hub >= 0.20.3
 hypothesis==6.91.0
 lastmile-utils==0.0.23
-mock
 nest_asyncio
 nltk
 openai >= 1.13.3
@@ -17,8 +16,6 @@ prompt_toolkit
 pybars3
 pydantic>=2.1
 pylint
-pytest
-pytest-asyncio
 python-dotenv
 pyyaml
 requests


### PR DESCRIPTION
[Python sdk] Remove test dependencies from Main Package Dependencies

This PR updates the Python SDK package to minimize its dependency footprint.

This pr removes the following packages from the main package dependencies. These libraries are primarily used for testing purposes and are not necessary for the sdk's functionality.

- `pytest`
- `pytest-asyncio`
- `mock`
