### PR TITLE
Bump python-sdk

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "python-aiconfig"
-version = "1.1.33"
+version = "1.1.34"
 authors = [
   { name="LastMile AI" },
   { name="Sarmad Qadri", email="sarmad@lastmileai.dev" },


### PR DESCRIPTION
Bump python-sdk

1.1.33 was silently pushed. This diff updates to 1.1.34

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/aiconfig/pull/1488).
* __->__ #1488
* #1487
* #1486