### PR TITLE
[sdk] pin HuggingFaceHub Dependency

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,7 @@ flask-cors
 flask[async]
 frozendict
 google-generativeai>=0.3.1
-huggingface-hub >= 0.20.3
+huggingface-hub >= 0.20.3, <= 0.21.4
 hypothesis==6.91.0
 lastmile-utils==0.0.23
 nest_asyncio


### PR DESCRIPTION
[sdk] pin HuggingFaceHub Dependency

HuggingFace Hub Python library released breaking changes in version 0.22.0: https://github.com/huggingface/huggingface_hub/releases/tag/v0.22.0

This diff pins the version dependency of `huggingface_hub` to avoid the impact of the broken change.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1478).
* #1479
* __->__ #1478