### PR TITLE
Fix Jest Tests

### DIFF
--- a/typescript/jest.config.ts
+++ b/typescript/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
     "^.+\\.ts?$": "ts-jest",
   },
   transformIgnorePatterns: ["<rootDir>/node_modules/", "dist"],
+  testPathIgnorePatterns: ["<rootDir>/node_modules/", "dist"],
 };
 
 export default config;


### PR DESCRIPTION
Fix Jest Tests

Summary: For some reason, the current `jest` command is running on /dist/ test files, which fails to parse the transpiled js. For example:

```
 FAIL  dist/__tests__/parsers/hf/hf.test.js
  HuggingFaceTextGeneration ModelParser
    ✕ uses HuggingFace API token from environment variable if it exists
    ✕ serializing params to config prompt
    ✕ serialize callbacks
    ✕ deserializing config prompt to params
    ✕ deserialize callbacks
    ✕ run prompt, non-streaming
    ✕ run prompt, streaming
    ✕ run callbacks

  ● HuggingFaceTextGeneration ModelParser › uses HuggingFace API token from environment variable if it exists

    TypeError: mockedHfInference.mockClear is not a function

      102 | describe("HuggingFaceTextGeneration ModelParser", () => {
      103 |     beforeEach(() => {
    > 104 |         mockedHfInference.mockClear();
          |                           ^
      105 |         mockGetApiKeyFromEnv.mockClear();
      106 |     });
      107 |     test("uses HuggingFace API token from environment variable if it exists", () => __awaiter(void 0, void 0, void 0, function* () {

      at Object.<anonymous> (dist/__tests__/parsers/hf/hf.test.js:104:27)

```


To fix, just explicitly tell jest to skip dist and node_modules tests.

Test Plan:
```
(aiconfig) ryanholinshead@Ryans-MacBook-Pro typescript % yarn test
yarn run v1.22.19
$ jest --runInBand
watchman warning:  Recrawled this watch 83 times, most recently because:
MustScanSubDirs UserDroppedTo resolve, please review the information on
https://facebook.github.io/watchman/docs/troubleshooting.html#recrawl
To clear this warning, run:
`watchman watch-del '/Users/ryanholinshead/Projects/aiconfig' ; watchman watch-project '/Users/ryanholinshead/Projects/aiconfig'`

(node:90548) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  __tests__/parsers/hf/hf.test.ts
  HuggingFaceTextGeneration ModelParser
    ✓ uses HuggingFace API token from environment variable if it exists (9 ms)
    ✓ serializing params to config prompt (4 ms)
    ✓ serialize callbacks (1 ms)
    ✓ deserializing config prompt to params (2 ms)
    ✓ deserialize callbacks (1 ms)
    ✓ run prompt, non-streaming (3 ms)
    ✓ run prompt, streaming (2 ms)
    ✓ run callbacks (1 ms)

 PASS  __tests__/parsers/palm-text/palm.test.ts
  PaLM Text ModelParser
    ✓ serializing params to config prompt (2 ms)
    ✓ deserializing params to config (1 ms)
    ✓ run prompt, non-streaming (80 ms)

 PASS  __tests__/config.test.ts
  Loading an AIConfig
    ✓ loading a basic chatgpt query config (2 ms)
    ✓ loading a prompt chain (2 ms)
    ✓ deserialize and re-serialize a prompt chain (1 ms)
    ✓ serialize a prompt chain with different settings (1 ms)

 PASS  __tests__/testProgramaticallyCreateConfig.ts
  test Get Global Settings
    ✓ Retrieving global setting from AIConfig with 1 model
  ExtractOverrideSettings function
    ✓ Should return initial settings when no global settings are defined
    ✓ Should return an override when initial settings differ from global settings
    ✓ Should return empty override when global settings match initial settings
    ✓ Should return empty override when Global settings defined and initial settings are empty

 PASS  __tests__/testSave.ts
  AIConfigRuntime save()
    ✓ saves the config and checks if the config json doesn't have key filePath (3 ms)

Test Suites: 5 passed, 5 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        2.069 s
Ran all test suites.
```
