### PR TITLE
Bump vscode extension package version

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -5,7 +5,7 @@
   "author": "LastMile AI",
   "displayName": "AIConfig Editor",
   "description": "AIConfig notebook editor that turns VSCode into a generative AI studio.",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "license": "MIT",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
# Bump vscode extension package version


Summary: Bump the package version to include the global model settings and new/empty config commands.

Test Plan: `vsce package`, installed extension from `vscode-aiconfig-0.0.21.vsix` and tested out the changes successfully
