### PR TITLE
Update aiconfig-editor for Delete Output

### DIFF
--- a/vscode-extension/editor/package.json
+++ b/vscode-extension/editor/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^5.7.0",
     "@emotion/react": "^11.11.1",
-    "@lastmileai/aiconfig-editor": "^0.2.6",
+    "@lastmileai/aiconfig-editor": "^0.2.7",
     "@mantine/carousel": "^6.0.7",
     "@mantine/core": "^6.0.7",
     "@mantine/dates": "^6.0.16",

--- a/vscode-extension/editor/src/VSCodeEditor.tsx
+++ b/vscode-extension/editor/src/VSCodeEditor.tsx
@@ -233,11 +233,20 @@ export default function VSCodeEditor() {
 
   const deleteModelSettings = useCallback(
     async (modelName: string) => {
-      return await ufetch.post(ROUTE_TABLE.DELETE_MODEL(aiConfigServerUrl), {
-        model_name: modelName,
-      });
+      const res = await ufetch.post(
+        ROUTE_TABLE.DELETE_MODEL(aiConfigServerUrl),
+        {
+          model_name: modelName,
+        }
+      );
+
+      if (vscode) {
+        notifyDocumentDirty(vscode);
+      }
+
+      return res;
     },
-    [aiConfigServerUrl]
+    [aiConfigServerUrl, vscode]
   );
 
   const deletePrompt = useCallback(
@@ -270,6 +279,24 @@ export default function VSCodeEditor() {
 
     return res;
   }, [aiConfigServerUrl, vscode]);
+
+  const deleteOutput = useCallback(
+    async (promptName: string) => {
+      const res = await ufetch.post(
+        ROUTE_TABLE.DELETE_OUTPUT(aiConfigServerUrl),
+        {
+          prompt_name: promptName,
+        }
+      );
+
+      if (vscode) {
+        notifyDocumentDirty(vscode);
+      }
+
+      return res;
+    },
+    [aiConfigServerUrl, vscode]
+  );
 
   const runPrompt = useCallback(
     async (
@@ -474,6 +501,7 @@ export default function VSCodeEditor() {
       cancel,
       clearOutputs,
       deleteModelSettings,
+      deleteOutput,
       deletePrompt,
       getModels,
       getServerStatus,
@@ -494,6 +522,7 @@ export default function VSCodeEditor() {
       cancel,
       clearOutputs,
       deleteModelSettings,
+      deleteOutput,
       deletePrompt,
       getModels,
       getServerStatus,

--- a/vscode-extension/editor/src/utils/api.ts
+++ b/vscode-extension/editor/src/utils/api.ts
@@ -10,6 +10,8 @@ export const ROUTE_TABLE = {
     urlJoin(hostUrl, API_ENDPOINT, "/clear_outputs"),
   DELETE_MODEL: (hostUrl: string) =>
     urlJoin(hostUrl, API_ENDPOINT, "/delete_model"),
+  DELETE_OUTPUT: (hostUrl: string) =>
+    urlJoin(hostUrl, API_ENDPOINT, "/delete_output"),
   DELETE_PROMPT: (hostUrl: string) =>
     urlJoin(hostUrl, API_ENDPOINT, "/delete_prompt"),
   GET_AICONFIGRC: (hostUrl: string) =>

--- a/vscode-extension/editor/yarn.lock
+++ b/vscode-extension/editor/yarn.lock
@@ -1780,10 +1780,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lastmileai/aiconfig-editor@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.6.tgz#18987db0718da8c0c1dea0d485ee446cc2d12a0a"
-  integrity sha512-YZl4OqP9D48WHB5//68lxQfRDeyIs8MnEGEaNfpDGPnwXvDaQwUJu4ofq8LWslSRcpRPEegx1w++UqD5nnZedA==
+"@lastmileai/aiconfig-editor@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@lastmileai/aiconfig-editor/-/aiconfig-editor-0.2.7.tgz#70bdf9839e1ddba3ef01fc5986a326165a5338f9"
+  integrity sha512-oQFgcOkPyRtM5DpDDCska5rKD72zBuWwheJW7f5gyz4KYJ0gI4Jh2Byzg5McP3cyyTYaPzB28abPNV2jNGlSng==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@mantine/carousel" "^6.0.7"


### PR DESCRIPTION
# Update aiconfig-editor for Delete Output


Summary: Bump `aiconfig-editor` package to include the UI for deleting single output. Connect the callback in VSCodeEditor. Also, updated deleteModelSettings callback to properly notify document change

Test Plan: Tested deleting output (and global model settings) and seeing the change reflected in the config
