### PR TITLE
Update aiconfig-editor Package and Attach delete_model request/callback

### DIFF
--- a/vscode-extension/editor/package.json
+++ b/vscode-extension/editor/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^5.7.0",
     "@emotion/react": "^11.11.1",
-    "@lastmileai/aiconfig-editor": "^0.2.5",
+    "@lastmileai/aiconfig-editor": "^0.2.6",
     "@mantine/carousel": "^6.0.7",
     "@mantine/core": "^6.0.7",
     "@mantine/dates": "^6.0.16",

--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -6,6 +6,8 @@ import {
   RunPromptStreamErrorEvent,
   LogEvent,
   LogEventData,
+  ThemeMode,
+  AIConfigEditorNotification,
 } from "@lastmileai/aiconfig-editor";
 import { Flex, Loader, createStyles } from "@mantine/core";
 import {
@@ -28,11 +30,7 @@ import {
   updateWebviewState,
 } from "./utils/vscodeUtils";
 import { VSCODE_THEME } from "./VSCodeTheme";
-// TODO: Update package to export AIConfigEditorNotification and ThemeMode types
-import { AIConfigEditorNotification } from "@lastmileai/aiconfig-editor/dist/components/notifications/NotificationProvider";
-import { ThemeMode } from "@lastmileai/aiconfig-editor/dist/shared/types";
-import {v4 as uuidv4} from "uuid";
-
+import { v4 as uuidv4 } from "uuid";
 
 const useStyles = createStyles(() => ({
   editorBackground: {
@@ -231,6 +229,15 @@ export default function VSCodeEditor() {
       return res;
     },
     [aiConfigServerUrl, vscode]
+  );
+
+  const deleteModelSettings = useCallback(
+    async (modelName: string) => {
+      return await ufetch.post(ROUTE_TABLE.DELETE_MODEL(aiConfigServerUrl), {
+        model_name: modelName,
+      });
+    },
+    [aiConfigServerUrl]
   );
 
   const deletePrompt = useCallback(
@@ -466,6 +473,7 @@ export default function VSCodeEditor() {
       addPrompt,
       cancel,
       clearOutputs,
+      deleteModelSettings,
       deletePrompt,
       getModels,
       getServerStatus,
@@ -485,6 +493,7 @@ export default function VSCodeEditor() {
       addPrompt,
       cancel,
       clearOutputs,
+      deleteModelSettings,
       deletePrompt,
       getModels,
       getServerStatus,

--- a/vscode-extension/editor/src/utils/api.ts
+++ b/vscode-extension/editor/src/utils/api.ts
@@ -8,6 +8,8 @@ export const ROUTE_TABLE = {
   CANCEL: (hostUrl: string) => urlJoin(hostUrl, API_ENDPOINT, "/cancel"),
   CLEAR_OUTPUTS: (hostUrl: string) =>
     urlJoin(hostUrl, API_ENDPOINT, "/clear_outputs"),
+  DELETE_MODEL: (hostUrl: string) =>
+    urlJoin(hostUrl, API_ENDPOINT, "/delete_model"),
   DELETE_PROMPT: (hostUrl: string) =>
     urlJoin(hostUrl, API_ENDPOINT, "/delete_prompt"),
   GET_AICONFIGRC: (hostUrl: string) =>

--- a/vscode-extension/editor/yarn.lock
+++ b/vscode-extension/editor/yarn.lock
@@ -1780,10 +1780,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lastmileai/aiconfig-editor@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.5.tgz#f93260169d724ff4a1e7eaaed42248443b8f9d56"
-  integrity sha512-eMs/9fkXuPJrY2XkJbOk24GcdTCDd3tNQKwUe77pygWa7fse51drKUsebXPWsgbXSte4PxtRIj3icxmTOz7HIg==
+"@lastmileai/aiconfig-editor@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.6.tgz#18987db0718da8c0c1dea0d485ee446cc2d12a0a"
+  integrity sha512-YZl4OqP9D48WHB5//68lxQfRDeyIs8MnEGEaNfpDGPnwXvDaQwUJu4ofq8LWslSRcpRPEegx1w++UqD5nnZedA==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@mantine/carousel" "^6.0.7"


### PR DESCRIPTION
# Update aiconfig-editor Package and Attach delete_model request/callback


Summary:
Update the aiconfig-editor package to include UI for global model settings. As part of this, add the code to connect the delete_model request. Note that the delete_model call doesn't work because aiconfig python package needs to be updates so that the server has the endpoint.

Test Plan:
Added global settings, system prompt "respond in capital letters" for gpt-3.5-turbo and it works as expected
