### PR TITLE
Update Gradio Space Documentation

### DIFF
--- a/aiconfig-docs/docs/gradio-notebook.md
+++ b/aiconfig-docs/docs/gradio-notebook.md
@@ -148,7 +148,7 @@ Duplicate the [Gradio Notebook Quickstart Space](https://huggingface.co/spaces/l
 
 #### [manual] Create from scratch
 
-- **Option 2: Create from scratch**. Create a [new Gradio SDK Space](https://huggingface.co/new-space) and add these files to your Space repo. To add files to your Space repo, you can do so through the [Web UI](https://huggingface.co/docs/hub/repositories-getting-started#adding-files-to-a-repository-web-ui) or [terminal](https://huggingface.co/docs/hub/repositories-getting-started#terminal).
+- **Option 2: Create from scratch**. Create a [new Gradio SDK Space](https://huggingface.co/new-space?sdk=gradio) (blank template) and add these files to your Space repo. To add files to your Space repo, you can do so through the [Web UI](https://huggingface.co/docs/hub/repositories-getting-started#adding-files-to-a-repository-web-ui) or [terminal](https://huggingface.co/docs/hub/repositories-getting-started#terminal).
   - [app.py](https://huggingface.co/spaces/lastmileai/gradio-notebook-template/blob/main/app.py)
   - [requirements.txt](https://huggingface.co/spaces/lastmileai/gradio-notebook-template/blob/main/requirements.txt)
 


### PR DESCRIPTION
# Update Gradio Space Documentation


Summary: Make the documentation clearer on which space to use. Auto-select gradio sdk (via url param) and clarify usage of blank template


