### PR TITLE
Bump VSCode Extension Package Version for Publish

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -5,7 +5,7 @@
   "author": "LastMile AI",
   "displayName": "AIConfig Editor",
   "description": "AIConfig notebook editor that turns VSCode into a generative AI studio.",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "license": "MIT",
   "engines": {
     "vscode": "^1.85.0"

--- a/vscode-extension/python/requirements.txt
+++ b/vscode-extension/python/requirements.txt
@@ -1,5 +1,5 @@
 # AIConfig
-python-aiconfig>=1.1.32
+python-aiconfig>=1.1.33
 
 #Other
 asyncio


### PR DESCRIPTION
# Bump VSCode Extension Package Version for Publish


Summary: Bump the package version to match the extension published version

Test Plan:  Created VSIX package and tested locally. Deleting outputs works (no server error, save empty outputs array to config)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1481).
* __->__ #1481
* #1480